### PR TITLE
fix: headers are not applied to stream response

### DIFF
--- a/worker-sys/src/response.rs
+++ b/worker-sys/src/response.rs
@@ -77,6 +77,13 @@ extern "C" {
         init: &web_sys::ResponseInit,
     ) -> Result<Response, JsValue>;
 
+    #[wasm_bindgen(catch, constructor, js_class=Response)]
+    #[doc = "The `new Response(..)` constructor, creating a new instance of `Response`."]
+    pub fn new_with_opt_stream_and_init(
+        body: Option<web_sys::ReadableStream>,
+        init: &web_sys::ResponseInit,
+    ) -> Result<Response, JsValue>;
+
     #[wasm_bindgen(catch, method, structural, js_class=Response, js_name=clone)]
     #[doc = "The `clone()` method."]
     pub fn clone(this: &Response) -> Result<Response, JsValue>;

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -236,7 +236,15 @@ impl From<Response> for EdgeResponse {
                 .into(),
             )
             .unwrap(),
-            ResponseBody::Stream(response) => response,
+            ResponseBody::Stream(response) => EdgeResponse::new_with_opt_stream_and_init(
+                response.body(),
+                &ResponseInit {
+                    status: res.status_code,
+                    headers: res.headers,
+                }
+                .into(),
+            )
+            .unwrap(),
             ResponseBody::Empty => EdgeResponse::new_with_opt_str_and_init(
                 None,
                 &ResponseInit {


### PR DESCRIPTION
I was also thinking about cloning the headers in the other `From` implementation:

```rust
impl From<EdgeResponse> for Response {
    fn from(res: EdgeResponse) -> Self {
        Self {
            // CLONE HERE
            headers: Headers(res.headers() /* .clone() */),
            status_code: res.status(),
            body: match res.body() {
                Some(_) => ResponseBody::Stream(res),
                None => ResponseBody::Empty,
            },
        }
    }
}
```

A response coming from the `cache` will not have modifiable headers, but this might sometimes not be necessary, would help a lot with ergonomics though.

Edit: Forgot I opened an issue for that, this fixes #112