### PR TITLE
Add `console.debug`, `console.error` & `console.error`

### DIFF
--- a/worker-sys/src/global.rs
+++ b/worker-sys/src/global.rs
@@ -48,5 +48,14 @@ extern "C" {
     ) -> ::js_sys::Promise;
 
     #[wasm_bindgen(js_namespace = console)]
+    pub fn debug(s: &str);
+
+    #[wasm_bindgen(js_namespace = console)]
     pub fn log(s: &str);
+
+    #[wasm_bindgen(js_namespace = console)]
+    pub fn warn(s: &str);
+
+    #[wasm_bindgen(js_namespace = console)]
+    pub fn error(s: &str);
 }

--- a/worker-sys/src/lib.rs
+++ b/worker-sys/src/lib.rs
@@ -11,13 +11,33 @@ pub mod response;
 /// When debugging your Worker via `wrangler dev`, `wrangler tail`, or from the Workers Dashboard,
 /// anything passed to this macro will be printed to the terminal or written to the console.
 #[macro_export]
+macro_rules! console_debug {
+    ($($t:tt)*) => (unsafe { $crate::global::debug(&format_args!($($t)*).to_string()) })
+}
+
+/// When debugging your Worker via `wrangler dev`, `wrangler tail`, or from the Workers Dashboard,
+/// anything passed to this macro will be printed to the terminal or written to the console.
+#[macro_export]
 macro_rules! console_log {
     ($($t:tt)*) => (unsafe { $crate::global::log(&format_args!($($t)*).to_string()) })
 }
 
+/// When debugging your Worker via `wrangler dev`, `wrangler tail`, or from the Workers Dashboard,
+/// anything passed to this macro will be printed to the terminal or written to the console.
+#[macro_export]
+macro_rules! console_warn {
+    ($($t:tt)*) => (unsafe { $crate::global::warn(&format_args!($($t)*).to_string()) })
+}
+
+/// When debugging your Worker via `wrangler dev`, `wrangler tail`, or from the Workers Dashboard,
+/// anything passed to this macro will be printed to the terminal or written to the console.
+#[macro_export]
+macro_rules! console_error {
+    ($($t:tt)*) => (unsafe { $crate::global::error(&format_args!($($t)*).to_string()) })
+}
+
 pub mod prelude {
     pub use crate::cf::Cf;
-    pub use crate::console_log;
     pub use crate::durable_object;
     pub use crate::file::File;
     pub use crate::formdata::FormData;
@@ -26,6 +46,7 @@ pub mod prelude {
     pub use crate::request::Request;
     pub use crate::request_init::*;
     pub use crate::response::Response;
+    pub use crate::{console_debug, console_error, console_log, console_warn};
 }
 
 pub use cf::Cf;

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::router::{RouteContext, RouteParams, Router};
 pub use cf::Cf;
 pub use url::Url;
 
-pub use worker_sys::console_log;
+pub use worker_sys::{console_debug, console_error, console_log, console_warn};
 
 pub use crate::durable::*;
 pub use worker_macros::{durable_object, event};


### PR DESCRIPTION
Maybe it's better to wrap them in a `console` mod, e.g., `console::error!`