### PR TITLE
Add linter github action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Linters
+
+on: [pull_request]
+
+jobs:
+  rustfmt:
+    name: Formatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Check Formatting
+        run: cargo fmt --all -- --check
+
+      - name: Check for idiomatic code
+        run: cargo clippy --all --all-features -- -D warnings

--- a/worker-macros/Cargo.toml
+++ b/worker-macros/Cargo.toml
@@ -17,6 +17,6 @@ worker-sys = { path = "../worker-sys", version = "0.0.2" }
 syn = "1.0.74"
 proc-macro2 = "1.0.28"
 quote = "1.0.9"
-wasm-bindgen = "0.2.78" 
+wasm-bindgen = "=0.2.78"
 wasm-bindgen-futures = "0.4.28"
 wasm-bindgen-macro-support = "0.2.78"

--- a/worker-sys/Cargo.toml
+++ b/worker-sys/Cargo.toml
@@ -10,8 +10,15 @@ description = "Low-level extern definitions / FFI bindings to the Cloudflare Wor
 [dependencies]
 cfg-if = "0.1.2"
 js-sys = "0.3.55"
-wasm-bindgen = "0.2.78"
+wasm-bindgen = "=0.2.78"
 
 [dependencies.web-sys]
 version = "0.3.55"
-features = ["ReadableStream", "RequestRedirect", "RequestInit", "ResponseInit", "FormData", "Blob"]
+features = [
+    "ReadableStream",
+    "RequestRedirect",
+    "RequestInit",
+    "ResponseInit",
+    "FormData",
+    "Blob",
+]

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -22,7 +22,7 @@ matchit = "0.4.2"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 url = "2.2.2"
-wasm-bindgen = "0.2.78"
+wasm-bindgen = "=0.2.78"
 wasm-bindgen-futures = "0.4.28"
 worker-kv = "0.5.0"
 worker-macros = { path = "../worker-macros", version = "0.0.2" }


### PR DESCRIPTION
Enforces valid formatting and lints in an effort to close #58. Requires #119 to be merged before this PR.

This also temporarily pins wasm-bindgen to `0.2.78` because of rustwasm/wasm-bindgen#2774.