### PR TITLE
Add Date Conversion

### DIFF
--- a/worker/src/date.rs
+++ b/worker/src/date.rs
@@ -1,3 +1,5 @@
+use chrono::offset::TimeZone;
+use chrono::Datelike;
 use js_sys::Date as JsDate;
 use wasm_bindgen::JsValue;
 
@@ -60,5 +62,17 @@ impl Date {
 impl ToString for Date {
     fn to_string(&self) -> String {
         self.js_date.to_string().into()
+    }
+}
+
+impl<T: TimeZone> From<chrono::Date<T>> for Date {
+    fn from(d: chrono::Date<T>) -> Self {
+        Self {
+            js_date: JsDate::new_with_year_month_day(
+                d.year() as u32,
+                d.month() as i32,
+                d.day() as i32,
+            ),
+        }
     }
 }


### PR DESCRIPTION
This patch adds a `From` implementation for the chrono crate's Date type. I can also add a conversion for `DateTime` if need be.

If you feel like this is an acceptable PR, could you please add a `hacktoberfest-accepted` label?

Closes #8 