### PR TITLE
Remove cloudflare api test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,13 +42,10 @@ jobs:
       - name: Run tests
         shell: bash
         working-directory: ./worker-sandbox
-        env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
         run: |
           set -e
 
           echo "
-          CF_API_TOKEN=\"$CF_API_TOKEN\"
           EXAMPLE_SECRET=\"example\"
           SOME_SECRET=\"secret!\"
           SOME_VARIABLE=\"some value\"

--- a/worker-sandbox/Cargo.toml
+++ b/worker-sandbox/Cargo.toml
@@ -14,8 +14,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 blake2 = "0.9.2"
-chrono = { version = "0.4", default-features = false, features = ["wasmbind"] }
-cloudflare = "0.8.7"
+chrono = { version = "0.4", default-features = false, features = ["wasmbind", "clock"] }
 cfg-if = "0.1.2"
 console_error_panic_hook = { version = "0.1.1", optional = true }
 getrandom = { version = "0.2", features = ["js"] }

--- a/worker-sandbox/tests/requests.rs
+++ b/worker-sandbox/tests/requests.rs
@@ -121,22 +121,6 @@ fn fetch_json() {
 }
 
 #[test]
-fn cloudflare_api() {
-    expect_wrangler();
-
-    let response = get("cloudflare-api", |r| r);
-    let email_header = response
-        .headers()
-        .get("user-details-email")
-        .cloned()
-        .expect("no user-details-email header specified");
-    let body = response.text().expect("body not valid utf8");
-
-    assert_eq!(body, "hello user");
-    assert!(email_header.to_str().is_ok());
-}
-
-#[test]
 fn proxy_request() {
     // Because the sandbox worker passes the response without touching it, we might get a response
     // with a body thats compressed. So we'll just use this which isn't compressed and is small.

--- a/worker-sandbox/tests/requests.rs
+++ b/worker-sandbox/tests/requests.rs
@@ -100,7 +100,7 @@ fn get_account_id_zones() {
 #[test]
 #[ignore = "does not work on miniflare https://github.com/cloudflare/miniflare/issues/59"]
 fn async_text_echo() {
-    const TEXT: &'static str = "Example text!";
+    const TEXT: &str = "Example text!";
     let body = get("async-text-echo", |req| req.body(TEXT)).text().unwrap();
     assert_eq!(body, TEXT);
 }
@@ -151,7 +151,7 @@ fn kv_key_value() {
         keys: Vec<serde_json::Value>,
     }
     let keys: Keys = post("kv/a/b", |r| r).json().unwrap();
-    assert!(keys.keys.len() > 0);
+    assert!(!keys.keys.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Removes the `/cloudflare-api` endpoint in worker-sandbox which was causing inconsistent behavior in the integration testing. Outbound HTTP requests are still made by the worker-sandbox, so we still test to ensure that works as intended.