### PR TITLE
Simplify router args, and enable shared data throughout routes

### DIFF
--- a/libworker/src/env.rs
+++ b/libworker/src/env.rs
@@ -102,5 +102,5 @@ impl ToString for StringBinding {
     }
 }
 
-type Secret = StringBinding;
-type Var = StringBinding;
+pub type Secret = StringBinding;
+pub type Var = StringBinding;

--- a/libworker/src/error.rs
+++ b/libworker/src/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
     Internal(JsValue),
     BindingError(String),
     RouteInsertError(matchit::InsertError),
+    RouteNoDataError,
     RustError(String),
     SerdeJsonError(serde_json::Error),
 }
@@ -31,6 +32,7 @@ impl std::fmt::Display for Error {
             Error::Internal(_) => write!(f, "unrecognized JavaScript object"),
             Error::BindingError(name) => write!(f, "no binding found for `{}`", name),
             Error::RouteInsertError(e) => write!(f, "failed to insert route: {}", e),
+            Error::RouteNoDataError => write!(f, "route has no corresponding shared data"),
             Error::SerdeJsonError(e) => write!(f, "Serde Error: {}", e),
         }
     }

--- a/libworker/src/lib.rs
+++ b/libworker/src/lib.rs
@@ -25,7 +25,7 @@ pub use crate::headers::Headers;
 pub use crate::request::Request;
 pub use crate::request_init::*;
 pub use crate::response::Response;
-pub use crate::router::Router;
+pub use crate::router::{RouteContext, RouteParams, Router};
 pub use cf::Cf;
 pub use edgeworker_sys::console_log;
 pub use matchit::Params;
@@ -42,7 +42,7 @@ pub mod prelude {
     pub use crate::request::Request;
     pub use crate::request_init::*;
     pub use crate::response::Response;
-    pub use crate::router::*;
+    pub use crate::router::{RouteContext, RouteParams, Router};
     pub use crate::Result;
     pub use edgeworker_sys::console_log;
     pub use matchit::Params;

--- a/libworker/src/router.rs
+++ b/libworker/src/router.rs
@@ -1,24 +1,32 @@
-use std::collections::HashMap;
 use std::rc::Rc;
+use std::{collections::HashMap, ops::Deref};
 
 use futures::{future::LocalBoxFuture, Future};
-use matchit::{InsertError, Match, Node};
+use matchit::{Match, Node};
+use worker_kv::KvStore;
 
-use crate::{env::Env, http::Method, request::Request, response::Response, Result};
+use crate::{
+    durable::ObjectNamespace,
+    env::{Env, Secret, Var},
+    error::Error,
+    http::Method,
+    request::Request,
+    response::Response,
+    Result,
+};
 
-type HandlerFn = fn(Request, Env, RouteParams) -> Result<Response>;
-type AsyncHandlerFn<'a> =
-    Rc<dyn Fn(Request, Env, RouteParams) -> LocalBoxFuture<'a, Result<Response>>>;
-type RouterResult<T = ()> = std::result::Result<T, InsertError>;
+type HandlerFn<D> = fn(Request, RouteContext<D>) -> Result<Response>;
+type AsyncHandlerFn<'a, D> =
+    Rc<dyn Fn(Request, RouteContext<D>) -> LocalBoxFuture<'a, Result<Response>>>;
 
 pub type RouteParams = HashMap<String, String>;
 
-pub enum Handler<'a> {
-    Async(AsyncHandlerFn<'a>),
-    Sync(HandlerFn),
+pub enum Handler<'a, D> {
+    Async(AsyncHandlerFn<'a, D>),
+    Sync(HandlerFn<D>),
 }
 
-impl Clone for Handler<'_> {
+impl<D> Clone for Handler<'_, D> {
     fn clone(&self) -> Self {
         match self {
             Self::Async(rc) => Self::Async(rc.clone()),
@@ -27,80 +35,159 @@ impl Clone for Handler<'_> {
     }
 }
 
-pub type HandlerSet<'a> = [Option<Handler<'a>>; 9];
+pub type HandlerSet<'a, D> = [Option<Handler<'a, D>>; 9];
 
-pub struct Router<'a> {
-    handlers: Node<HandlerSet<'a>>,
+pub struct Router<'a, D> {
+    handlers: Node<HandlerSet<'a, D>>,
+    data: Option<Data<D>>,
+    env: Option<Env>,
+    params: Option<RouteParams>,
 }
 
