### PR TITLE
Add size & type for FormData

### DIFF
--- a/worker/src/formdata.rs
+++ b/worker/src/formdata.rs
@@ -132,6 +132,16 @@ impl File {
         self.0.name()
     }
 
+    /// Get the file size.
+    pub fn size(&self) -> f64 {
+        self.0.size()
+    }
+
+    /// Get the file type.
+    pub fn type_(&self) -> String {
+        self.0.type_()
+    }
+
     /// Read the file from an internal buffer and get the resulting bytes.
     pub async fn bytes(&self) -> Result<Vec<u8>> {
         JsFuture::from(self.0.array_buffer())


### PR DESCRIPTION
This will expose the size & type functions to match how you would use them natively in js/ts workers.