### PR TITLE
Fix respond_with_error attribute

### DIFF
--- a/worker-macros/src/event.rs
+++ b/worker-macros/src/event.rs
@@ -46,7 +46,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             let error_handling = match respond_with_errors {
                 true => {
                     quote! {
-                        Response::error(e.to_string(), 500).unwrap().into()
+                        worker::Response::error(e.to_string(), 500).unwrap().into()
                     }
                 }
                 false => {


### PR DESCRIPTION
The macro has not been using an import or qualified path for the Response in the macro, thus it failed to compile.
This should fix it. (It fixed it for me at least.)