-impl<'a> Router<'a> {
-    pub fn new() -> Self {
-        Default::default()
+#[derive(Debug)]
+pub struct Data<D>(Rc<D>);
+
+impl<D> Data<D> {
+    /// Create new `Data` instance.
+    pub fn new(state: D) -> Data<D> {
+        Data(Rc::new(state))
     }
 
-    pub fn get(&mut self, pattern: &str, func: HandlerFn) -> RouterResult {
-        self.add_handler(pattern, Handler::Sync(func), vec![Method::Get])
+    /// Get reference to inner app data.
+    pub fn get_ref(&self) -> &D {
+        self.0.as_ref()
     }
 
-    pub fn post(&mut self, pattern: &str, func: HandlerFn) -> RouterResult {
-        self.add_handler(pattern, Handler::Sync(func), vec![Method::Post])
+    /// Convert to the internal Rc<D>
+    pub fn into_inner(self) -> Rc<D> {
+        self.0
+    }
+}
+
+impl<D> Deref for Data<D> {
+    type Target = Rc<D>;
+
+    fn deref(&self) -> &Rc<D> {
+        &self.0
+    }
+}
+
+impl<D> Clone for Data<D> {
+    fn clone(&self) -> Data<D> {
+        Data(self.0.clone())
+    }
+}
+
+pub struct RouteContext<D> {
+    data: Option<Data<D>>,
+    env: Env,
+    params: RouteParams,
+}
+
+impl<D> RouteContext<D> {
+    pub fn data(&self) -> Option<&Data<D>> {
+        self.data.as_ref()
     }
 
-    pub fn on(&mut self, pattern: &str, func: HandlerFn) -> RouterResult {
-        self.add_handler(pattern, Handler::Sync(func), Method::all())
+    pub fn get_env(self) -> Env {
+        self.env
     }
 
-    pub fn get_async<T>(
-        &mut self,
-        pattern: &str,
-        func: fn(Request, Env, RouteParams) -> T,
-    ) -> RouterResult
+    pub fn secret(&self, binding: &str) -> Result<Secret> {
+        self.env.get_binding::<Secret>(binding)
+    }
+
+    pub fn var(&self, binding: &str) -> Result<Var> {
+        self.env.get_binding::<Var>(binding)
+    }
+
+    pub fn kv(&self, binding: &str) -> Result<KvStore> {
+        KvStore::from_this(&self.env, binding).map_err(From::from)
+    }
+
+    pub fn durable_object(&self, binding: &str) -> Result<ObjectNamespace> {
+        self.env.get_binding(binding)
+    }
+
+    pub fn param(&self, key: &str) -> Option<&String> {
+        self.params.get(key)
+    }
+}
+
+impl<'a, D: 'static> Router<'a, D> {
+    pub fn new(data: D) -> Self {
+        Self {
+            handlers: Node::new(),
+            data: Some(Data::new(data)),
+            env: None,
+            params: None,
+        }
+    }
+
+    pub fn with_data(mut self, data: D) -> Self {
+        self.data = Some(Data::new(data));
+
+        self
+    }
+
+    pub fn get(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Get]);
+
+        self
+    }
+
+    pub fn post(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Post]);
+
+        self
+    }
+
+    pub fn on(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), Method::all());
+
+        self
+    }
+
+    pub fn get_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
         T: Future<Output = Result<Response>> + 'static,
     {
         self.add_handler(
             pattern,
-            Handler::Async(Rc::new(move |req, env, par| Box::pin(func(req, env, par)))),
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
             vec![Method::Get],
-        )
+        );
+
+        self
     }
 
-    pub fn post_async<T>(
-        &mut self,
-        pattern: &str,
-        func: fn(Request, Env, RouteParams) -> T,
-    ) -> RouterResult
+    pub fn post_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
         T: Future<Output = Result<Response>> + 'static,
     {
         self.add_handler(
             pattern,
-            Handler::Async(Rc::new(move |req, env, par| Box::pin(func(req, env, par)))),
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
             vec![Method::Post],
-        )
+        );
+
+        self
     }
 
