### PR TITLE
Match http handler methods to platform support

### DIFF
--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -339,6 +339,32 @@ pub async fn main(req: Request, env: Env) -> Result<Response> {
 
             Response::error("Bad Request", 400)
         })
+        .options("/", respond)
+        .put("/", respond)
+        .patch("/", respond)
+        .delete("/", respond)
+        .head("/", respond)
+        .options_async("/async", respond_async)
+        .put_async("/async", respond_async)
+        .patch_async("/async", respond_async)
+        .delete_async("/async", respond_async)
+        .head_async("/async", respond_async)
         .run(req, env)
         .await
+}
+
+fn respond<D>(req: Request, _ctx: RouteContext<D>) -> Result<Response> {
+    Response::ok(format!("Ok: {}", String::from(req.method()))).map(|resp| {
+        let mut headers = Headers::new();
+        headers.set("x-testing", "123").unwrap();
+        resp.with_headers(headers)
+    })
+}
+
+async fn respond_async<D>(req: Request, _ctx: RouteContext<D>) -> Result<Response> {
+    Response::ok(format!("Ok (async): {}", String::from(req.method()))).map(|resp| {
+        let mut headers = Headers::new();
+        headers.set("x-testing", "123").unwrap();
+        resp.with_headers(headers)
+    })
 }

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -107,7 +107,7 @@ impl Response {
         })
     }
 
-    /// Set the HTTP Status code on this `Response`.
+    /// Get the HTTP Status code of this `Response`.
     pub fn status_code(&self) -> u16 {
         self.status_code
     }

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -154,17 +154,9 @@ impl Response {
     }
 
     /// Set this response's status code.
-    ///
-    /// Will return Err if the status code provided is outside the valid HTTP
-    /// error range of 100-599.
-    pub fn with_status(mut self, status_code: u16) -> Result<Self> {
-        if !(100..=599).contains(&status_code) {
-            return Err(Error::Internal(
-                "provided error status code is invalid".into(),
-            ));
-        }
+    pub fn with_status(mut self, status_code: u16) -> Self {
         self.status_code = status_code;
-        Ok(self)
+        self
     }
 
     /// Read the `Headers` on this response.

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -154,9 +154,17 @@ impl Response {
     }
 
     /// Set this response's status code.
-    pub fn with_status(mut self, status_code: u16) -> Self {
+    ///
+    /// Will return Err if the status code provided is outside the valid HTTP
+    /// error range of 100-599.
+    pub fn with_status(mut self, status_code: u16) -> Result<Self> {
+        if !(100..=599).contains(&status_code) {
+            return Err(Error::Internal(
+                "provided error status code is invalid".into(),
+            ));
+        }
         self.status_code = status_code;
-        self
+        Ok(self)
     }
 
     /// Read the `Headers` on this response.

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -142,18 +142,6 @@ impl<'a, D: 'static> Router<'a, D> {
         self
     }
 
-    /// Register an HTTP handler that will exclusively respond to CONNECT requests.
-    pub fn connect(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
-        self.add_handler(pattern, Handler::Sync(func), vec![Method::Connect]);
-        self
-    }
-
-    /// Register an HTTP handler that will exclusively respond to TRACE requests.
-    pub fn trace(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
-        self.add_handler(pattern, Handler::Sync(func), vec![Method::Trace]);
-        self
-    }
-
     /// Register an HTTP handler that will respond to any requests.
     pub fn on(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
         self.add_handler(pattern, Handler::Sync(func), Method::all());
@@ -230,8 +218,8 @@ impl<'a, D: 'static> Router<'a, D> {
         self
     }
 
-    /// Register an HTTP handler that will exclusively respond to DELETE requests. Enables the use of
-    /// `async/await` syntax in the callback.
+    /// Register an HTTP handler that will exclusively respond to DELETE requests. Enables the use
+    /// of `async/await` syntax in the callback.
     pub fn delete_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
         T: Future<Output = Result<Response>> + 'static,
@@ -244,9 +232,13 @@ impl<'a, D: 'static> Router<'a, D> {
         self
     }
 
