### PR TITLE
fix: uninitialized wasm imports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,18 @@ jobs:
         with:
           command: check
 
+      - name: Build bindgen test subject
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --manifest-path worker-build/bindgen-test-subject/Cargo.toml --target wasm32-unknown-unknown --release
+
+      - name: Run builder tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path worker-build/Cargo.toml
+
       - name: Setup node
         uses: actions/setup-node@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 members = [
-    "worker", 
+    "worker",
     "worker-build",
-    "worker-macros", 
+    "worker-macros",
     "worker-sandbox",
-    "worker-sys"
+    "worker-sys",
 ]
 
 [profile.release]
@@ -28,4 +28,4 @@ lto = true
 # https://docs.rust-embedded.org/book/unsorted/speed-vs-size.html#optimizing-dependencies
 [profile.release.package."*"]
 codegen-units = 1
-opt-level     = "z"
+opt-level = "z"

--- a/worker-build/Cargo.toml
+++ b/worker-build/Cargo.toml
@@ -12,3 +12,6 @@ description = "This is a tool to be used as a custom build command for a Cloudfl
 
 [dependencies]
 anyhow = "1"
+
+[dev-dependencies]
+wasm-bindgen-cli-support = "=0.2.78"

--- a/worker-build/bindgen-test-subject/Cargo.toml
+++ b/worker-build/bindgen-test-subject/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+
+[package]
+name = "bindgen-test-subject"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+js-sys = "0.3.55"
+wasm-bindgen = "=0.2.78"

--- a/worker-build/bindgen-test-subject/src/lib.rs
+++ b/worker-build/bindgen-test-subject/src/lib.rs
@@ -1,0 +1,12 @@
+use js_sys::Math;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(js_name = "addRandom")]
+pub fn add_random(x: f64) -> f64 {
+    // Called to get wasm-bindgen to generate an exported function that we can check.
+    js_sys::global();
+
+    // Math.random is used because wasm-bindgen generates a exported constant that is set to
+    // Math.random
+    x + Math::random()
+}

--- a/worker-build/src/main.rs
+++ b/worker-build/src/main.rs
@@ -107,28 +107,6 @@ fn write_worker_shims_to_worker_dir() -> Result<()> {
     // _bg implies "bindgen" from wasm-bindgen tooling
     let bg_name = format!("{}_bg", OUT_NAME);
 
-    // this shim exports a webassembly instance with 512 pages
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/Memory#parameters
-    let export_wasm_content = format!(
-        r#"
-import * as {0} from "./{0}.mjs";
-import _wasm from "./{0}.wasm";
-
-const _wasm_memory = new WebAssembly.Memory({{initial: 512}});
-let importsObject = {{
-    env: {{ memory: _wasm_memory }},
-    "./{0}.js": {0}
-}};
-
-export default new WebAssembly.Instance(_wasm, importsObject).exports;
-
-"#,
-        bg_name
-    );
-    let export_wasm_path = PathBuf::from(OUT_DIR)
-        .join(WORKER_SUBDIR)
-        .join("export_wasm.mjs");
-
     // this shim just re-exports things in the pattern workers expects
     let shim_content = format!(
         r#"
@@ -146,26 +124,53 @@ export default {{ fetch, scheduled }};
     let shim_path = PathBuf::from(OUT_DIR).join(WORKER_SUBDIR).join("shim.mjs");
 
     // write our content out to files
-    for (content, path) in [
-        (export_wasm_content, export_wasm_path),
-        (shim_content, shim_path),
-    ] {
-        let mut file = File::create(path)?;
-        file.write_all(content.as_bytes())?;
-    }
+    let mut file = File::create(shim_path)?;
+    file.write_all(shim_content.as_bytes())?;
 
     Ok(())
 }
 
 fn replace_generated_import_with_custom_impl() -> Result<()> {
+    let bg_name = format!("{}_bg", OUT_NAME);
     let bindgen_glue_path = PathBuf::from(OUT_DIR)
         .join(WORKER_SUBDIR)
         .join(format!("{}_bg.mjs", OUT_NAME));
     let old_bindgen_glue = read_file_to_string(&bindgen_glue_path)?;
     let old_import = format!("import * as wasm from './{}_bg.wasm'", OUT_NAME);
-    let fixed_bindgen_glue =
-        old_bindgen_glue.replace(&old_import, "import wasm from './export_wasm.mjs'");
+    let mut fixed_bindgen_glue = old_bindgen_glue.replace(&old_import, "let wasm;");
+
+    // Previously we just used a namespace import as the wasm's import obj but this had a problem
+    // where wasm-bindgen would re-export built-in functions as a const variable. This caused a
+    // problem because the OUTNAME_bg.mjs imported the wasm from another file causing a circular
+    // import so the const function items were never initialized.
+    //
+    // Because can't use import OUTNAME_bg.mjs module and use that module's exports as the import
+    // object, we'll have to find all the exports and use that to construct the wasm's import obj.
+    let names_for_import_obj = find_exports(&fixed_bindgen_glue);
+
+    // this shim exports a webassembly instance with 512 pages
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/Memory#parameters
+    let initialization_glue = format!(
+        r#"
+import _wasm from "./{0}.wasm";
+
+const _wasm_memory = new WebAssembly.Memory({{initial: 512}});
+let importsObject = {{
+    env: {{ memory: _wasm_memory }},
+    "./{0}.js": {{ {1} }}
+}};
+
+wasm = new WebAssembly.Instance(_wasm, importsObject).exports;
+"#,
+        bg_name,
+        names_for_import_obj.join(", ")
+    );
+
+    // Add the code that initializes the `wasm` variable we declared at the top of the file.
+    fixed_bindgen_glue.push_str(&initialization_glue);
+
     write_string_to_file(bindgen_glue_path, fixed_bindgen_glue)?;
+
     Ok(())
 }
 
@@ -182,4 +187,26 @@ fn write_string_to_file<P: AsRef<Path>>(path: P, contents: String) -> Result<()>
     file.write_all(contents.as_bytes())?;
 
     Ok(())
+}
+
+// TODO: Potentially rewrite this to run an actual JavaScript parser.
+fn find_exports(js: &str) -> Vec<&str> {
+    const FUNCTION_EXPORT_PREFIXES: [&str; 2] = ["export function ", "export const "];
+
+    js.lines()
+        .filter_map(|line| {
+            for prefix in FUNCTION_EXPORT_PREFIXES {
+                if line.starts_with(prefix) {
+                    let name_end_index = line
+                        .chars()
+                        .skip(prefix.len())
+                        .take_while(|c| *c != '(' && *c != ' ')
+                        .count();
+                    return Some(&line[prefix.len()..name_end_index + prefix.len()]);
+                }
+            }
+
+            None
+        })
+        .collect::<Vec<_>>()
 }


### PR DESCRIPTION
Previously we generated a `export_wasm.mjs` that imported all of the glue generated by wasm bindgen and modified the glue to import from the generated file. This caused a circular import leading to some functions, specifically ones that were just const aliases of builtins, generated by wasm-bindgen to be uninitialized and cause a crash. This bug can be replicated by making a worker that tries to use [Math::random()](https://docs.rs/js-sys/latest/js_sys/Math/fn.random.html).

To fix this we move all of the code in the `export_wasm.mjs` to that glue file. I don't think this would cause any side effects but I'd like to know what you think @nilslice.