### PR TITLE
Start event

### DIFF
--- a/worker-build/src/main.rs
+++ b/worker-build/src/main.rs
@@ -175,6 +175,7 @@ let importsObject = {{
 }};
 
 wasm = new WebAssembly.Instance(_wasm, importsObject).exports;
+wasm.__wbindgen_start?.();
 "#,
         bg_name,
         names_for_import_obj.join(", ")

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -3,7 +3,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use blake2::{Blake2b, Digest};
 use futures::{StreamExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
-use wasm_bindgen::prelude::*;
 use worker::*;
 
 mod counter;
@@ -65,7 +64,7 @@ async fn handle_async_request<D>(req: Request, _ctx: RouteContext<D>) -> Result<
 
 static GLOBAL_STATE: AtomicBool = AtomicBool::new(false);
 
-#[wasm_bindgen(start)]
+#[event(start)]
 pub fn start() {
     GLOBAL_STATE.store(true, Ordering::SeqCst)
 }

--- a/worker-sandbox/tests/requests.rs
+++ b/worker-sandbox/tests/requests.rs
@@ -305,6 +305,14 @@ fn custom_response_body() {
     assert_eq!(body.to_vec(), b"hello");
 }
 
+#[test]
+fn init_called() {
+    // JavaScript doesn't use a date format that chrono can natively parse, so we'll just assume
+    // any 200 status code is a pass.
+    let body = get("init-called", |r| r).text().unwrap();
+    assert_eq!(body, "true");
+}
+
 #[tokio::test]
 async fn xor() {
     expect_wrangler();


### PR DESCRIPTION
Adds support for a `start` event that is invoked when the worker is initialized. This is useful for things like setting panic hooks, setting up loggers, creating any initial state, etc.

Under the hood this uses wasm-bindgen's [start feature](https://rustwasm.github.io/docs/wasm-bindgen/reference/attributes/on-rust-exports/start.html) and because of that we inherit it's limitations, like not being able to register multiple start events.