### PR TITLE
feat: add var support, cleanup

### DIFF
--- a/rust-sandbox/src/counter.rs
+++ b/rust-sandbox/src/counter.rs
@@ -1,5 +1,5 @@
 use cf::durable_object;
-use worker::{prelude::*, durable::{State}};
+use worker::{durable::State, prelude::*};
 
 const ONE_HOUR: u64 = 3600000;
 
@@ -8,13 +8,18 @@ pub struct Counter {
     count: usize,
     state: State,
     initialized: bool,
-    last_backup: Date
+    last_backup: Date,
 }
 
 #[durable_object]
 impl DurableObject for Counter {
     fn constructor(state: worker::durable::State, _env: worker::Env) -> Self {
-        Self { count: 0, initialized: false, state, last_backup: Date::now() }
+        Self {
+            count: 0,
+            initialized: false,
+            state,
+            last_backup: Date::now(),
+        }
     }
 
     async fn fetch(&mut self, _req: worker::Request) -> worker::Result<worker::Response> {

--- a/rust-sandbox/src/lib.rs
+++ b/rust-sandbox/src/lib.rs
@@ -31,7 +31,7 @@ struct User {
 }
 
 fn handle_a_request(_req: Request, _env: Env, _params: Params) -> Result<Response> {
-    Response::ok("weeee")
+    Response::ok("hello, world.")
 }
 
 #[cf::worker(fetch, respond_with_errors)]
@@ -129,91 +129,19 @@ pub async fn main(req: Request, env: Env) -> Result<Response> {
     })?;
 
     router.get("/secret", |_req, env, _params| {
-        Response::ok(env.secret("SOME_SECRET")?)
+        Response::ok(env.secret("SOME_SECRET")?.to_string())
+    })?;
+
+    router.get("/var", |_req, env, _params| {
+        Response::ok(env.var("SOME_VARIABLE")?.to_string())
     })?;
 
     router.on_async("/kv", |_req, env, _params| async move {
         let kv = env.kv("SOME_NAMESPACE")?;
-        kv.put("a-key", "a-value")?.execute().await?;
+        kv.put("another-key", "another-value")?.execute().await?;
 
         Response::empty()
     })?;
 
     router.run(req, env).await
-
-    // match (req.method(), req.path().as_str()) {
-    //     (Method::Get, "/") => {
-    //         let msg = format!(
-    //             "[rustwasm] event type: {}, colo: {}, asn: {}",
-    //             req.event_type(),
-    //             req.cf().colo(),
-    //             req.cf().asn(),
-    //         );
-    //         Response::ok(Some(msg))
-    //     }
-    //     (Method::Post, "/") => {
-    //         let data: MyData = req.json().await?;
-    //         Response::ok(Some(format!("[POST /] message = {}", data.message)))
-    //     }
-    //     (Method::Post, "/read-text") => Response::ok(Some(format!(
-    //         "[POST /read-text] text = {}",
-    //         req.text().await?
-    //     ))),
-    //     (_, "/json") => Response::json(&MyData {
-    //         message: "hello!".into(),
-    //         is: true,
-    //         data: vec![1, 2, 3, 4, 5],
-    //     }),
-    // (Method::Get, "/headers") => {
-    //     for (_, value) in req.headers() {
-    //         if &value == "evil value" {
-    //             return Response::error("stop that!".into(), 400);
-    //         }
-    //     }
-    //     let msg = req
-    //         .headers()
-    //         .into_iter()
-    //         .map(|(name, value)| format!("{}: {}\n", name, value))
-    //         .collect();
-    //     let mut headers: worker::Headers = [
-    //         ("Content-Type", "application/json"),
-    //         ("Set-Cookie", "hello=true"),
-    //     ]
-    //     .iter()
-    //     .collect();
-    //     headers.append("Set-Cookie", "world=true")?;
-    //     Response::ok(Some(msg)).map(|res| res.with_headers(headers))
-    // }
-    // (Method::Post, "/headers") => {
-    //     let mut headers: http::HeaderMap = req.headers().into();
-    //     headers.append("Hello", "World!".parse().unwrap());
-    //     Response::ok(Some("returned your headers to you.".into()))
-    //         .map(|res| res.with_headers(headers.into()))
-    // }
-    //     (Method::Post, "/job") => {
-    //         let kv = KvStore::create("JOB_LOG").expect("no binding for JOB_LOG");
-    //         if kv
-    //             .put("manual entry", 123)
-    //             .expect("fail to build KV put operation")
-    //             .execute()
-    //             .await
-    //             .is_err()
-    //         {
-    //             return Response::error("Failed to put into KV".into(), 500);
-    //         } else {
-    //             return Response::empty();
-    //         }
-    //     }
-    //     (_, "/jobs") => {
-    //         if let Ok(kv) = KvStore::create("JOB_LOG") {
-    //             return match kv.list().execute().await {
-    //                 Ok(jobs) => Response::json(&jobs),
-    //                 Err(e) => Response::error(format!("KV list error: {:?}", e), 500),
-    //             };
-    //         }
-    //         Response::error("Failed to access KV binding".into(), 500)
-    //     }
-    //     (_, "/404") => Response::error("Not Found".to_string(), 404),
-    //     _ => Response::ok(Some(format!("{:?} {}", req.method(), req.path()))),
-    // }
 }

