### PR TITLE
Cleanup clippy lints

### DIFF
--- a/worker-sandbox/tests/util.rs
+++ b/worker-sandbox/tests/util.rs
@@ -15,12 +15,11 @@ pub fn expect_wrangler() {
     let addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8787).into();
 
     // Try to connect to wrangler's dev server, if it can't be reached assume the user isn't running it.
-    if let Err(_) = TcpStream::connect_timeout(&addr, WAIT_FOR_WRANGLER) {
+    if TcpStream::connect_timeout(&addr, WAIT_FOR_WRANGLER).is_err() {
         panic!("Unable to verify wrangler is running");
     }
 }
 
-#[allow(unused)]
 pub fn get(endpoint: &str, builder_fn: impl FnOnce(RequestBuilder) -> RequestBuilder) -> Response {
     expect_wrangler();
 
@@ -31,10 +30,9 @@ pub fn get(endpoint: &str, builder_fn: impl FnOnce(RequestBuilder) -> RequestBui
         .send()
         .expect("could not make request to wrangler")
         .error_for_status()
-        .expect(&format!("received invalid status code for {endpoint}"))
+        .unwrap_or_else(|_| panic!("received invalid status code for {}", endpoint))
 }
 
-#[allow(unused)]
 pub fn post(endpoint: &str, builder_fn: impl FnOnce(RequestBuilder) -> RequestBuilder) -> Response {
     expect_wrangler();
 
@@ -45,10 +43,9 @@ pub fn post(endpoint: &str, builder_fn: impl FnOnce(RequestBuilder) -> RequestBu
         .send()
         .expect("could not make request to wrangler")
         .error_for_status()
-        .expect(&format!("received invalid status code for {endpoint}"))
+        .unwrap_or_else(|_| panic!("received invalid status code for {}", endpoint))
 }
 
-#[allow(unused)]
 pub fn put(endpoint: &str, builder_fn: impl FnOnce(RequestBuilder) -> RequestBuilder) -> Response {
     expect_wrangler();
 
@@ -59,10 +56,9 @@ pub fn put(endpoint: &str, builder_fn: impl FnOnce(RequestBuilder) -> RequestBui
         .send()
         .expect("could not make request to wrangler")
         .error_for_status()
-        .expect(&format!("received invalid status code for {endpoint}"))
+        .unwrap_or_else(|_| panic!("received invalid status code for {}", endpoint))
 }
 
-#[allow(unused)]
 pub fn options(
     endpoint: &str,
     builder_fn: impl FnOnce(RequestBuilder) -> RequestBuilder,
@@ -78,5 +74,5 @@ pub fn options(
         .send()
         .expect("could not make request to wrangler")
         .error_for_status()
-        .expect(&format!("received invalid status code for {endpoint}"))
+        .unwrap_or_else(|_| panic!("received invalid status code for {}", endpoint))
 }

--- a/worker-sys/src/file.rs
+++ b/worker-sys/src/file.rs
@@ -44,9 +44,7 @@ extern "C" {
 impl FilePropertyBag {
     #[doc = "Construct a new `FilePropertyBag`."]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
-        let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret
+        ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new())
     }
 
     #[doc = "Change the `lastModified` field of this object."]

--- a/worker-sys/src/file.rs
+++ b/worker-sys/src/file.rs
@@ -51,14 +51,11 @@ impl FilePropertyBag {
 
     #[doc = "Change the `lastModified` field of this object."]
     pub fn last_modified(&mut self, val: f64) -> &mut Self {
-        #[allow(unused_unsafe)]
-        let r = unsafe {
-            ::js_sys::Reflect::set(
-                self.as_ref(),
-                &JsValue::from("lastModified"),
-                &JsValue::from(val),
-            )
-        };
+        let r = ::js_sys::Reflect::set(
+            self.as_ref(),
+            &JsValue::from("lastModified"),
+            &JsValue::from(val),
+        );
         debug_assert!(
             r.is_ok(),
             "setting properties should never fail on our dictionary objects"
@@ -69,10 +66,7 @@ impl FilePropertyBag {
 
     #[doc = "Change the `type` field of this object."]
     pub fn type_(&mut self, val: &str) -> &mut Self {
-        #[allow(unused_unsafe)]
-        let r = unsafe {
-            ::js_sys::Reflect::set(self.as_ref(), &JsValue::from("type"), &JsValue::from(val))
-        };
+        let r = ::js_sys::Reflect::set(self.as_ref(), &JsValue::from("type"), &JsValue::from(val));
         debug_assert!(
             r.is_ok(),
             "setting properties should never fail on our dictionary objects"

--- a/worker-sys/src/request_init.rs
+++ b/worker-sys/src/request_init.rs
@@ -16,10 +16,7 @@ impl RequestInit {
     }
     #[doc = "Change the `body` field of this object."]
     pub fn body(&mut self, val: Option<&::wasm_bindgen::JsValue>) -> &mut Self {
-        #[allow(unused_unsafe)]
-        let r = unsafe {
-            ::js_sys::Reflect::set(self.as_ref(), &JsValue::from("body"), &JsValue::from(val))
-        };
+        let r = ::js_sys::Reflect::set(self.as_ref(), &JsValue::from("body"), &JsValue::from(val));
         debug_assert!(
             r.is_ok(),
             "setting properties should never fail on our dictionary objects"
@@ -30,14 +27,11 @@ impl RequestInit {
 
     #[doc = "Change the `headers` field of this object."]
     pub fn headers(&mut self, val: &::wasm_bindgen::JsValue) -> &mut Self {
-        #[allow(unused_unsafe)]
-        let r = unsafe {
-            ::js_sys::Reflect::set(
-                self.as_ref(),
-                &JsValue::from("headers"),
-                &JsValue::from(val),
-            )
-        };
+        let r = ::js_sys::Reflect::set(
+            self.as_ref(),
+            &JsValue::from("headers"),
+            &JsValue::from(val),
+        );
         debug_assert!(
             r.is_ok(),
             "setting properties should never fail on our dictionary objects"
@@ -48,10 +42,8 @@ impl RequestInit {
 
     #[doc = "Change the `method` field of this object."]
     pub fn method(&mut self, val: &str) -> &mut Self {
-        #[allow(unused_unsafe)]
-        let r = unsafe {
-            ::js_sys::Reflect::set(self.as_ref(), &JsValue::from("method"), &JsValue::from(val))
-        };
+        let r =
+            ::js_sys::Reflect::set(self.as_ref(), &JsValue::from("method"), &JsValue::from(val));
         debug_assert!(
             r.is_ok(),
             "setting properties should never fail on our dictionary objects"
@@ -62,14 +54,11 @@ impl RequestInit {
 
     #[doc = "Change the `redirect` field of this object."]
     pub fn redirect(&mut self, val: RequestRedirect) -> &mut Self {
-        #[allow(unused_unsafe)]
-        let r = unsafe {
-            ::js_sys::Reflect::set(
-                self.as_ref(),
-                &JsValue::from("redirect"),
-                &JsValue::from(val),
-            )
-        };
+        let r = ::js_sys::Reflect::set(
+            self.as_ref(),
+            &JsValue::from("redirect"),
+            &JsValue::from(val),
+        );
         debug_assert!(
             r.is_ok(),
             "setting properties should never fail on our dictionary objects"

--- a/worker-sys/src/request_init.rs
+++ b/worker-sys/src/request_init.rs
@@ -10,9 +10,7 @@ extern "C" {
 impl RequestInit {
     #[doc = "Construct a new `RequestInit`."]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
-        let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret
+        ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new())
     }
     #[doc = "Change the `body` field of this object."]
     pub fn body(&mut self, val: Option<&::wasm_bindgen::JsValue>) -> &mut Self {

--- a/worker-sys/src/response_init.rs
+++ b/worker-sys/src/response_init.rs
@@ -11,9 +11,7 @@ extern "C" {
 impl ResponseInit {
     #[doc = "Construct a new `ResponseInit`."]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
-        let mut ret: Self = wasm_bindgen::JsCast::unchecked_into(js_sys::Object::new());
-        ret
+        ::wasm_bindgen::JsCast::unchecked_into(js_sys::Object::new())
     }
 
     #[doc = "Change the `headers` field of this object."]

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -118,10 +118,7 @@ impl ObjectNamespace {
     /// <https://developers.cloudflare.com/workers/runtime-apis/durable-objects#restricting-objects-to-a-jurisdiction>
     pub fn unique_id_with_jurisdiction(&self, jd: &str) -> Result<ObjectId> {
         let options = Object::new();
-        #[allow(unused_unsafe)]
-        unsafe {
-            js_sys::Reflect::set(&options, &JsValue::from("jurisdiction"), &jd.into())?
-        };
+        js_sys::Reflect::set(&options, &JsValue::from("jurisdiction"), &jd.into())?;
         self.inner
             .new_unique_id_with_options_internal(&options)
             .map_err(Error::from)

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -437,7 +437,7 @@ impl Transaction {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Default, Serialize)]
 pub struct ListOptions<'a> {
     /// Key at which the list results should start, inclusive.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -459,15 +459,8 @@ pub struct ListOptions<'a> {
 
 impl<'a> ListOptions<'a> {
     /// Create a new ListOptions struct with no options set.
-    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        Self {
-            start: None,
-            end: None,
-            prefix: None,
-            reverse: None,
-            limit: None,
-        }
+        Default::default()
     }
 
     /// Key at which the list results should start, inclusive.

--- a/worker/src/env.rs
+++ b/worker/src/env.rs
@@ -14,9 +14,7 @@ extern "C" {
 
 impl Env {
     fn get_binding<T: EnvBinding>(&self, name: &str) -> Result<T> {
-        // Weird rust-analyzer bug is causing it to think Reflect::get is unsafe
-        #[allow(unused_unsafe)]
-        let binding = unsafe { js_sys::Reflect::get(self, &JsValue::from(name)) }
+        let binding = js_sys::Reflect::get(self, &JsValue::from(name))
             .map_err(|_| Error::JsError(format!("Env does not contain binding `{}`", name)))?;
         if binding.is_undefined() {
             Err(format!("Binding `{}` is undefined.", name).into())

--- a/worker/src/headers.rs
+++ b/worker/src/headers.rs
@@ -25,12 +25,10 @@ impl std::fmt::Debug for Headers {
     }
 }
 
-#[allow(clippy::new_without_default)]
 impl Headers {
     /// Construct a new `Headers` struct.
     pub fn new() -> Self {
-        // This cannot throw an error: https://developer.mozilla.org/en-US/docs/Web/API/Headers/Headers
-        Headers(EdgeHeaders::new().unwrap())
+        Default::default()
     }
 
     /// Returns all the values of a header within a `Headers` object with a given name.
@@ -98,6 +96,13 @@ impl Headers {
             .into_iter()
             // The values iterator.next() will always return a proper value containing a string
             .map(|a| a.unwrap().as_string().unwrap())
+    }
+}
+
+impl Default for Headers {
+    fn default() -> Self {
+        // This cannot throw an error: https://developer.mozilla.org/en-US/docs/Web/API/Headers/Headers
+        Headers(EdgeHeaders::new().unwrap())
     }
 }
 

--- a/worker/src/request_init.rs
+++ b/worker/src/request_init.rs
@@ -63,14 +63,11 @@ impl From<&RequestInit> for worker_sys::RequestInit {
         inner.body(req.body.as_ref());
 
         // set the Cloudflare-specific `cf` property on FFI RequestInit
-        #[allow(unused_unsafe)]
-        let r = unsafe {
-            ::js_sys::Reflect::set(
-                inner.as_ref(),
-                &JsValue::from("cf"),
-                &JsValue::from(&req.cf),
-            )
-        };
+        let r = ::js_sys::Reflect::set(
+            inner.as_ref(),
+            &JsValue::from("cf"),
+            &JsValue::from(&req.cf),
+        );
         debug_assert!(
             r.is_ok(),
             "setting properties should never fail on our dictionary objects"
@@ -240,8 +237,7 @@ impl From<&CfProperties> for JsValue {
 }
 
 fn set_prop(target: &Object, key: &JsValue, val: &JsValue) {
-    #[allow(unused_unsafe)]
-    let r = unsafe { ::js_sys::Reflect::set(target, key, val) };
+    let r = ::js_sys::Reflect::set(target, key, val);
     debug_assert!(
         r.is_ok(),
         "setting properties should never fail on our dictionary objects"


### PR DESCRIPTION
Cleans up some lints in the integration tests and removes any unnecessary `#[allow]`s that are no longer required. Makes no changes to the API except adding two `Default` implementations on `ListOptions` and `Headers`.