### PR TITLE
Merge PR for #34, add or_else_any_method explicit handlers

### DIFF
--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -347,7 +347,12 @@ pub async fn main(req: Request, env: Env) -> Result<Response> {
         .options("/*catchall", |_, ctx| {
             Response::ok(ctx.param("catchall").unwrap())
         })
-        .or_else_any_method_async("/*catchall", |_, _| async move {
+        .or_else_any_method_async("/*catchall", |_, ctx| async move {
+            console_log!(
+                "[or_else_any_method_async] caught: {}",
+                ctx.param("catchall").unwrap_or(&"?".to_string())
+            );
+
             Fetch::Url("https://github.com/404".parse().unwrap())
                 .send()
                 .await

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -154,17 +154,11 @@ impl Response {
     }
 
     /// Set this response's status code.
-    ///
-    /// Will return Err if the status code provided is outside the valid HTTP
-    /// error range of 100-599.
-    pub fn with_status(mut self, status_code: u16) -> Result<Self> {
-        if !(100..=599).contains(&status_code) {
-            return Err(Error::Internal(
-                "provided error status code is invalid".into(),
-            ));
-        }
+    /// The Workers platform will reject HTTP status codes outside the range of 200..599 inclusive,
+    /// and will throw a JavaScript `RangeError`, returning a response with an HTTP 500 status code.
+    pub fn with_status(mut self, status_code: u16) -> Self {
         self.status_code = status_code;
-        Ok(self)
+        self
     }
 
     /// Read the `Headers` on this response.

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -154,9 +154,17 @@ impl Response {
     }
 
     /// Set this response's status code.
-    pub fn with_status(mut self, status_code: u16) -> Self {
+    ///
+    /// Will return Err if the status code provided is outside the valid HTTP
+    /// error range of 100-599.
+    pub fn with_status(mut self, status_code: u16) -> Result<Self> {
+        if !(100..=599).contains(&status_code) {
+            return Err(Error::Internal(
+                "provided error status code is invalid".into(),
+            ));
+        }
         self.status_code = status_code;
-        self
+        Ok(self)
     }
 
     /// Read the `Headers` on this response.

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -290,10 +290,12 @@ impl<'a, D: 'static> Router<'a, D> {
                 .entry(method.clone())
                 .or_insert_with(Node::new)
                 .insert(pattern, func.clone())
-                .expect(&format!(
-                    "failed to register {:?} route for {} pattern",
-                    method, pattern
-                ));
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "failed to register {:?} route for {} pattern: {}",
+                        method, pattern, e
+                    )
+                });
         }
     }
 

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -36,11 +36,9 @@ impl<D> Clone for Handler<'_, D> {
     }
 }
 
-type HandlerSet<'a, D> = [Option<Handler<'a, D>>; 9];
-
 /// A path-based HTTP router supporting exact-match or wildcard placeholders and shared data.
 pub struct Router<'a, D> {
-    handlers: Node<HandlerSet<'a, D>>,
+    handlers: HashMap<Method, Node<Handler<'a, D>>>,
     data: Option<D>,
 }
 
@@ -95,7 +93,7 @@ impl<'a, D: 'static> Router<'a, D> {
     /// If no data is needed, provide any valid data. The unit type `()` is a good option.
     pub fn new(data: D) -> Self {
         Self {
-            handlers: Node::new(),
+            handlers: HashMap::new(),
             data: Some(data),
         }
     }
@@ -265,23 +263,15 @@ impl<'a, D: 'static> Router<'a, D> {
     }
 
     fn add_handler(&mut self, pattern: &str, func: Handler<'a, D>, methods: Vec<Method>) {
-        if let Ok(Match {
-            value: handler_set,
-            params: _,
-        }) = self.handlers.at_mut(pattern)
-        {
-            for method in methods {
-                handler_set[method as usize] = Some(func.clone());
-            }
-        } else {
-            let mut handler_set = [None, None, None, None, None, None, None, None, None];
-            for method in methods.clone() {
-                handler_set[method as usize] = Some(func.clone());
-            }
-            self.handlers.insert(pattern, handler_set).expect(&format!(
-                "failed to register {:?} route for {} pattern",
-                methods, pattern
-            ));
+        for method in methods {
+            self.handlers
+                .entry(method.clone())
+                .or_insert_with(Node::new)
+                .insert(pattern, func.clone())
+                .expect(&format!(
+                    "failed to register {:?} route for {} pattern",
+                    method, pattern
+                ));
         }
     }
 
@@ -289,33 +279,41 @@ impl<'a, D: 'static> Router<'a, D> {
     pub async fn run(self, req: Request, env: Env) -> Result<Response> {
         let (handlers, data) = self.split();
 
-        if let Ok(Match { value, params }) = handlers.at(&req.path()) {
-            let mut par: RouteParams = HashMap::new();
-            for (ident, value) in params.iter() {
-                par.insert(ident.into(), value.into());
-            }
-            let route_info = RouteContext {
-                data,
-                env,
-                params: par,
-            };
-
-            if let Some(handler) = value[req.method() as usize].as_ref() {
-                return match handler {
+        if let Some(handlers) = handlers.get(&req.method()) {
+            if let Ok(Match { value, params }) = handlers.at(&req.path()) {
+                let mut par: RouteParams = HashMap::new();
+                for (ident, value) in params.iter() {
+                    par.insert(ident.into(), value.into());
+                }
+                let route_info = RouteContext {
+                    data,
+                    env,
+                    params: par,
+                };
+                return match value {
                     Handler::Sync(func) => (func)(req, route_info),
                     Handler::Async(func) => (func)(req, route_info).await,
                 };
             }
-            return Response::error("Method Not Allowed", 405);
+        }
+        for method in Method::all() {
+            if method == Method::Head || method == Method::Options || method == Method::Trace {
+                continue;
+            }
+            if let Some(handlers) = handlers.get(&method) {
+                if let Ok(Match { .. }) = handlers.at(&req.path()) {
+                    return Response::error("Method Not Allowed", 405);
+                }
+            }
         }
         Response::error("Not Found", 404)
     }
 }
 
-type NodeWithHandlers<'a, D> = Node<[Option<Handler<'a, D>>; 9]>;
+type NodeWithHandlers<'a, D> = Node<Handler<'a, D>>;
 
 impl<'a, D: 'static> Router<'a, D> {
-    fn split(self) -> (NodeWithHandlers<'a, D>, Option<D>) {
+    fn split(self) -> (HashMap<Method, NodeWithHandlers<'a, D>>, Option<D>) {
         (self.handlers, self.data)
     }
 }
@@ -323,7 +321,7 @@ impl<'a, D: 'static> Router<'a, D> {
 impl<D> Default for Router<'_, D> {
     fn default() -> Self {
         Self {
-            handlers: Node::new(),
+            handlers: HashMap::new(),
             data: None,
         }
     }


### PR DESCRIPTION
This PR builds on #34, adding explicit route handler for non-match patterns using the `not_found` and `not_found_async` methods.

It also modifies the `worker-sandbox` Worker to narrow its match handlers to more specific HTTP methods to allow for better testing of wildcard patterns and `not_found` handler.