### PR TITLE
Generalize `not_found` handler to handle arbitrary patterns

### DIFF
--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -347,10 +347,11 @@ pub async fn main(req: Request, env: Env) -> Result<Response> {
         .options("/*catchall", |_, ctx| {
             Response::ok(ctx.param("catchall").unwrap())
         })
-        .not_found_async(|_, _| async move {
+        .or_else_any_method_async("/*catchall", |_, _| async move {
             Fetch::Url("https://github.com/404".parse().unwrap())
                 .send()
                 .await
+                .map(|resp| resp.with_status(404))
         })
         .run(req, env)
         .await

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -16,7 +16,7 @@ use crate::{
 
 type HandlerFn<D> = fn(Request, RouteContext<D>) -> Result<Response>;
 type AsyncHandlerFn<'a, D> =
-    Rc<dyn Fn(Request, RouteContext<D>) -> LocalBoxFuture<'a, Result<Response>>>;
+    Rc<dyn 'a + Fn(Request, RouteContext<D>) -> LocalBoxFuture<'a, Result<Response>>>;
 
 /// Represents the URL parameters parsed from the path, e.g. a route with "/user/:id" pattern would
 /// contain a single "id" key.
@@ -89,7 +89,7 @@ impl<D> RouteContext<D> {
     }
 }
 
-impl<'a, D: 'static> Router<'a, D> {
+impl<'a, D: 'a> Router<'a, D> {
     /// Construct a new `Router`, with arbitrary data that will be available to your various routes.
     /// If no data is needed, provide any valid data. The unit type `()` is a good option.
     pub fn new(data: D) -> Self {
@@ -159,7 +159,7 @@ impl<'a, D: 'static> Router<'a, D> {
     /// `async/await` syntax in the callback.
     pub fn head_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
-        T: Future<Output = Result<Response>> + 'static,
+        T: Future<Output = Result<Response>> + 'a,
     {
         self.add_handler(
             pattern,
@@ -173,7 +173,7 @@ impl<'a, D: 'static> Router<'a, D> {
     /// `async/await` syntax in the callback.
     pub fn get_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
-        T: Future<Output = Result<Response>> + 'static,
+        T: Future<Output = Result<Response>> + 'a,
     {
         self.add_handler(
             pattern,
@@ -187,7 +187,7 @@ impl<'a, D: 'static> Router<'a, D> {
     /// `async/await` syntax in the callback.
     pub fn post_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
-        T: Future<Output = Result<Response>> + 'static,
+        T: Future<Output = Result<Response>> + 'a,
     {
         self.add_handler(
             pattern,
@@ -201,7 +201,7 @@ impl<'a, D: 'static> Router<'a, D> {
     /// `async/await` syntax in the callback.
     pub fn put_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
-        T: Future<Output = Result<Response>> + 'static,
+        T: Future<Output = Result<Response>> + 'a,
     {
         self.add_handler(
             pattern,
@@ -215,7 +215,7 @@ impl<'a, D: 'static> Router<'a, D> {
     /// `async/await` syntax in the callback.
     pub fn patch_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
-        T: Future<Output = Result<Response>> + 'static,
+        T: Future<Output = Result<Response>> + 'a,
     {
         self.add_handler(
             pattern,
@@ -229,7 +229,7 @@ impl<'a, D: 'static> Router<'a, D> {
     /// of `async/await` syntax in the callback.
     pub fn delete_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
-        T: Future<Output = Result<Response>> + 'static,
+        T: Future<Output = Result<Response>> + 'a,
     {
         self.add_handler(
             pattern,
@@ -247,7 +247,7 @@ impl<'a, D: 'static> Router<'a, D> {
         func: fn(Request, RouteContext<D>) -> T,
     ) -> Self
     where
-        T: Future<Output = Result<Response>> + 'static,
+        T: Future<Output = Result<Response>> + 'a,
     {
         self.add_handler(
             pattern,
@@ -261,7 +261,7 @@ impl<'a, D: 'static> Router<'a, D> {
     /// syntax in the callback.
     pub fn on_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
-        T: Future<Output = Result<Response>> + 'static,
+        T: Future<Output = Result<Response>> + 'a,
     {
         self.add_handler(
             pattern,
@@ -276,7 +276,7 @@ impl<'a, D: 'static> Router<'a, D> {
     /// the callback.
     pub fn not_found_async<T>(mut self, func: fn(Request, RouteContext<D>) -> T) -> Self
     where
-        T: Future<Output = Result<Response>> + 'static,
+        T: Future<Output = Result<Response>> + 'a,
     {
         self.not_found_handler = Some(Handler::Async(Rc::new(move |req, route| {
             Box::pin(func(req, route))
@@ -352,7 +352,7 @@ impl<'a, D: 'static> Router<'a, D> {
 
 type NodeWithHandlers<'a, D> = Node<Handler<'a, D>>;
 
-impl<'a, D: 'static> Router<'a, D> {
+impl<'a, D: 'a> Router<'a, D> {
     fn split(
         self,
     ) -> (


### PR DESCRIPTION
(I am honestly not totally sure whether this PR adds any value compared to a more specific `not_found` handler.)

I think of the `not_found` case as a kind of "fall-through" pattern in the pattern matching logic. The current implementation of `not_found` is specific to the 404 case, however, because it assumes a catchall route and always maps the response status to a 404. This is certainly the most common case for a fall-through route, so it might make sense to prioritize this situation, but perhaps it would be useful to generalize the logic and allow for arbitrary patterns? (One example I was thinking of is a "proxy router", which only handles a few specific methods and routes, but wants to pass on all other method + route combinations to a different router or even call another worker.)

The more specific `not_found` case can still be implemented pretty easily:

```rust
        .or_else_any_method("/*catchall", |_req, _ctx| {
            let resp = ...;
            resp.map(|resp| resp.with_status(404))
        })
```

I'm not totally happy with the naming, `or_else_any_method` is pretty verbose, but I personally like the `or_else_...` prefix because it emphasizes that the handler will be called only if no other pattern matches, even if it is defined in the code before a "normal" handler.

(I also included @jyn514 's lifetime suggestions for convenience here.)