### PR TITLE
Fix unresolved type Response in macro generated code

### DIFF
--- a/worker-macros/src/event.rs
+++ b/worker-macros/src/event.rs
@@ -46,7 +46,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             let error_handling = match respond_with_errors {
                 true => {
                     quote! {
-                        Response::error(e.to_string(), 500).unwrap().into()
+                        ::worker::Response::error(e.to_string(), 500).unwrap().into()
                     }
                 }
                 false => {


### PR DESCRIPTION
Follow-up of #106 

```
error[E0433]: failed to resolve: use of undeclared type `Response`
  --> cf-worker/src/lib.rs:45:1
   |
45 | #[event(fetch, respond_with_errors)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
   |
   = note: consider importing one of these items:
           crate::Response
           twitter_api::transport::Response
           web_sys::Response
           worker::Response
   = note: this error originates in the attribute macro `event` (in Nightly builds, run with -Z macro-backtrace for more info)
```