--- a/rust-sandbox/wrangler.toml
+++ b/rust-sandbox/wrangler.toml
@@ -6,6 +6,7 @@ kv_namespaces = [
   { binding = "SOME_NAMESPACE", id = "e019ce08616d48f2a498e49fe0c51be2" },
   { binding = "SOME_KV", id = "23e78ed5402541b4a8c1bffef4726408" }
 ]
+vars = { SOME_VARIABLE = "some value" }
 
 [build]
 command = """wasm-pack build --no-typescript --out-dir worker/build --out-name index && \

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -2,7 +2,9 @@
 name = "worker"
 version = "0.1.0"
 authors = ["Cloudflare Workers Team <workers@cloudflare.com>"]
+repository = "https://github.com/cloudflare/workers-rs"
 edition = "2018"
+keywords = ["serverless", "ffi", "workers", "wasm", "cloudflare"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,7 +16,7 @@ serde_json = "1.0.64"
 url = "2.2.2"
 wasm-bindgen = "0.2.74"
 wasm-bindgen-futures = "0.4.24"
-worker-kv = { git = "https://github.com/zebp/worker-kv" } # waiting for upstream crates.io release
+worker-kv = "0.3.0"
 web-sys = { version = "0.3.51", features = ["console"] }
 http = "0.2.4"
 matchit = "0.4.2"

--- a/worker/src/date.rs
+++ b/worker/src/date.rs
@@ -1,0 +1,47 @@
+use js_sys::Date as JsDate;
+use wasm_bindgen::JsValue;
+
+#[derive(Debug)]
+pub struct Date {
+    js_date: JsDate,
+}
+
+pub enum DateInit {
+    Millis(u64),
+    String(String),
+}
+
+impl From<DateInit> for Date {
+    fn from(init: DateInit) -> Self {
+        Date::new(init)
+    }
+}
+
+impl Date {
+    pub fn new(init: DateInit) -> Self {
+        let val = match init {
+            DateInit::Millis(n) => JsValue::from_f64(n as f64),
+            DateInit::String(s) => JsValue::from_str(&s),
+        };
+
+        Self {
+            js_date: JsDate::new(&val),
+        }
+    }
+
+    pub fn now() -> Self {
+        Self {
+            js_date: JsDate::new_0(),
+        }
+    }
+
+    pub fn as_millis(&self) -> u64 {
+        self.js_date.get_time() as u64
+    }
+}
+
+impl ToString for Date {
+    fn to_string(&self) -> String {
+        self.js_date.to_string().into()
+    }
+}


### PR DESCRIPTION
Adds support for environment variables provided as bindings defined in wrangler.toml `vars` (also adds `Secret` and `Var` types).

Minor cleanup / formatting / re-org, still more to follow.

