### PR TITLE
Router avoid method conflicts

### DIFF
--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -107,7 +107,7 @@ impl Response {
         })
     }
 
-    /// Set the HTTP Status code on this `Response`.
+    /// Get the HTTP Status code of this `Response`.
     pub fn status_code(&self) -> u16 {
         self.status_code
     }

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -154,9 +154,17 @@ impl Response {
     }
 
     /// Set this response's status code.
-    pub fn with_status(mut self, status_code: u16) -> Self {
+    ///
+    /// Will return Err if the status code provided is outside the valid HTTP
+    /// error range of 100-599.
+    pub fn with_status(mut self, status_code: u16) -> Result<Self> {
+        if !(100..=599).contains(&status_code) {
+            return Err(Error::Internal(
+                "provided error status code is invalid".into(),
+            ));
+        }
         self.status_code = status_code;
-        self
+        Ok(self)
     }
 
     /// Read the `Headers` on this response.

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -100,6 +100,12 @@ impl<'a, D: 'static> Router<'a, D> {
         }
     }
 
+    /// Register an HTTP handler that will exclusively respond to HEAD requests.
+    pub fn head(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Head]);
+        self
+    }
+
     /// Register an HTTP handler that will exclusively respond to GET requests.
     pub fn get(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
         self.add_handler(pattern, Handler::Sync(func), vec![Method::Get]);
@@ -130,9 +136,41 @@ impl<'a, D: 'static> Router<'a, D> {
         self
     }
 
+    /// Register an HTTP handler that will exclusively respond to OPTIONS requests.
+    pub fn options(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Options]);
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to CONNECT requests.
+    pub fn connect(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Connect]);
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to TRACE requests.
+    pub fn trace(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Trace]);
+        self
+    }
+
     /// Register an HTTP handler that will respond to any requests.
     pub fn on(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
         self.add_handler(pattern, Handler::Sync(func), Method::all());
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to HEAD requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn head_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Head],
+        );
         self
     }
 
@@ -202,6 +240,48 @@ impl<'a, D: 'static> Router<'a, D> {
             pattern,
             Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
             vec![Method::Delete],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to OPTIONS requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn options_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Options],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to CONNECT requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn connect_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Connect],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to TRACE requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn trace_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Trace],
         );
         self
     }

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -112,6 +112,24 @@ impl<'a, D: 'static> Router<'a, D> {
         self
     }
 
+    /// Register an HTTP handler that will exclusively respond to PUT requests.
+    pub fn put(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Put]);
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to PATCH requests.
+    pub fn patch(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Patch]);
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to DELETE requests.
+    pub fn delete(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Delete]);
+        self
+    }
+
     /// Register an HTTP handler that will respond to any requests.
     pub fn on(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
         self.add_handler(pattern, Handler::Sync(func), Method::all());
@@ -142,6 +160,48 @@ impl<'a, D: 'static> Router<'a, D> {
             pattern,
             Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
             vec![Method::Post],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to PUT requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn put_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Put],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to PATCH requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn patch_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Patch],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to DELETE requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn delete_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Delete],
         );
         self
     }


### PR DESCRIPTION
Depends on #33 

I noticed that I could not add a catchall route `/*whatever` without causing a conflict with an existing route `/something`, even if the 2 routes used different HTTP methods. I am not sure whether this is expected behavior, but I thought that it might make sense to check conflicts only for routes with the same HTTP methods, which is what this PR implements.

For example, with this PR it is possible to define a `/*whatever` route for OPTIONS requests without causing conflicts with any existing and more specific GET route.