### PR TITLE
chore: fix unused function warning

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Check for idiomatic code
-        run: cargo clippy --all --all-features -- -D warnings
+        run: cargo clippy --all-features --all-targets --all -- -D warnings

--- a/worker-sandbox/tests/websocket.rs
+++ b/worker-sandbox/tests/websocket.rs
@@ -1,3 +1,9 @@
+// Cargo compiles each integration test individually so we can run into scenarios like this where
+// cargo emits a warning in `util.rs` saying that some of the exported functions aren't used. This
+// warning is raised because the websocket specifically doesn't use those functions, it doesn't
+// consider their usage in `requests.rs` when compiling this test.
+#![allow(unused)]
+
 use reqwest::Url;
 use tungstenite::{connect, Message};
 


### PR DESCRIPTION
With the addition of integration testing for WebSockets we unintentionally introduced a warning where some functions declared in the integration test's util module were unused. This is because all integration tests are compiled as separate binaries so for the websocket binary functions weren't used for that specific compile job.

This also adjust flags in the CI to catch warnings like this in the future.