### PR TITLE
don't interpret raw bytes as text

### DIFF
--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -171,9 +171,10 @@ impl Response {
         match &self.body {
             ResponseBody::Body(bytes) => Ok(bytes.clone()),
             ResponseBody::Empty => Ok(Vec::new()),
-            ResponseBody::Stream(response) => JsFuture::from(response.text()?)
+            ResponseBody::Stream(response) => JsFuture::from(response.array_buffer()?)
                 .await
-                .map(|value| value.as_string().unwrap().into_bytes())
+                .map(|value| js_sys::Uint8Array::new(&value))
+                .map(|arr| arr.to_vec())
                 .map_err(Error::from),
         }
     }

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -173,8 +173,7 @@ impl Response {
             ResponseBody::Empty => Ok(Vec::new()),
             ResponseBody::Stream(response) => JsFuture::from(response.array_buffer()?)
                 .await
-                .map(|value| js_sys::Uint8Array::new(&value))
-                .map(|arr| arr.to_vec())
+                .map(|value| js_sys::Uint8Array::new(&value).to_vec())
                 .map_err(Error::from),
         }
     }


### PR DESCRIPTION
You can't actually obtain the "raw bytes" of a response body without this change.