### PR TITLE
Direct field access for RouteContext#env

### DIFF
--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -53,7 +53,7 @@ pub struct Router<'a, D> {
 /// as KV Stores, Durable Objects, Variables, and Secrets).
 pub struct RouteContext<D> {
     pub data: D,
-    env: Env,
+    pub env: Env,
     params: RouteParams,
 }
 
@@ -66,6 +66,7 @@ impl<D> RouteContext<D> {
 
     /// Get the `Env` for this Worker. Typically users should opt for the `secret`, `var`, `kv` and
     /// `durable_object` methods on the `RouteContext` instead.
+    #[deprecated(since = "0.0.8", note="please use the `env` field directly")]
     pub fn get_env(self) -> Env {
         self.env
     }

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -66,7 +66,7 @@ impl<D> RouteContext<D> {
 
     /// Get the `Env` for this Worker. Typically users should opt for the `secret`, `var`, `kv` and
     /// `durable_object` methods on the `RouteContext` instead.
-    #[deprecated(since = "0.0.8", note="please use the `env` field directly")]
+    #[deprecated(since = "0.0.8", note = "please use the `env` field directly")]
     pub fn get_env(self) -> Env {
         self.env
     }


### PR DESCRIPTION
Hi,

since data just got updated to use direct field access instead, but env is facinig the same limitiations, I thought a PR to fix that would be a good idea.