### PR TITLE
Uses wasm-pack as a library

### DIFF
--- a/worker-build/Cargo.toml
+++ b/worker-build/Cargo.toml
@@ -18,6 +18,7 @@ swc_common = "0.17.20"
 swc_ecma_codegen = "0.103.0"
 swc_ecma_loader = "0.29.0"
 swc_ecma_parser = "0.100.2"
+wasm-pack = "0.10.2"
 
 [dev-dependencies]
 tempdir = "0.3.7"


### PR DESCRIPTION
This makes use of the wasm-pack as a library rather than as a command.
So there is no need to check whether is already installed, since it will be as is listed as a dependency.