### PR TITLE
Return InsertError from router methods, not libworker::Error

### DIFF
--- a/libworker/src/router.rs
+++ b/libworker/src/router.rs
@@ -82,7 +82,7 @@ impl<'a> Router<'a> {
         func: fn(Request, Env, Params) -> T,
     ) -> RouterResult
     where
-        T: Future<Output = Result<Response>> + 'a,
+        T: Future<Output = Result<Response>> + 'static,
     {
         self.add_handler(
             pattern,


### PR DESCRIPTION
This statically prevents other types of errors, making the docs easier to read
and error handling simpler.

Fixes https://github.com/cloudflare/workers-rs/issues/18.