### PR TITLE
feat: support mutable Request paths

### DIFF
--- a/worker-macros/src/durable_object.rs
+++ b/worker-macros/src/durable_object.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
-use syn::{spanned::Spanned, FnArg, Error, ImplItem, Type, TypePath, PatType, Item};
+use syn::{spanned::Spanned, Error, FnArg, ImplItem, Item, PatType, Type, TypePath};
 
 pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
     let item = syn::parse2::<Item>(tokens)?;

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -146,7 +146,7 @@ impl Request {
         Err(Error::BodyUsed)
     }
 
-    /// Get the `Headers` for this reuqest.
+    /// Get the `Headers` for this request.
     pub fn headers(&self) -> &Headers {
         &self.headers
     }
@@ -175,6 +175,17 @@ impl Request {
     /// The URL Path of this `Request`.
     pub fn path(&self) -> String {
         self.path.clone()
+    }
+
+    /// Get a mutable reference to this request's path.
+    /// **Note:** they can only be modified if the request was created from scratch or cloned.
+    pub fn path_mut(&mut self) -> Result<&mut String> {
+        if self.immutable {
+            return Err(Error::JsError(
+                "Cannot get a mutable reference to an immutable path.".into(),
+            ));
+        }
+        Ok(&mut self.path)
     }
 
     /// The parsed [`url::Url`] of this `Request`.


### PR DESCRIPTION
This PR adds support for mutating a path in-place for a `Request`s using `req.path_mut()`.

See https://github.com/cloudflare/workers-rs/issues/89 for more information.