### PR TITLE
refactor: Make data field of RouteContext public

### DIFF
--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -85,7 +85,7 @@ pub async fn main(req: Request, env: Env) -> Result<Response> {
         .get_async("/async-request", handle_async_request)
         .get("/test-data", |_, ctx| {
             // just here to test data works
-            if ctx.data().regex.is_match("2014-01-01") {
+            if ctx.data.regex.is_match("2014-01-01") {
                 Response::ok("data ok")
             } else {
                 Response::error("bad match", 500)
@@ -256,7 +256,7 @@ pub async fn main(req: Request, env: Env) -> Result<Response> {
         })
         .get_async("/cloudflare-api", |_req, ctx| async move {
             let resp = ctx
-                .data()
+                .data
                 .cloudflare_api_client
                 .request_handle(&cloudflare::endpoints::user::GetUserDetails {})
                 .await
@@ -310,10 +310,7 @@ pub async fn main(req: Request, env: Env) -> Result<Response> {
             Response::from_bytes(serde_json::to_vec(&todo)?)
         })
         .post_async("/nonsense-repeat", |_, ctx| async move {
-            //  just here to test data works, and verify borrow
-            let _d = ctx.data();
-
-            if ctx.data().regex.is_match("2014-01-01") {
+            if ctx.data.regex.is_match("2014-01-01") {
                 Response::ok("data ok")
             } else {
                 Response::error("bad match", 500)

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -52,13 +52,14 @@ pub struct Router<'a, D> {
 /// Container for a route's parsed parameters, data, and environment bindings from the Runtime (such
 /// as KV Stores, Durable Objects, Variables, and Secrets).
 pub struct RouteContext<D> {
-    data: D,
+    pub data: D,
     env: Env,
     params: RouteParams,
 }
 
 impl<D> RouteContext<D> {
     /// Get a reference to the generic associated data provided to the `Router`.
+    #[deprecated(since = "0.0.8", note="please use the `data` field directly")]
     pub fn data(&self) -> &D {
         &self.data
     }


### PR DESCRIPTION
I specifically need this to call state.put in a durable object, I could also use a mutable getter, but there doesn't seem to be any reason why this field isn't public. It's just user supplied data after all, the framework doesn't have any expectations about how it can change. If for some reason a mutable getter (or something else) would be preferable, I'm happy to change this PR to do that instead.

I left the old getter in place for backwards compatibility, but with a deprecation warning, since using a getter when the field is directly available is unnecessary.