### PR TITLE
Fix two compiler errors about iterating arrays and remove one unneeded unsafe block

### DIFF
--- a/worker-build/src/main.rs
+++ b/worker-build/src/main.rs
@@ -151,7 +151,7 @@ export default {{ fetch }};
         (shim_content, shim_path),
     ].iter() {
         let mut file = File::create(path)?;
-        let buf = unsafe {
+        let buf = {
             // SAFETY: this string contains valid UTF-8, and will continue to do so
             // until the write is complete. So this operation is safe.
             content.as_bytes()

--- a/worker-build/src/main.rs
+++ b/worker-build/src/main.rs
@@ -96,7 +96,7 @@ fn copy_generated_code_to_worker_dir() -> Result<()> {
         .join(WORKER_SUBDIR)
         .join(format!("{}_bg.wasm", OUT_NAME));
 
-    for (src, dest) in [(glue_src, glue_dest), (wasm_src, wasm_dest)] {
+    for (src, dest) in [(glue_src, glue_dest), (wasm_src, wasm_dest)].iter() {
         fs::rename(src, dest)?;
     }
 
@@ -146,15 +146,15 @@ export default {{ fetch }};
     let shim_path = PathBuf::from(OUT_DIR).join(WORKER_SUBDIR).join("shim.mjs");
 
     // write our content out to files
-    for (mut content, path) in [
+    for (content, path) in [
         (export_wasm_content, export_wasm_path),
         (shim_content, shim_path),
-    ] {
+    ].iter() {
         let mut file = File::create(path)?;
         let buf = unsafe {
             // SAFETY: this string contains valid UTF-8, and will continue to do so
             // until the write is complete. So this operation is safe.
-            content.as_bytes_mut()
+            content.as_bytes()
         };
 
         file.write_all(buf)?;


### PR DESCRIPTION
While trying the Getting Started steps I had to locally fix these issues to continue because the latest Rust compiler reports errors on building worker-build. The fixes are simple and after making them I was able to successfully run the example, make changes to the worker and see those changes applied.