### PR TITLE
chore: update worker-kv to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ pub async fn main(req: Request, env: Env) -> Result<Response> {
         .get_async("/account/:id", |_req, ctx| async move {
             if let Some(id) = ctx.param("id") {
                 let accounts = ctx.kv("ACCOUNTS")?;
-                return match accounts.get(id).await? {
-                    Some(account) => Response::from_json(&account.as_json::<Account>()?),
+                return match accounts.get(id).json::<Account>().await? {
+                    Some(account) => Response::from_json(&account),
                     None => Response::error("Not found", 404),
                 };
             }

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -180,8 +180,8 @@ pub async fn main(req: Request, env: Env) -> Result<Response> {
         .get_async("/formdata-file-size/:hash", |_, ctx| async move {
             if let Some(hash) = ctx.param("hash") {
                 let kv = ctx.kv("FILE_SIZES")?;
-                return match kv.get(&hash).await? {
-                    Some(val) => Response::from_json(&val.as_json::<FileSize>()?),
+                return match kv.get(&hash).json::<FileSize>().await? {
+                    Some(val) => Response::from_json(&val),
                     None => Response::error("Not Found", 404),
                 };
             }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -24,6 +24,6 @@ serde_json = "1.0.64"
 url = "2.2.2"
 wasm-bindgen = "0.2.78"
 wasm-bindgen-futures = "0.4.28"
-worker-kv = "0.4.0"
+worker-kv = "0.5.0"
 worker-macros = { path = "../worker-macros", version = "0.0.2" }
 worker-sys = { path = "../worker-sys", version = "0.0.2" }


### PR DESCRIPTION
Fixes #101. Version `0.5.0` contains breaking changes with the `get` operation on KV stores. These changes were made to fix inconsistencies with the JS api, but it unintentionally fixed this issue.