-    pub fn on_async<T>(
-        &mut self,
-        pattern: &str,
-        func: fn(Request, Env, RouteParams) -> T,
-    ) -> RouterResult
+    pub fn on_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
         T: Future<Output = Result<Response>> + 'static,
     {
         self.add_handler(
             pattern,
-            Handler::Async(Rc::new(move |req, env, par| Box::pin(func(req, env, par)))),
+            Handler::Async(Rc::new(move |req, route| Box::pin(func(req, route)))),
             Method::all(),
-        )
+        );
+
+        self
     }
 
-    fn add_handler(
-        &mut self,
-        pattern: &str,
-        func: Handler<'a>,
-        methods: Vec<Method>,
-    ) -> RouterResult {
+    fn add_handler(&mut self, pattern: &str, func: Handler<'a, D>, methods: Vec<Method>) {
         if let Ok(Match {
             value: handler_set,
             params: _,
@@ -111,26 +198,34 @@ impl<'a> Router<'a> {
             }
         } else {
             let mut handler_set = [None, None, None, None, None, None, None, None, None];
-            for method in methods {
+            for method in methods.clone() {
                 handler_set[method as usize] = Some(func.clone());
             }
-            self.handlers.insert(pattern, handler_set)?;
+            self.handlers.insert(pattern, handler_set).expect(&format!(
+                "failed to register {:?} route for {} pattern",
+                methods, pattern
+            ));
         }
-
-        Ok(())
     }
 
-    pub async fn run(&self, req: Request, env: Env) -> Result<Response> {
-        if let Ok(Match { value, params }) = self.handlers.at(&req.path()) {
+    pub async fn run(self, req: Request, env: Env) -> Result<Response> {
+        let (handlers, data) = self.split();
+
+        if let Ok(Match { value, params }) = handlers.at(&req.path()) {
             let mut par: RouteParams = HashMap::new();
             for (ident, value) in params.iter() {
                 par.insert(ident.into(), value.into());
             }
+            let route_info = RouteContext {
+                data,
+                env,
+                params: par,
+            };
 
             if let Some(handler) = value[req.method() as usize].as_ref() {
                 return match handler {
-                    Handler::Sync(func) => (func)(req, env, par),
-                    Handler::Async(func) => (func)(req, env, par).await,
+                    Handler::Sync(func) => (func)(req, route_info),
+                    Handler::Async(func) => (func)(req, route_info).await,
                 };
             }
             return Response::error("Method Not Allowed", 405);
@@ -139,10 +234,21 @@ impl<'a> Router<'a> {
     }
 }
 
-impl Default for Router<'_> {
+type NodeWithHandlers<'a, D> = Node<[Option<Handler<'a, D>>; 9]>;
+
+impl<'a, D: 'static> Router<'a, D> {
+    fn split(self) -> (NodeWithHandlers<'a, D>, Option<Data<D>>) {
+        (self.handlers, self.data)
+    }
+}
+
+impl<D> Default for Router<'_, D> {
     fn default() -> Self {
         Self {
             handlers: Node::new(),
+            data: None,
+            env: None,
+            params: None,
         }
     }
 }

--- a/rust-sandbox/Cargo.toml
+++ b/rust-sandbox/Cargo.toml
@@ -18,6 +18,7 @@ cfg-if = "0.1.2"
 console_error_panic_hook = { version = "0.1.1", optional = true }
 hex = "0.4.3"
 http = "0.2.4"
+regex = "1.5.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 url = "2.2.2"

--- a/rust-sandbox/src/lib.rs
+++ b/rust-sandbox/src/lib.rs
@@ -31,9 +31,30 @@ struct User {
     date_from_str: String,
 }
 
-fn handle_a_request(req: Request, _env: Env, _params: RouteParams) -> Result<Response> {
+#[derive(Deserialize, Serialize)]
+struct FileSize {
+    name: String,
+    size: u32,
+}
+
+#[derive(Clone)]
+struct SomeSharedData<'a> {
+    prefix: &'a str,
+    regex: regex::Regex,
+}
+
+fn handle_a_request<D>(req: Request, _ctx: RouteContext<D>) -> Result<Response> {
     Response::ok(&format!(
         "req at: {}, located at: {:?}, within: {}",
+        req.path(),
+        req.cf().coordinates().unwrap_or_default(),
+        req.cf().region().unwrap_or("unknown region".into())
+    ))
+}
+
+async fn handle_async_request<D>(req: Request, _ctx: RouteContext<D>) -> Result<Response> {
+    Response::ok(&format!(
+        "[async] req at: {}, located at: {:?}, within: {}",
         req.path(),
         req.cf().coordinates().unwrap_or_default(),
         req.cf().region().unwrap_or("unknown region".into())
@@ -44,222 +65,240 @@ fn handle_a_request(req: Request, _env: Env, _params: RouteParams) -> Result<Res
 pub async fn main(req: Request, env: Env) -> Result<Response> {
     utils::set_panic_hook();
 
-    let mut router = Router::new();
+    let data = SomeSharedData {
+        prefix: "value".into(),
+        regex: regex::Regex::new(r"^\d{4}-\d{2}-\d{2}$").unwrap(),
+    };
 
-    router.get("/request", handle_a_request)?;
-    router.post("/headers", |req, _, _| {
-        let mut headers: http::HeaderMap = req.headers().into();
-        headers.append("Hello", "World!".parse().unwrap());
-
-        Response::ok("returned your headers to you.").map(|res| res.with_headers(headers.into()))
-    })?;
-
-    router.on_async("/formdata-name", |mut req, _env, _params| async move {
-        let form = req.form_data().await?;
-        const NAME: &str = "name";
-        let bad_request = Response::error("Bad Request", 400);
-
-        if !form.has(NAME) {
-            return bad_request;
-        }
-
-        let names: Vec<String> = form
-            .get_all(NAME)
-            .unwrap_or_default()
-            .into_iter()
-            .map(|entry| match entry {
-                FormEntry::Field(s) => s,
-                FormEntry::File(f) => f.name(),
-            })
-            .collect();
-        if names.len() > 1 {
-            return Response::from_json(&serde_json::json!({ "names": names }));
-        }
-
-        if let Some(value) = form.get(NAME) {
-            match value {
-                FormEntry::Field(v) => Response::from_json(&serde_json::json!({ NAME: v })),
-                _ => bad_request,
-            }
-        } else {
-            bad_request
-        }
-    })?;
-
-    #[derive(Deserialize, Serialize)]
-    struct FileSize {
-        name: String,
-        size: u32,
-    }
-    router.post_async("/formdata-file-size", |mut req, env, _| async move {
-        let form = req.form_data().await?;
-
-        if let Some(entry) = form.get("file") {
-            return match entry {
-                FormEntry::File(file) => {
-                    let kv = env.kv("FILE_SIZES")?;
-
-                    // create a new FileSize record to store
-                    let b = file.bytes().await?;
-                    let record = FileSize {
-                        name: file.name(),
-                        size: b.len() as u32,
-                    };
-
-                    // hash the file, and use result as the key
-                    let mut hasher = Blake2b::new();
-                    hasher.update(b);
-                    let hash = hasher.finalize();
-                    let key = hex::encode(&hash[..]);
-
-                    // serialize the record and put it into kv
-                    let val = serde_json::to_string(&record)?;
-                    kv.put(&key, val)?.execute().await?;
-
-                    // list the default number of keys from the namespace
-                    Response::from_json(&kv.list().execute().await?.keys)
+    let router = Router::new(data); // if no data is needed, pass `()`
+    router
+        .get("/request", handle_a_request) // can pass a fn pointer to keep routes tidy
+        .get_async("/async-request", handle_async_request)
+        .get("/test-data", |_, ctx| {
+            // just here to test data works
+            if let Some(data) = ctx.data() {
+                if data.regex.is_match("2014-01-01") {
+                    Response::ok("data ok")
+                } else {
+                    Response::error("bad match", 500)
                 }
-                _ => Response::error("Bad Request", 400),
-            };
-        }
-
-        Response::error("Bad Request", 400)
-    })?;
-
-    router.get_async("/formdata-file-size/:hash", |_, env, params| async move {
-        if let Some(hash) = params.get("hash") {
-            let kv = env.kv("FILE_SIZES")?;
-            return match kv.get(&hash).await? {
-                Some(val) => Response::from_json(&val.as_json::<FileSize>()?),
-                None => Response::error("Not Found", 404),
-            };
-        }
-
-        Response::error("Bad Request", 400)
-    })?;
-
-    router.post_async("/post-file-size", |mut req, _, _| async move {
-        let bytes = req.bytes().await?;
-        Response::ok(&format!("size = {}", bytes.len()))
-    })?;
-
-    router.on("/user/:id/test", |req, _env, params| {
-        if !matches!(req.method(), Method::Get) {
-            return Response::error("Method Not Allowed", 405);
-        }
-        if let Some(id) = params.get("id") {
-            return Response::ok(format!("TEST user id: {}", id));
-        }
-
-        Response::error("Error", 500)
-    })?;
-
-    router.on("/user/:id", |_req, _env, params| {
-        if let Some(id) = params.get("id") {
-            return Response::from_json(&User {
-                id: id.to_string(),
-                timestamp: Date::now().as_millis(),
-                date_from_int: Date::new(DateInit::Millis(1234567890)).to_string(),
-                date_from_str: Date::new(DateInit::String(
-                    "Wed Jan 14 1980 23:56:07 GMT-0700 (Mountain Standard Time)".into(),
-                ))
-                .to_string(),
-            });
-        }
-
-        Response::error("Bad Request", 400)
-    })?;
-
-    router.post("/account/:id/zones", |_, _, params| {
-        Response::ok(format!(
-            "Create new zone for Account: {}",
-            params.get("id").unwrap_or(&"not found".into())
-        ))
-    })?;
-
-    router.get("/account/:id/zones", |_, _, params| {
-        Response::ok(format!(
-            "Account id: {}..... You get a zone, you get a zone!",
-            params.get("id").unwrap_or(&"not found".into())
-        ))
-    })?;
-
-    router.on_async("/async", |mut req, _env, _params| async move {
-        Response::ok(format!("Request body: {}", req.text().await?))
-    })?;
-
-    router.on_async("/fetch", |_req, _env, _params| async move {
-        let req = Request::new("https://example.com", Method::Post)?;
-        let resp = Fetch::Request(&req).send().await?;
-        let resp2 = Fetch::Url("https://example.com").send().await?;
-        Response::ok(format!(
-            "received responses with codes {} and {}",
-            resp.status_code(),
-            resp2.status_code()
-        ))
-    })?;
-
-    router.on_async("/fetch_json", |_req, _env, _params| async move {
-        let data: ApiData = Fetch::Url("https://jsonplaceholder.typicode.com/todos/1")
-            .send()
-            .await?
-            .json()
-            .await?;
-        Response::ok(format!(
-            "API Returned user: {} with title: {} and completed: {}",
-            data.user_id, data.title, data.completed
-        ))
-    })?;
-
-    router.on_async("/proxy_request/*url", |_req, _env, params| async move {
-        let url = params
-            .get("url")
-            .unwrap()
-            .strip_prefix('/')
-            .unwrap();
-
-        Fetch::Url(url).send().await
-    })?;
-
-    router.on_async("/durable/:id", |_req, env, _params| async move {
-        let namespace = env.durable_object("COUNTER")?;
-        let stub = namespace.id_from_name("A")?.get_stub()?;
-        stub.fetch_with_str("/").await
-    })?;
-
-    router.get("/secret", |_req, env, _params| {
-        Response::ok(env.secret("SOME_SECRET")?.to_string())
-    })?;
-
-    router.get("/var", |_req, env, _params| {
-        Response::ok(env.var("SOME_VARIABLE")?.to_string())
-    })?;
-
-    router.post_async("/kv/:key/:value", |_req, env, params| async move {
-        let kv = env.kv("SOME_NAMESPACE")?;
-        if let Some(key) = params.get("key") {
-            if let Some(value) = params.get("value") {
-                kv.put(&key, value)?.execute().await?;
+            } else {
+                Response::error("no data", 500)
             }
-        }
+        })
+        .post("/headers", |req, _ctx| {
+            let mut headers: http::HeaderMap = req.headers().into();
+            headers.append("Hello", "World!".parse().unwrap());
 
-        Response::from_json(&kv.list().execute().await?)
-    })?;
+            Response::ok("returned your headers to you.")
+                .map(|res| res.with_headers(headers.into()))
+        })
+        .on_async("/formdata-name", |mut req, _ctx| async move {
+            let form = req.form_data().await?;
+            const NAME: &str = "name";
+            let bad_request = Response::error("Bad Request", 400);
 
-    router.get("/bytes", |_, _, _| {
-        Response::from_bytes(vec![1, 2, 3, 4, 5, 6, 7])
-    })?;
+            if !form.has(NAME) {
+                return bad_request;
+            }
 
-    router.post_async("/api-data", |mut req, _, _| async move {
-        let data = req.bytes().await?;
-        let mut todo: ApiData = serde_json::from_slice(&data)?;
+            let names: Vec<String> = form
+                .get_all(NAME)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|entry| match entry {
+                    FormEntry::Field(s) => s,
+                    FormEntry::File(f) => f.name(),
+                })
+                .collect();
+            if names.len() > 1 {
+                return Response::from_json(&serde_json::json!({ "names": names }));
+            }
 
-        unsafe { todo.title.as_mut_vec().reverse() };
+            if let Some(value) = form.get(NAME) {
+                match value {
+                    FormEntry::Field(v) => Response::from_json(&serde_json::json!({ NAME: v })),
+                    _ => bad_request,
+                }
+            } else {
+                bad_request
+            }
+        })
+        .post_async("/is-secret", |mut req, ctx| async move {
+            let form = req.form_data().await?;
+            if let Some(secret) = form.get("secret") {
+                match secret {
+                    FormEntry::Field(name) => {
+                        let val = ctx.secret(&name)?;
+                        return Response::ok(val.to_string());
+                    }
+                    _ => return Response::error("Bad Request", 400),
+                };
+            }
 
-        console_log!("todo = (title {}) (id {})", todo.title, todo.user_id);
+            Response::error("Bad Request", 400)
+        })
+        .post_async("/formdata-file-size", |mut req, ctx| async move {
+            let form = req.form_data().await?;
 
-        Response::from_bytes(serde_json::to_vec(&todo)?)
-    })?;
+            if let Some(entry) = form.get("file") {
+                return match entry {
+                    FormEntry::File(file) => {
+                        let kv = ctx.kv("FILE_SIZES")?;
 
-    router.run(req, env).await
+                        // create a new FileSize record to store
+                        let b = file.bytes().await?;
+                        let record = FileSize {
+                            name: file.name(),
+                            size: b.len() as u32,
+                        };
+
+                        // hash the file, and use result as the key
+                        let mut hasher = Blake2b::new();
+                        hasher.update(b);
+                        let hash = hasher.finalize();
+                        let key = hex::encode(&hash[..]);
+
+                        // serialize the record and put it into kv
+                        let val = serde_json::to_string(&record)?;
+                        kv.put(&key, val)?.execute().await?;
+
+                        // list the default number of keys from the namespace
+                        Response::from_json(&kv.list().execute().await?.keys)
+                    }
+                    _ => Response::error("Bad Request", 400),
+                };
+            }
+
+            Response::error("Bad Request", 400)
+        })
+        .get_async("/formdata-file-size/:hash", |_, ctx| async move {
+            if let Some(hash) = ctx.param("hash") {
+                let kv = ctx.kv("FILE_SIZES")?;
+                return match kv.get(&hash).await? {
+                    Some(val) => Response::from_json(&val.as_json::<FileSize>()?),
+                    None => Response::error("Not Found", 404),
+                };
+            }
+
+            Response::error("Bad Request", 400)
+        })
+        .post_async("/post-file-size", |mut req, _| async move {
+            let bytes = req.bytes().await?;
+            Response::ok(&format!("size = {}", bytes.len()))
+        })
+        .on("/user/:id/test", |req, ctx| {
+            if !matches!(req.method(), Method::Get) {
+                return Response::error("Method Not Allowed", 405);
+            }
+            if let Some(id) = ctx.param("id") {
+                return Response::ok(format!("TEST user id: {}", id));
+            }
+
+            Response::error("Error", 500)
+        })
+        .on("/user/:id", |_req, ctx| {
+            if let Some(id) = ctx.param("id") {
+                return Response::from_json(&User {
+                    id: id.to_string(),
+                    timestamp: Date::now().as_millis(),
+                    date_from_int: Date::new(DateInit::Millis(1234567890)).to_string(),
+                    date_from_str: Date::new(DateInit::String(
+                        "Wed Jan 14 1980 23:56:07 GMT-0700 (Mountain Standard Time)".into(),
+                    ))
+                    .to_string(),
+                });
+            }
+
+            Response::error("Bad Request", 400)
+        })
+        .post("/account/:id/zones", |_, ctx| {
+            Response::ok(format!(
+                "Create new zone for Account: {}",
+                ctx.param("id").unwrap_or(&"not found".into())
+            ))
+        })
+        .get("/account/:id/zones", |_, ctx| {
+            Response::ok(format!(
+                "Account id: {}..... You get a zone, you get a zone!",
+                ctx.param("id").unwrap_or(&"not found".into())
+            ))
+        })
+        .on_async("/async", |mut req, _ctx| async move {
+            Response::ok(format!("Request body: {}", req.text().await?))
+        })
+        .on_async("/fetch", |_req, _ctx| async move {
+            let req = Request::new("https://example.com", Method::Post)?;
+            let resp = Fetch::Request(&req).send().await?;
+            let resp2 = Fetch::Url("https://example.com").send().await?;
+            Response::ok(format!(
+                "received responses with codes {} and {}",
+                resp.status_code(),
+                resp2.status_code()
+            ))
+        })
+        .on_async("/fetch_json", |_req, _ctx| async move {
+            let data: ApiData = Fetch::Url("https://jsonplaceholder.typicode.com/todos/1")
+                .send()
+                .await?
+                .json()
+                .await?;
+            Response::ok(format!(
+                "API Returned user: {} with title: {} and completed: {}",
+                data.user_id, data.title, data.completed
+            ))
+        })
+        .on_async("/proxy_request/*url", |_req, ctx| async move {
+            let url = ctx.param("url").unwrap().strip_prefix('/').unwrap();
+
+            Fetch::Url(url).send().await
+        })
+        .on_async("/durable/:id", |_req, ctx| async move {
+            let namespace = ctx.durable_object("COUNTER")?;
+            let stub = namespace.id_from_name("A")?.get_stub()?;
+            stub.fetch_with_str("/").await
+        })
+        .get("/secret", |_req, ctx| {
+            Response::ok(ctx.secret("SOME_SECRET")?.to_string())
+        })
+        .get("/var", |_req, ctx| {
+            Response::ok(ctx.var("SOME_VARIABLE")?.to_string())
+        })
+        .post_async("/kv/:key/:value", |_req, ctx| async move {
+            let kv = ctx.kv("SOME_NAMESPACE")?;
+            if let Some(key) = ctx.param("key") {
+                if let Some(value) = ctx.param("value") {
+                    kv.put(&key, value)?.execute().await?;
+                }
+            }
+
+            Response::from_json(&kv.list().execute().await?)
+        })
+        .get("/bytes", |_, _| {
+            Response::from_bytes(vec![1, 2, 3, 4, 5, 6, 7])
+        })
+        .post_async("/api-data", |mut req, _ctx| async move {
+            let data = req.bytes().await?;
+            let mut todo: ApiData = serde_json::from_slice(&data)?;
+
+            unsafe { todo.title.as_mut_vec().reverse() };
+
+            console_log!("todo = (title {}) (id {})", todo.title, todo.user_id);
+
+            Response::from_bytes(serde_json::to_vec(&todo)?)
+        })
+        .post_async("/nonsense-repeat", |_, ctx| async move {
+            //  just here to test data works
+            if let Some(data) = ctx.data() {
+                if data.regex.is_match("2014-01-01") {
+                    Response::ok("data ok")
+                } else {
+                    Response::error("bad match", 500)
+                }
+            } else {
+                Response::error("no data", 500)
+            }
+        })
+        .run(req, env)
+        .await
 }


### PR DESCRIPTION
- `Router::new` now must be constructed with some shared data, either your own type, or a `()` stub to define the generic type parameter. I'd be happy to know how this can be avoided.. 
- `Router` methods return `Self` now so routes can be chained.
- All `Env` access is done though the `RouteContex`, a `ctx` param in the route fn. 

```rust
use worker::*;

#[event(fetch, respond_with_errors)]
pub async fn main(req: Request, env: Env) -> Result<Response> {
    utils::set_panic_hook();

    let router = Router::new(()); 

    router
        .on_async("/durable", |_req, ctx| async move {
            let namespace = ctx.durable_object("CHATROOM")?;
            let stub = namespace.id_from_name("A")?.get_stub()?;
            stub.fetch_with_str("/messages").await
        })
        .get("/secret", |_req, ctx| {
            Response::ok(ctx.secret("CF_API_TOKEN")?.to_string())
        })
        .get("/var", |_req, ctx| {
            Response::ok(ctx.var("BUILD_NUMBER")?.to_string())
        })
        .post_async("/kv", |_req, ctx| async move {
            let kv = ctx.kv("SOME_NAMESPACE")?;

            kv.put("key", "value")?.execute().await?;

            Response::empty()
        })
        .run(req, env).await
}
```