### PR TITLE
fix: responses occasionally corrupted

### DIFF
--- a/worker-sys/src/response.rs
+++ b/worker-sys/src/response.rs
@@ -1,5 +1,7 @@
 use crate::FormData;
 use crate::ResponseInit;
+
+use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -46,7 +48,7 @@ extern "C" {
 
     #[wasm_bindgen(catch, constructor, js_class=Response)]
     #[doc = "The `new Response(..)` constructor, creating a new instance of `Response`."]
-    pub fn new_with_opt_u8_array(body: Option<&mut [u8]>) -> Result<Response, JsValue>;
+    pub fn new_with_opt_u8_array(body: Option<Uint8Array>) -> Result<Response, JsValue>;
 
     #[wasm_bindgen(catch, constructor, js_class=Response)]
     #[doc = "The `new Response(..)` constructor, creating a new instance of `Response`."]
@@ -59,7 +61,7 @@ extern "C" {
     #[wasm_bindgen(catch, constructor, js_class=Response)]
     #[doc = "The `new Response(..)` constructor, creating a new instance of `Response`."]
     pub fn new_with_opt_u8_array_and_init(
-        body: Option<&mut [u8]>,
+        body: Option<Uint8Array>,
         init: &web_sys::ResponseInit,
     ) -> Result<Response, JsValue>;
 


### PR DESCRIPTION
Fixes issue where responses can have their bodies corrupted. This is caused by us giving JS the body's bytes as a reference to a byte slice, which is then dropped causing a use after free. Most of the time this is fine, but occasionally the allocator will allocate something that overlaps with the response body.

To fix this, we instead give the [Response constructor](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response) an owned `Uint8Array` that doesn't have any references into the wasm memory.

Probably fixes #64 or at least parts of it.