### PR TITLE
Extend the Response with_cors!

### DIFF
--- a/worker/src/cors.rs
+++ b/worker/src/cors.rs
@@ -1,34 +1,5 @@
 use crate::{Error, Headers, Method, Result};
 
-/// Utility macro which applies cors to a response while properly handling the error results
-/// produced by the `with_cors` call.
-///
-/// This macro requires the calling method to have a `Result<T, From<worker::Error>>` return type!
-///
-/// Example code
-/// ```
-/// pub fn fetch() -> Result<worker::Response, worker::Error> {
-///     let cors = worker::Cors::default();
-///     let response = worker::Response::empty();
-///     return with_cors!(response, cors);
-/// }
-/// ```
-#[macro_export]
-macro_rules! with_cors {
-    ($response:expr, $cors:ident) => {
-        match $response {
-            Ok(response) => Ok(response.with_cors(&$cors)?),
-            err => err,
-        }
-    };
-    ($response:ident, $cors:ident) => {
-        match $response {
-            Ok(response) => Ok(response.with_cors(&$cors)?),
-            err => err,
-        }
-    };
-}
-
 /// Cors struct, holding cors configuration
 #[derive(Debug, Clone)]
 pub struct Cors {

--- a/worker/src/cors.rs
+++ b/worker/src/cors.rs
@@ -1,0 +1,111 @@
+use crate::{Error, Headers, Method, Result};
+
+/// Cors struct, holding cors configuration
+#[derive(Debug, Clone)]
+pub struct Cors {
+    credentials: bool,
+    max_age: Option<u32>,
+    origins: Vec<String>,
+    methods: Vec<Method>,
+    allowed_headers: Vec<String>,
+    exposed_headers: Vec<String>,
+}
+
+/// Creates a default cors configuration, which will do nothing.
+impl Default for Cors {
+    fn default() -> Self {
+        Self {
+            credentials: false,
+            max_age: None,
+            origins: vec![],
+            methods: vec![],
+            allowed_headers: vec![],
+            exposed_headers: vec![],
+        }
+    }
+}
+
+impl Cors {
+    /// `new` constructor for convenience; does the same as `Self::default()`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Configures whether cors is allowed to share credentials or not.
+    pub fn with_credentials(mut self, credentials: bool) -> Self {
+        self.credentials = credentials;
+        self
+    }
+
+    /// Configures how long cors is allowed to cache a preflight-response.
+    pub fn with_max_age(mut self, max_age: u32) -> Self {
+        self.max_age = Some(max_age);
+        self
+    }
+
+    /// Configures which origins are allowed for cors.
+    pub fn with_origins<S: Into<String>, V: IntoIterator<Item=S>>(mut self, origins: V) -> Self {
+        self.origins = origins.into_iter()
+            .map(|item| item.into())
+            .collect::<Vec<String>>();
+        self
+    }
+
+    /// Configures which methods are allowed for cors.
+    pub fn with_methods<V: IntoIterator<Item=Method>>(mut self, methods: V) -> Self {
+        self.methods = methods.into_iter().collect();
+        self
+    }
+
+    /// Configures which headers are allowed for cors.
+    pub fn with_allowed_headers<S: Into<String>, V: IntoIterator<Item=S>>(mut self, origins: V) -> Self {
+        self.origins = origins.into_iter()
+            .map(|item| item.into())
+            .collect::<Vec<String>>();
+        self
+    }
+
+    /// Configures which headers the client is allowed to access.
+    pub fn with_exposed_headers<S: Into<String>, V: IntoIterator<Item=S>>(mut self, origins: V) -> Self {
+        self.origins = origins.into_iter()
+            .map(|item| item.into())
+            .collect::<Vec<String>>();
+        self
+    }
+
+    /// Applies the cors configuration to response headers.
+    pub fn apply_headers(&self, headers: &mut Headers) -> Result<()> {
+        if self.credentials {
+            headers.set("Access-Control-Allow-Credentials", "true")?;
+        }
+        if let Some(ref max_age) = self.max_age {
+            headers.set("Access-Control-Max-Age", format!("{}", max_age).as_str())?;
+        }
+        if self.origins.len() > 0 {
+            headers.set("Access-Control-Allow-Origin", concat_vec_to_string(&self.origins)?.as_str())?;
+        }
+        if self.methods.len() > 0 {
+            headers.set("Access-Control-Allow-Methods", concat_vec_to_string(&self.methods)?.as_str())?;
+        }
+        if self.allowed_headers.len() > 0 {
+            headers.set("Access-Control-Allow-Headers", concat_vec_to_string(&self.allowed_headers)?.as_str())?;
+        }
+        if self.exposed_headers.len() > 0 {
+            headers.set("Access-Control-Expose-headers", concat_vec_to_string(&self.exposed_headers)?.as_str())?;
+        }
+        Ok(())
+    }
+}
+
+fn concat_vec_to_string<S: AsRef<str>>(vec: &Vec<S>) -> Result<String> {
+    let str = vec.iter().fold("".to_owned(), |mut init, item| {
+        init.push_str(",");
+        init.push_str(item.as_ref());
+        init
+    });
+    if str.len() > 0 {
+        Ok(str[1..].to_string())
+    } else {
+        Err(Error::RustError("Tried to concat header values without values.".to_string()))
+    }
+}

--- a/worker/src/cors.rs
+++ b/worker/src/cors.rs
@@ -1,5 +1,34 @@
 use crate::{Error, Headers, Method, Result};
 
+/// Utility macro which applies cors to a response while properly handling the error results
+/// produced by the `with_cors` call.
+///
+/// This macro requires the calling method to have a `Result<T, From<worker::Error>>` return type!
+///
+/// Example code
+/// ```
+/// pub fn fetch() -> Result<worker::Response, worker::Error> {
+///     let cors = worker::Cors::default();
+///     let response = worker::Response::empty();
+///     return with_cors!(response, cors);
+/// }
+/// ```
+#[macro_export]
+macro_rules! with_cors {
+    ($response:expr, $cors:ident) => {
+        match $response {
+            Ok(response) => Ok(response.with_cors(&$cors)?),
+            err => err,
+        }
+    };
+    ($response:ident, $cors:ident) => {
+        match $response {
+            Ok(response) => Ok(response.with_cors(&$cors)?),
+            err => err,
+        }
+    };
+}
+
 /// Cors struct, holding cors configuration
 #[derive(Debug, Clone)]
 pub struct Cors {

--- a/worker/src/cors.rs
+++ b/worker/src/cors.rs
@@ -119,25 +119,25 @@ impl Cors {
         if let Some(ref max_age) = self.max_age {
             headers.set("Access-Control-Max-Age", format!("{}", max_age).as_str())?;
         }
-        if self.origins.len() > 0 {
+        if !self.origins.is_empty() {
             headers.set(
                 "Access-Control-Allow-Origin",
                 concat_vec_to_string(&self.origins)?.as_str(),
             )?;
         }
-        if self.methods.len() > 0 {
+        if !self.methods.is_empty() {
             headers.set(
                 "Access-Control-Allow-Methods",
                 concat_vec_to_string(&self.methods)?.as_str(),
             )?;
         }
-        if self.allowed_headers.len() > 0 {
+        if !self.allowed_headers.is_empty() {
             headers.set(
                 "Access-Control-Allow-Headers",
                 concat_vec_to_string(&self.allowed_headers)?.as_str(),
             )?;
         }
-        if self.exposed_headers.len() > 0 {
+        if !self.exposed_headers.is_empty() {
             headers.set(
                 "Access-Control-Expose-headers",
                 concat_vec_to_string(&self.exposed_headers)?.as_str(),
@@ -149,7 +149,7 @@ impl Cors {
 
 fn concat_vec_to_string<S: AsRef<str>>(vec: &Vec<S>) -> Result<String> {
     let str = vec.iter().fold("".to_owned(), |mut init, item| {
-        init.push_str(",");
+        init.push(',');
         init.push_str(item.as_ref());
         init
     });

--- a/worker/src/cors.rs
+++ b/worker/src/cors.rs
@@ -122,38 +122,38 @@ impl Cors {
         if !self.origins.is_empty() {
             headers.set(
                 "Access-Control-Allow-Origin",
-                concat_vec_to_string(&self.origins)?.as_str(),
+                concat_vec_to_string(self.origins.as_slice())?.as_str(),
             )?;
         }
         if !self.methods.is_empty() {
             headers.set(
                 "Access-Control-Allow-Methods",
-                concat_vec_to_string(&self.methods)?.as_str(),
+                concat_vec_to_string(self.methods.as_slice())?.as_str(),
             )?;
         }
         if !self.allowed_headers.is_empty() {
             headers.set(
                 "Access-Control-Allow-Headers",
-                concat_vec_to_string(&self.allowed_headers)?.as_str(),
+                concat_vec_to_string(self.allowed_headers.as_slice())?.as_str(),
             )?;
         }
         if !self.exposed_headers.is_empty() {
             headers.set(
                 "Access-Control-Expose-headers",
-                concat_vec_to_string(&self.exposed_headers)?.as_str(),
+                concat_vec_to_string(self.exposed_headers.as_slice())?.as_str(),
             )?;
         }
         Ok(())
     }
 }
 
-fn concat_vec_to_string<S: AsRef<str>>(vec: &Vec<S>) -> Result<String> {
+fn concat_vec_to_string<S: AsRef<str>>(vec: &[S]) -> Result<String> {
     let str = vec.iter().fold("".to_owned(), |mut init, item| {
         init.push(',');
         init.push_str(item.as_ref());
         init
     });
-    if str.len() > 0 {
+    if !str.is_empty() {
         Ok(str[1..].to_string())
     } else {
         Err(Error::RustError(

--- a/worker/src/cors.rs
+++ b/worker/src/cors.rs
@@ -73,30 +73,39 @@ impl Cors {
     }
 
     /// Configures which origins are allowed for cors.
-    pub fn with_origins<S: Into<String>, V: IntoIterator<Item=S>>(mut self, origins: V) -> Self {
-        self.origins = origins.into_iter()
+    pub fn with_origins<S: Into<String>, V: IntoIterator<Item = S>>(mut self, origins: V) -> Self {
+        self.origins = origins
+            .into_iter()
             .map(|item| item.into())
             .collect::<Vec<String>>();
         self
     }
 
     /// Configures which methods are allowed for cors.
-    pub fn with_methods<V: IntoIterator<Item=Method>>(mut self, methods: V) -> Self {
+    pub fn with_methods<V: IntoIterator<Item = Method>>(mut self, methods: V) -> Self {
         self.methods = methods.into_iter().collect();
         self
     }
 
     /// Configures which headers are allowed for cors.
-    pub fn with_allowed_headers<S: Into<String>, V: IntoIterator<Item=S>>(mut self, origins: V) -> Self {
-        self.allowed_headers = origins.into_iter()
+    pub fn with_allowed_headers<S: Into<String>, V: IntoIterator<Item = S>>(
+        mut self,
+        origins: V,
+    ) -> Self {
+        self.allowed_headers = origins
+            .into_iter()
             .map(|item| item.into())
             .collect::<Vec<String>>();
         self
     }
 
     /// Configures which headers the client is allowed to access.
-    pub fn with_exposed_headers<S: Into<String>, V: IntoIterator<Item=S>>(mut self, origins: V) -> Self {
-        self.exposed_headers = origins.into_iter()
+    pub fn with_exposed_headers<S: Into<String>, V: IntoIterator<Item = S>>(
+        mut self,
+        origins: V,
+    ) -> Self {
+        self.exposed_headers = origins
+            .into_iter()
             .map(|item| item.into())
             .collect::<Vec<String>>();
         self
@@ -111,16 +120,28 @@ impl Cors {
             headers.set("Access-Control-Max-Age", format!("{}", max_age).as_str())?;
         }
         if self.origins.len() > 0 {
-            headers.set("Access-Control-Allow-Origin", concat_vec_to_string(&self.origins)?.as_str())?;
+            headers.set(
+                "Access-Control-Allow-Origin",
+                concat_vec_to_string(&self.origins)?.as_str(),
+            )?;
         }
         if self.methods.len() > 0 {
-            headers.set("Access-Control-Allow-Methods", concat_vec_to_string(&self.methods)?.as_str())?;
+            headers.set(
+                "Access-Control-Allow-Methods",
+                concat_vec_to_string(&self.methods)?.as_str(),
+            )?;
         }
         if self.allowed_headers.len() > 0 {
-            headers.set("Access-Control-Allow-Headers", concat_vec_to_string(&self.allowed_headers)?.as_str())?;
+            headers.set(
+                "Access-Control-Allow-Headers",
+                concat_vec_to_string(&self.allowed_headers)?.as_str(),
+            )?;
         }
         if self.exposed_headers.len() > 0 {
-            headers.set("Access-Control-Expose-headers", concat_vec_to_string(&self.exposed_headers)?.as_str())?;
+            headers.set(
+                "Access-Control-Expose-headers",
+                concat_vec_to_string(&self.exposed_headers)?.as_str(),
+            )?;
         }
         Ok(())
     }
@@ -135,6 +156,8 @@ fn concat_vec_to_string<S: AsRef<str>>(vec: &Vec<S>) -> Result<String> {
     if str.len() > 0 {
         Ok(str[1..].to_string())
     } else {
-        Err(Error::RustError("Tried to concat header values without values.".to_string()))
+        Err(Error::RustError(
+            "Tried to concat header values without values.".to_string(),
+        ))
     }
 }

--- a/worker/src/cors.rs
+++ b/worker/src/cors.rs
@@ -59,7 +59,7 @@ impl Cors {
 
     /// Configures which headers are allowed for cors.
     pub fn with_allowed_headers<S: Into<String>, V: IntoIterator<Item=S>>(mut self, origins: V) -> Self {
-        self.origins = origins.into_iter()
+        self.allowed_headers = origins.into_iter()
             .map(|item| item.into())
             .collect::<Vec<String>>();
         self
@@ -67,7 +67,7 @@ impl Cors {
 
     /// Configures which headers the client is allowed to access.
     pub fn with_exposed_headers<S: Into<String>, V: IntoIterator<Item=S>>(mut self, origins: V) -> Self {
-        self.origins = origins.into_iter()
+        self.exposed_headers = origins.into_iter()
             .map(|item| item.into())
             .collect::<Vec<String>>();
         self

--- a/worker/src/http.rs
+++ b/worker/src/http.rs
@@ -47,7 +47,13 @@ impl From<String> for Method {
 
 impl From<Method> for String {
     fn from(val: Method) -> Self {
-        match val {
+        val.as_ref().to_string()
+    }
+}
+
+impl AsRef<str> for Method {
+    fn as_ref(&self) -> &'static str {
+        match self {
             Method::Head => "HEAD",
             Method::Post => "POST",
             Method::Put => "PUT",
@@ -58,7 +64,6 @@ impl From<Method> for String {
             Method::Trace => "TRACE",
             Method::Get => "GET",
         }
-        .to_string()
     }
 }
 

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod cf;
 mod context;
+mod cors;
 mod date;
 pub mod durable;
 mod env;
@@ -16,7 +17,6 @@ mod request_init;
 mod response;
 mod router;
 mod schedule;
-mod cors;
 
 #[doc(hidden)]
 use std::result::Result as StdResult;
@@ -24,6 +24,7 @@ use std::result::Result as StdResult;
 pub type Result<T> = StdResult<T, error::Error>;
 
 pub use crate::context::Context;
+pub use crate::cors::Cors;
 pub use crate::date::{Date, DateInit};
 pub use crate::env::Env;
 pub use crate::error::Error;
@@ -36,7 +37,6 @@ pub use crate::request_init::*;
 pub use crate::response::{Response, ResponseBody};
 pub use crate::router::{RouteContext, RouteParams, Router};
 pub use crate::schedule::*;
-pub use crate::cors::Cors;
 pub use cf::Cf;
 pub use url::Url;
 

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -36,6 +36,7 @@ pub use crate::request_init::*;
 pub use crate::response::{Response, ResponseBody};
 pub use crate::router::{RouteContext, RouteParams, Router};
 pub use crate::schedule::*;
+pub use crate::cors::Cors;
 pub use cf::Cf;
 pub use url::Url;
 

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -16,6 +16,7 @@ mod request_init;
 mod response;
 mod router;
 mod schedule;
+mod cors;
 
 #[doc(hidden)]
 use std::result::Result as StdResult;

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -1,3 +1,4 @@
+use crate::cors::Cors;
 use crate::error::Error;
 use crate::headers::Headers;
 use crate::Result;
@@ -6,7 +7,6 @@ use js_sys::Uint8Array;
 use serde::{de::DeserializeOwned, Serialize};
 use wasm_bindgen_futures::JsFuture;
 use worker_sys::{Response as EdgeResponse, ResponseInit as EdgeResponseInit};
-use crate::cors::Cors;
 
 #[derive(Debug)]
 pub enum ResponseBody {

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -262,9 +262,9 @@ impl From<Response> for EdgeResponse {
                     status: res.status_code,
                     headers: res.headers,
                 }
-                    .into(),
+                .into(),
             )
-                .unwrap(),
+            .unwrap(),
             ResponseBody::Empty => EdgeResponse::new_with_opt_str_and_init(
                 None,
                 &ResponseInit {

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -6,6 +6,7 @@ use js_sys::Uint8Array;
 use serde::{de::DeserializeOwned, Serialize};
 use wasm_bindgen_futures::JsFuture;
 use worker_sys::{Response as EdgeResponse, ResponseInit as EdgeResponseInit};
+use crate::cors::Cors;
 
 #[derive(Debug)]
 pub enum ResponseBody {
@@ -193,6 +194,19 @@ impl Response {
         self
     }
 
+    /// Sets this response's cors headers from the `Cors` struct.
+    pub fn with_cors(mut self, cors: &Cors) -> Result<Self> {
+        cors.apply_headers(self.headers_mut())?;
+        Ok(self)
+    }
+
+    /// Sets this response's cors headers from the `Cors` struct without checking for the
+    /// `apply_headers` `Result`.
+    pub fn with_cors_unsafe(mut self, cors: &Cors) -> Self {
+        cors.apply_headers(self.headers_mut()).ok();
+        self
+    }
+
     /// Read the `Headers` on this response.
     pub fn headers(&self) -> &Headers {
         &self.headers
@@ -238,9 +252,9 @@ impl From<Response> for EdgeResponse {
                         status: res.status_code,
                         headers: res.headers,
                     }
-                    .into(),
+                        .into(),
                 )
-                .unwrap()
+                    .unwrap()
             }
             ResponseBody::Stream(response) => EdgeResponse::new_with_opt_stream_and_init(
                 response.body(),
@@ -248,18 +262,18 @@ impl From<Response> for EdgeResponse {
                     status: res.status_code,
                     headers: res.headers,
                 }
-                .into(),
+                    .into(),
             )
-            .unwrap(),
+                .unwrap(),
             ResponseBody::Empty => EdgeResponse::new_with_opt_str_and_init(
                 None,
                 &ResponseInit {
                     status: res.status_code,
                     headers: res.headers,
                 }
-                .into(),
+                    .into(),
             )
-            .unwrap(),
+                .unwrap(),
         }
     }
 }

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -252,9 +252,9 @@ impl From<Response> for EdgeResponse {
                         status: res.status_code,
                         headers: res.headers,
                     }
-                        .into(),
+                    .into(),
                 )
-                    .unwrap()
+                .unwrap()
             }
             ResponseBody::Stream(response) => EdgeResponse::new_with_opt_stream_and_init(
                 response.body(),
@@ -271,9 +271,9 @@ impl From<Response> for EdgeResponse {
                     status: res.status_code,
                     headers: res.headers,
                 }
-                    .into(),
+                .into(),
             )
-                .unwrap(),
+            .unwrap(),
         }
     }
 }

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -195,16 +195,18 @@ impl Response {
     }
 
     /// Sets this response's cors headers from the `Cors` struct.
+    /// Example usage:
+    /// ```
+    /// use worker::*;
+    /// fn fetch() -> worker::Result<Response> {
+    ///     let cors = Cors::default();
+    ///     Response::empty()?
+    ///         .with_cors(&cors)
+    /// }
+    /// ```
     pub fn with_cors(mut self, cors: &Cors) -> Result<Self> {
         cors.apply_headers(self.headers_mut())?;
         Ok(self)
-    }
-
-    /// Sets this response's cors headers from the `Cors` struct without checking for the
-    /// `apply_headers` `Result`.
-    pub fn with_cors_unsafe(mut self, cors: &Cors) -> Self {
-        cors.apply_headers(self.headers_mut()).ok();
-        self
     }
 
     /// Read the `Headers` on this response.


### PR DESCRIPTION
This PR is a pure QoL PR, which aims to make it easier to configure a CORS policy and apply it to responses using `with_cors` or `with_cors_unsafe` (for convenience).