-    /// Register an HTTP handler that will exclusively respond to OPTIONS requests. Enables the use of
-    /// `async/await` syntax in the callback.
-    pub fn options_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    /// Register an HTTP handler that will exclusively respond to OPTIONS requests. Enables the use
+    /// of `async/await` syntax in the callback.
+    pub fn options_async<T>(
+        mut self,
+        pattern: &str,
+        func: fn(Request, RouteContext<D>) -> T,
+    ) -> Self
     where
         T: Future<Output = Result<Response>> + 'static,
     {
@@ -254,34 +246,6 @@ impl<'a, D: 'static> Router<'a, D> {
             pattern,
             Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
             vec![Method::Options],
-        );
-        self
-    }
-
-    /// Register an HTTP handler that will exclusively respond to CONNECT requests. Enables the use of
-    /// `async/await` syntax in the callback.
-    pub fn connect_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
-    where
-        T: Future<Output = Result<Response>> + 'static,
-    {
-        self.add_handler(
-            pattern,
-            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
-            vec![Method::Connect],
-        );
-        self
-    }
-
-    /// Register an HTTP handler that will exclusively respond to TRACE requests. Enables the use of
-    /// `async/await` syntax in the callback.
-    pub fn trace_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
-    where
-        T: Future<Output = Result<Response>> + 'static,
-    {
-        self.add_handler(
-            pattern,
-            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
-            vec![Method::Trace],
         );
         self
     }

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -100,6 +100,12 @@ impl<'a, D: 'static> Router<'a, D> {
         }
     }
 
+    /// Register an HTTP handler that will exclusively respond to HEAD requests.
+    pub fn head(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Head]);
+        self
+    }
+
     /// Register an HTTP handler that will exclusively respond to GET requests.
     pub fn get(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
         self.add_handler(pattern, Handler::Sync(func), vec![Method::Get]);
@@ -130,9 +136,41 @@ impl<'a, D: 'static> Router<'a, D> {
         self
     }
 
+    /// Register an HTTP handler that will exclusively respond to OPTIONS requests.
+    pub fn options(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Options]);
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to CONNECT requests.
+    pub fn connect(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Connect]);
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to TRACE requests.
+    pub fn trace(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Trace]);
+        self
+    }
+
     /// Register an HTTP handler that will respond to any requests.
     pub fn on(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
         self.add_handler(pattern, Handler::Sync(func), Method::all());
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to HEAD requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn head_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Head],
+        );
         self
     }
 
@@ -202,6 +240,48 @@ impl<'a, D: 'static> Router<'a, D> {
             pattern,
             Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
             vec![Method::Delete],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to OPTIONS requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn options_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Options],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to CONNECT requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn connect_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Connect],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to TRACE requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn trace_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Trace],
         );
         self
     }

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -112,6 +112,24 @@ impl<'a, D: 'static> Router<'a, D> {
         self
     }
 
+    /// Register an HTTP handler that will exclusively respond to PUT requests.
+    pub fn put(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Put]);
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to PATCH requests.
+    pub fn patch(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Patch]);
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to DELETE requests.
+    pub fn delete(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Delete]);
+        self
+    }
+
     /// Register an HTTP handler that will respond to any requests.
     pub fn on(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
         self.add_handler(pattern, Handler::Sync(func), Method::all());
@@ -142,6 +160,48 @@ impl<'a, D: 'static> Router<'a, D> {
             pattern,
             Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
             vec![Method::Post],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to PUT requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn put_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Put],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to PATCH requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn patch_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Patch],
+        );
+        self
+    }
+
+    /// Register an HTTP handler that will exclusively respond to DELETE requests. Enables the use of
+    /// `async/await` syntax in the callback.
+    pub fn delete_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    where
+        T: Future<Output = Result<Response>> + 'static,
+    {
+        self.add_handler(
+            pattern,
+            Handler::Async(Rc::new(move |req, info| Box::pin(func(req, info)))),
+            vec![Method::Delete],
         );
         self
     }


### PR DESCRIPTION
Slight modification of #33, whereby some HTTP verb handler methods should be omitted due to platform restrictions. `TRACE` and `CONNECT` are not supported and the platform will not yield any control to the Worker for these. 

Also, I have changed the `with_status` implementation to return `Self` and skip the range check for valid HTTP spec status codes. While it is nice to check this at the Rust level, it hinders the usability of `with_status` (as it would likely be `map`'d from a `Response::from_json(...)` or something and thus requires the Result to be handled within the map. Unless I have something wrong here, which is completely possible :) 

I am going to merge this ASAP, and we can make further considerations for the `with_status` method. But merging this should unblock other PRs from being merged. 