### PR TITLE
remove Option container from router data, provide method to use no router data 

### DIFF
--- a/worker-sandbox/Cargo.toml
+++ b/worker-sandbox/Cargo.toml
@@ -14,7 +14,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 blake2 = "0.9.2"
-cloudflare = "0.8.6"
+cloudflare = "0.8.7"
 cfg-if = "0.1.2"
 console_error_panic_hook = { version = "0.1.1", optional = true }
 getrandom = { version = "0.2", features = ["js"] }

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -46,21 +46,21 @@ impl<D> Clone for Handler<'_, D> {
 pub struct Router<'a, D> {
     handlers: HashMap<Method, Node<Handler<'a, D>>>,
     or_else_any_method: Node<Handler<'a, D>>,
-    data: Option<D>,
+    data: D,
 }
 
 /// Container for a route's parsed parameters, data, and environment bindings from the Runtime (such
 /// as KV Stores, Durable Objects, Variables, and Secrets).
 pub struct RouteContext<D> {
-    data: Option<D>,
+    data: D,
     env: Env,
     params: RouteParams,
 }
 
 impl<D> RouteContext<D> {
     /// Get a reference to the generic associated data provided to the `Router`.
-    pub fn data(&self) -> Option<&D> {
-        self.data.as_ref()
+    pub fn data(&self) -> &D {
+        &self.data
     }
 
     /// Get the `Env` for this Worker. Typically users should opt for the `secret`, `var`, `kv` and
@@ -95,14 +95,21 @@ impl<D> RouteContext<D> {
     }
 }
 
+impl<'a> Router<'a, ()> {
+    /// Construct a new `Router`. Or, call `Router::with_data(D)` to add arbitrary data that will be
+    /// available to your various routes.
+    pub fn new() -> Self {
+        Self::with_data(())
+    }
+}
+
 impl<'a, D: 'a> Router<'a, D> {
-    /// Construct a new `Router`, with arbitrary data that will be available to your various routes.
-    /// If no data is needed, provide any valid data. The unit type `()` is a good option.
-    pub fn new(data: D) -> Self {
+    /// Construct a new `Router` with arbitrary data that will be available to your various routes.
+    pub fn with_data(data: D) -> Self {
         Self {
             handlers: HashMap::new(),
             or_else_any_method: Node::new(),
-            data: Some(data),
+            data,
         }
     }
 
@@ -365,7 +372,7 @@ impl<'a, D: 'a> Router<'a, D> {
         self,
     ) -> (
         HashMap<Method, NodeWithHandlers<'a, D>>,
-        Option<D>,
+        D,
         NodeWithHandlers<'a, D>,
     ) {
         (self.handlers, self.data, self.or_else_any_method)


### PR DESCRIPTION
This PR removes the `Option` from the RouteContext and Router types containing the user provided data which is to be shared amongst routes. This was a leftover artifact from a previous design and doesn't provide any useful functionality, so it's be re-worked and removed. 

Additionally, the `ctx.data()` method which returns the Router data now returns a `&D`, so that we do not force any user to implement `Clone` on their type. If ownership of the data is required, users can implement `Clone` and call `.clone()` on their data within the route. 
