### PR TITLE
refactor websockets to be more idiomatic

### DIFF
--- a/worker-sandbox/Cargo.toml
+++ b/worker-sandbox/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 wee_alloc = { version = "0.4.2", optional = true }
 worker = { path = "../worker", version = "0.0.8" }
+futures = "0.3.19"
 
 [dev-dependencies]
 reqwest = { version = "0.11.9", features = ["blocking", "json", "multipart"] }

--- a/worker-sandbox/Cargo.toml
+++ b/worker-sandbox/Cargo.toml
@@ -32,4 +32,5 @@ futures = "0.3.19"
 
 [dev-dependencies]
 reqwest = { version = "0.11.9", features = ["blocking", "json", "multipart"] }
+tungstenite = "0.16.0"
 wasm-bindgen-test = "0.2"

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -1,7 +1,7 @@
 use blake2::{Blake2b, Digest};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use worker::{ws_events::WebsocketEvent, *};
+use worker::*;
 
 mod counter;
 mod test;

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -85,7 +85,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
                 while let Some(event) = event_stream.next().await {
                     match event.expect("received error in websocket") {
                         WebsocketEvent::Message(msg) => {
-                            if let Some(text) = msg.get_text() {
+                            if let Some(text) = msg.text() {
                                 server.send_with_str(text).expect("could not relay text");
                             }
                         }

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -110,7 +110,11 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         })
         .get_async("/got-close-event", |_, ctx| async move {
             let some_namespace_kv = ctx.kv("SOME_NAMESPACE")?;
-            let got_close_event = some_namespace_kv.get("got-close-event").text().await?.unwrap_or_else(|| "false".into());
+            let got_close_event = some_namespace_kv
+                .get("got-close-event")
+                .text()
+                .await?
+                .unwrap_or_else(|| "false".into());
 
             // Let the integration tests have some way of knowing if we successfully received the closed event.
             Response::ok(got_close_event)

--- a/worker-sandbox/tests/websocket.rs
+++ b/worker-sandbox/tests/websocket.rs
@@ -19,5 +19,17 @@ fn websocket() {
         .and_then(|msg| msg.into_text())
         .unwrap();
 
-    assert_eq!(&msg, "Hello, world!")
+    assert_eq!(&msg, "Hello, world!");
+
+    // Drop the socket, causing the connection to get closed.
+    drop(socket);
+
+    println!("Dropped socket");
+
+    let got_close_event: bool = util::get("got-close-event", |r| r)
+        .text()
+        .expect("could not deserialize as text")
+        .parse()
+        .expect("body was not boolean");
+    assert!(got_close_event)
 }

--- a/worker-sandbox/tests/websocket.rs
+++ b/worker-sandbox/tests/websocket.rs
@@ -1,0 +1,23 @@
+use reqwest::Url;
+use tungstenite::{connect, Message};
+
+mod util;
+
+#[test]
+fn websocket() {
+    util::expect_wrangler();
+
+    let (mut socket, _) =
+        connect(Url::parse("ws://localhost:8787/websocket").unwrap()).expect("Can't connect");
+
+    socket
+        .write_message(Message::Text("Hello, world!".into()))
+        .unwrap();
+
+    let msg = socket
+        .read_message()
+        .and_then(|msg| msg.into_text())
+        .unwrap();
+
+    assert_eq!(&msg, "Hello, world!")
+}

--- a/worker-sys/src/websocket.rs
+++ b/worker-sys/src/websocket.rs
@@ -86,4 +86,14 @@ extern "C" {
         r#type: JsValue,
         value: Option<&::js_sys::Function>,
     ) -> Result<(), JsValue>;
+
+    #[wasm_bindgen(catch, method, structural, js_class = "WebSocket", js_name = removeEventListener)]
+    #[doc = "The `removeEventListener()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](hhttps://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener)"]
+    pub fn remove_event_listener(
+        this: &WebSocket,
+        r#type: JsValue,
+        value: Option<&::js_sys::Function>,
+    ) -> Result<(), JsValue>;
 }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3.16"
 http = "0.2.4"
 js-sys = "0.3.55"
 matchit = "0.4.2"
+pin-project = "1.0.10"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 url = "2.2.2"

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -293,17 +293,17 @@ pub mod ws_events {
 
     impl MessageEvent {
         /// Gets the data/payload from the message.
-        fn get_data(&self) -> JsValue {
+        fn data(&self) -> JsValue {
             self.event.data()
         }
 
-        pub fn get_text(&self) -> Option<String> {
-            let value = self.get_data();
+        pub fn text(&self) -> Option<String> {
+            let value = self.data();
             value.as_string()
         }
 
-        pub fn get_blob(&self) -> Option<Vec<u8>> {
-            let value = self.get_data();
+        pub fn bytes(&self) -> Option<Vec<u8>> {
+            let value = self.data();
             if value.is_object() {
                 Some(js_sys::Uint8Array::new(&value).to_vec())
             } else {
@@ -311,8 +311,8 @@ pub mod ws_events {
             }
         }
 
-        pub fn get_json<T: DeserializeOwned>(&self) -> crate::Result<T> {
-            let text = match self.get_text() {
+        pub fn json<T: DeserializeOwned>(&self) -> crate::Result<T> {
+            let text = match self.text() {
                 Some(text) => text,
                 None => return Err(Error::from("data of message event is not text")),
             };

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -55,7 +55,7 @@ impl WebSocket {
     }
 
     /// Sends raw binary data through the `WebSocket`.
-    pub fn send_with_binary<D: AsRef<[u8]>>(&self, bytes: D) -> Result<()> {
+    pub fn send_with_bytes<D: AsRef<[u8]>>(&self, bytes: D) -> Result<()> {
         let slice = bytes.as_ref();
         let array = js_sys::Uint8Array::new_with_length(slice.len() as u32);
         array.copy_from(slice);

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -1,10 +1,16 @@
-use crate::ws_events::{CloseEvent, ErrorEvent, MessageEvent};
 use crate::{Error, Result};
+use futures::channel::mpsc::UnboundedReceiver;
+use futures::Stream;
 use serde::Serialize;
-use std::future::Future;
+
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll};
 use wasm_bindgen::convert::FromWasmAbi;
 use wasm_bindgen::prelude::Closure;
 use wasm_bindgen::{JsCast, JsValue};
+
+pub use crate::ws_events::*;
 
 /// Struct holding the values for a JavaScript `WebSocketPair`
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,115 +84,167 @@ impl WebSocket {
         .map_err(Error::from)
     }
 
-    /// Registers an event-handler for the `message` event.
+    /// Internal utility method to avoid verbose code.
+    /// This method registers a closure in the underlying JS environment, which calls back into the
+    /// Rust/wasm environment.
     ///
-    /// This event will be fired when the `WebSocket` receives a payload.
-    ///
-    /// https://developers.cloudflare.com/workers/runtime-apis/websockets#events     
-    pub fn on_message<F: Fn(MessageEvent) + 'static>(&self, fun: F) -> Result<()> {
-        self.add_event_handler("message", move |event: worker_sys::MessageEvent| {
-            fun(event.into());
-        })
-    }
-
-    /// Registers an async event-handler for the `message` event.
-    ///
-    /// This event will be fired when the `WebSocket` receives a payload.
-    ///
-    /// https://developers.cloudflare.com/workers/runtime-apis/websockets#events    
-    pub fn on_message_async<
-        Fut: Future<Output = ()> + 'static,
-        F: Fn(MessageEvent) -> Fut + 'static,
-    >(
+    /// Since this is a 'long living closure', we need to keep the lifetime of this closure until
+    /// we remove any references to the closure. So the caller of this must not drop the closure
+    /// until they call [`Self::remove_event_handler`].
+    fn add_event_handler<T: FromWasmAbi + 'static, F: FnMut(T) + 'static>(
         &self,
+        r#type: &str,
         fun: F,
-    ) -> Result<()> {
-        self.add_event_handler("message", move |event: worker_sys::MessageEvent| {
-            let fut = fun(event.into());
-            wasm_bindgen_futures::spawn_local(async move { fut.await });
-        })
-    }
+    ) -> Result<Closure<dyn FnMut(T)>> {
+        let js_callback = Closure::wrap(Box::new(fun) as Box<dyn FnMut(T)>);
+        self.socket
+            .add_event_listener(
+                JsValue::from_str(r#type),
+                Some(js_callback.as_ref().unchecked_ref()),
+            )
+            .map_err(Error::from)?;
 
-    /// Registers an event-handler for the `close` event.
-    ///
-    /// This event will be fired when the `WebSocket` closes.
-    ///
-    /// https://developers.cloudflare.com/workers/runtime-apis/websockets#events    
-    pub fn on_close<F: Fn(CloseEvent) + 'static>(&self, fun: F) -> Result<()> {
-        self.add_event_handler("close", move |event: worker_sys::CloseEvent| {
-            fun(event.into());
-        })
-    }
-
-    /// Registers an async event-handler for the `close` event.
-    ///
-    /// This event will be fired when the `WebSocket` closes.
-    ///
-    /// https://developers.cloudflare.com/workers/runtime-apis/websockets#events
-    pub fn on_close_async<
-        Fut: Future<Output = ()> + 'static,
-        F: Fn(CloseEvent) -> Fut + 'static,
-    >(
-        &self,
-        fun: F,
-    ) -> Result<()> {
-        self.add_event_handler("close", move |event: worker_sys::CloseEvent| {
-            let fut = fun(event.into());
-            wasm_bindgen_futures::spawn_local(async move { fut.await });
-        })
-    }
-
-    /// Registers an event-handler for the `error` event.
-    ///
-    /// This event will be fired when the `WebSocket` caught an error.
-    ///
-    /// https://developers.cloudflare.com/workers/runtime-apis/websockets#events
-    pub fn on_error<F: Fn(ErrorEvent) + 'static>(&self, fun: F) -> Result<()> {
-        self.add_event_handler("error", move |event: worker_sys::ErrorEvent| {
-            fun(event.into());
-        })
-    }
-
-    /// Registers an async event-handler for the `error` event.
-    ///
-    /// This event will be fired when the `WebSocket` caught an error.
-    ///
-    /// https://developers.cloudflare.com/workers/runtime-apis/websockets#events
-    pub fn on_error_async<
-        Fut: Future<Output = ()> + 'static,
-        F: Fn(ErrorEvent) -> Fut + 'static,
-    >(
-        &self,
-        fun: F,
-    ) -> Result<()> {
-        self.add_event_handler("error", move |event: worker_sys::ErrorEvent| {
-            let fut = fun(event.into());
-            wasm_bindgen_futures::spawn_local(async move { fut.await });
-        })
+        Ok(js_callback)
     }
 
     /// Internal utility method to avoid verbose code.
     /// This method registers a closure in the underlying JS environment, which calls back
     /// into the Rust/wasm environment.
-    /// Since this is a 'long living closure', we need to actively "leak" memory in this,
-    /// as we need to drop the reference to the `WasmClosure` or it will be destroyed with
-    /// it's lifetime at the end of the function.
-    fn add_event_handler<T: FromWasmAbi + 'static, F: FnMut(T) + 'static>(
+    fn remove_event_handler<T: FromWasmAbi + 'static>(
         &self,
         r#type: &str,
-        fun: F,
+        js_callback: Closure<dyn FnMut(T)>,
     ) -> Result<()> {
-        let js_callback = Closure::wrap(Box::new(fun) as Box<dyn FnMut(T)>);
-        let result = self
-            .socket
-            .add_event_listener(
+        self.socket
+            .remove_event_listener(
                 JsValue::from_str(r#type),
                 Some(js_callback.as_ref().unchecked_ref()),
             )
-            .map_err(Error::from);
-        // we need to leak this closure, or it will be invalidated at the end of the function.
-        js_callback.forget();
-        result
+            .map_err(Error::from)
+    }
+
+    /// Gets an implementation [`Stream`](futures::Stream) that yields events from the inner
+    /// WebSocket.
+    pub fn events(&self) -> Result<EventStream> {
+        let (tx, rx) = futures::channel::mpsc::unbounded::<Result<WebsocketEvent>>();
+        let tx = Rc::new(tx);
+
+        let close_closure = self.add_event_handler("close", {
+            let tx = tx.clone();
+            move |event: worker_sys::CloseEvent| {
+                tx.unbounded_send(Ok(WebsocketEvent::Close(event.into())))
+                    .unwrap();
+            }
+        })?;
+        let message_closure = self.add_event_handler("message", {
+            let tx = tx.clone();
+            move |event: worker_sys::MessageEvent| {
+                tx.unbounded_send(Ok(WebsocketEvent::Message(event.into())))
+                    .unwrap();
+            }
+        })?;
+        let error_closure =
+            self.add_event_handler("error", move |event: worker_sys::ErrorEvent| {
+                let error = event.error();
+                tx.unbounded_send(Err(error.into())).unwrap();
+            })?;
+
+        Ok(EventStream {
+            ws: self,
+            rx,
+            closed: false,
+            closures: Some((message_closure, error_closure, close_closure)),
+        })
+    }
+}
+
+type EvCallback<T> = Closure<dyn FnMut(T)>;
+
+/// A [`Stream`](futures::Stream) that yields [`WebsocketEvent`](crate::ws_events::WebsocketEvent)s
+/// emitted by the inner [`WebSocket`](crate::WebSocket). The stream is guranteed to always yield a
+/// `WebsocketEvent::Close` as the final non-none item.
+///
+/// # Example
+/// ```rust,ignore
+/// use futures::StreamExt;
+///
+/// let pair = WebSocketPair::new()?;
+/// let server = pair.server;
+///
+/// server.accept()?;
+///
+/// // Spawn a future for handling the stream of events from the websocket.
+/// wasm_bindgen_futures::spawn_local(async move {
+///     let mut event_stream = server.events().expect("could not open stream");
+///
+///     while let Some(event) = event_stream.next().await {
+///         match event.expect("received error in websocket") {
+///             WebsocketEvent::Message(msg) => console_log!("{:#?}", msg),
+///             WebsocketEvent::Close(event) => console_log!("Closed!"),
+///         }
+///     }
+/// });
+/// ```
+#[pin_project::pin_project(PinnedDrop)]
+pub struct EventStream<'ws> {
+    ws: &'ws WebSocket,
+    #[pin]
+    rx: UnboundedReceiver<Result<WebsocketEvent>>,
+    closed: bool,
+    /// Once we have decided we need to finish the stream, we need to remove any listeners we
+    /// registered with the websocket.
+    closures: Option<(
+        EvCallback<worker_sys::MessageEvent>,
+        EvCallback<worker_sys::ErrorEvent>,
+        EvCallback<worker_sys::CloseEvent>,
+    )>,
+}
+
+impl<'ws> Stream for EventStream<'ws> {
+    type Item = Result<WebsocketEvent>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+
+        if *this.closed {
+            return Poll::Ready(None);
+        }
+
+        // Poll the inner receiver to check if theres any events from our event callbacks.
+        let item = futures::ready!(this.rx.poll_next(cx));
+
+        // Mark the stream as closed if we get a close event and yield None next iteration.
+        if let Some(item) = &item {
+            if matches!(&item, Ok(WebsocketEvent::Close(_))) {
+                *this.closed = true;
+            }
+        }
+
+        Poll::Ready(item)
+    }
+}
+
+// Because we don't want to receive messages once our stream is done we need to remove all our
+// listeners when we go to drop the stream.
+#[pin_project::pinned_drop]
+impl PinnedDrop for EventStream<'_> {
+    fn drop(self: Pin<&'_ mut Self>) {
+        let this = self.project();
+
+        // remove_event_handler takes an owned closure, so we'll do this little hack and wrap our
+        // closures in an Option. This should never panic because we should never call drop twice.
+        let (message_closure, error_closure, close_closure) =
+            std::mem::take(this.closures).expect("double drop on worker::EventStream");
+
+        this.ws
+            .remove_event_handler("message", message_closure)
+            .expect("could not remove message handler");
+        this.ws
+            .remove_event_handler("error", error_closure)
+            .expect("could not remove error handler");
+        this.ws
+            .remove_event_handler("close", close_closure)
+            .expect("could not remove close handler");
     }
 }
 
@@ -204,6 +262,13 @@ impl AsRef<worker_sys::WebSocket> for WebSocket {
 
 pub mod ws_events {
     use wasm_bindgen::JsValue;
+
+    /// Events that can be yielded by a [`EventStream`](crate::EventStream).
+    #[derive(Debug, Clone)]
+    pub enum WebsocketEvent {
+        Message(MessageEvent),
+        Close(CloseEvent),
+    }
 
     /// Wrapper/Utility struct for the `web_sys::MessageEvent`
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -250,6 +315,20 @@ pub mod ws_events {
         event: worker_sys::CloseEvent,
     }
 
+    impl CloseEvent {
+        pub fn reason(&self) -> String {
+            self.event.reason()
+        }
+
+        pub fn code(&self) -> u16 {
+            self.event.code()
+        }
+
+        pub fn was_clean(&self) -> bool {
+            self.event.was_clean()
+        }
+    }
+
     impl From<worker_sys::CloseEvent> for CloseEvent {
         fn from(event: worker_sys::CloseEvent) -> Self {
             Self { event }
@@ -258,24 +337,6 @@ pub mod ws_events {
 
     impl AsRef<worker_sys::CloseEvent> for CloseEvent {
         fn as_ref(&self) -> &worker_sys::CloseEvent {
-            &self.event
-        }
-    }
-
-    /// Wrapper/Utility struct for the `web_sys::ErrorEvent`
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct ErrorEvent {
-        event: worker_sys::ErrorEvent,
-    }
-
-    impl From<worker_sys::ErrorEvent> for ErrorEvent {
-        fn from(event: worker_sys::ErrorEvent) -> Self {
-            Self { event }
-        }
-    }
-
-    impl AsRef<worker_sys::ErrorEvent> for ErrorEvent {
-        fn as_ref(&self) -> &worker_sys::ErrorEvent {
             &self.event
         }
     }


### PR DESCRIPTION
The current WebSocket api is closely modeled after the JavaScript WebSocket api which is functional but seems like a strange fit inside of a rust program. This PR is meant to refactor the WebSocket api to feel more *rust-y*.

Inspiration was taken from several other rust http frameworks (primarily [axum](https://docs.rs/axum/latest/axum/extract/ws/struct.WebSocket.html) and [warp](https://docs.rs/warp/latest/warp/filters/ws/struct.WebSocket.html)) but some of the restrictions JavaScript places on us requires us to make some changes. The biggest different in my opinion is that we don't use a [Sink](https://docs.rs/futures/latest/futures/prelude/trait.Sink.html) for sending messages through the WebSocket, which is because [send](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/send) does not return a promise for when it has finished sending the message and I thought having an async trait that always acts synchronously is strange.

This PR is a draft so if you have opinions on what the WebSocket api should look like leave your opinion, I'd love some feedback on this.