### PR TITLE
feat: add cloned to Response

### DIFF
--- a/worker-sandbox/tests/requests.rs
+++ b/worker-sandbox/tests/requests.rs
@@ -312,6 +312,24 @@ fn now() {
 }
 
 #[test]
+fn cloned() {
+    let resp = get("cloned", |r| r);
+    assert_eq!(resp.text().unwrap(), "true")
+}
+
+#[test]
+fn cloned_stream() {
+    let resp = get("cloned-stream", |r| r);
+    assert_eq!(resp.text().unwrap(), "true")
+}
+
+#[test]
+fn cloned_fetch() {
+    let resp = get("cloned-fetch", |r| r);
+    assert_eq!(resp.text().unwrap(), "true")
+}
+
+#[test]
 fn wait() {
     const MILLIS: u64 = 100;
     let then = Instant::now();

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -11,7 +11,6 @@ use js_sys::Uint8Array;
 use serde::{de::DeserializeOwned, Serialize};
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
-use wasm_bindgen_futures::JsFuture;
 use web_sys::ReadableStream;
 use worker_sys::{response_init::ResponseInit as EdgeResponseInit, Response as EdgeResponse};
 
@@ -19,7 +18,7 @@ use worker_sys::{response_init::ResponseInit as EdgeResponseInit, Response as Ed
 pub enum ResponseBody {
     Empty,
     Body(Vec<u8>),
-    Stream(EdgeResponse),
+    Stream(ReadableStream),
 }
 
 const CONTENT_TYPE: &str = "content-type";
@@ -205,10 +204,10 @@ impl Response {
                 Ok(String::from_utf8(bytes.clone()).map_err(|e| Error::from(e.to_string()))?)
             }
             ResponseBody::Empty => Ok(String::new()),
-            ResponseBody::Stream(response) => JsFuture::from(response.text()?)
-                .await
-                .map(|value| value.as_string().unwrap())
-                .map_err(Error::from),
+            ResponseBody::Stream(_) => {
+                let bytes = self.bytes().await?;
+                String::from_utf8(bytes).map_err(|e| Error::RustError(e.to_string()))
+            },
         }
     }
 
@@ -226,25 +225,26 @@ impl Response {
         match &self.body {
             ResponseBody::Body(bytes) => Ok(bytes.clone()),
             ResponseBody::Empty => Ok(Vec::new()),
-            ResponseBody::Stream(response) => JsFuture::from(response.array_buffer()?)
-                .await
-                .map(|value| js_sys::Uint8Array::new(&value).to_vec())
-                .map_err(Error::from),
+            ResponseBody::Stream(_) => {
+                self.stream()?
+                    .try_fold(Vec::new(), |mut bytes, mut chunk| async move {
+                        bytes.append(&mut chunk);
+                        Ok(bytes)
+                    })
+                    .await
+            }
         }
     }
 
     /// Access this response's body as a [`Stream`](futures::stream::Stream) of bytes.
     pub fn stream(&mut self) -> Result<ByteStream> {
-        let edge_request = match &self.body {
-            ResponseBody::Stream(edge_request) => edge_request,
+        let stream = match &self.body {
+            ResponseBody::Stream(edge_request) => edge_request.clone(),
             _ => return Err(Error::RustError("body is not streamable".into())),
         };
 
-        let stream = edge_request
-            .body()
-            .ok_or_else(|| Error::RustError("no body for request".into()))?;
-
         let stream = wasm_streams::ReadableStream::from_raw(stream.dyn_into().unwrap());
+
         Ok(ByteStream {
             inner: stream.into_stream(),
         })
@@ -301,6 +301,25 @@ impl Response {
     pub fn headers_mut(&mut self) -> &mut Headers {
         &mut self.headers
     }
+
+    /// Clones the response so it can be used multiple times.
+    pub fn cloned(&mut self) -> Result<Self> {
+        if self.websocket.is_some() {
+            return Err(Error::RustError("WebSockets cannot be cloned".into()));
+        }
+
+        let edge = EdgeResponse::from(&*self);
+        let cloned = edge.clone()?;
+
+        // Cloning a response might modify it's body as it might need to tee the stream, so we'll
+        // need to update it.
+        self.body = match edge.body() {
+            Some(stream) => ResponseBody::Stream(stream),
+            None => ResponseBody::Empty,
+        };
+
+        Ok(cloned.into())
+    }
 }
 
 #[test]
@@ -346,8 +365,8 @@ impl From<Response> for EdgeResponse {
                 )
                 .unwrap()
             }
-            ResponseBody::Stream(response) => EdgeResponse::new_with_opt_stream_and_init(
-                response.body(),
+            ResponseBody::Stream(stream) => EdgeResponse::new_with_opt_stream_and_init(
+                Some(stream),
                 &ResponseInit {
                     status: res.status_code,
                     headers: res.headers,
@@ -370,6 +389,48 @@ impl From<Response> for EdgeResponse {
     }
 }
 
+impl From<&Response> for EdgeResponse {
+    fn from(res: &Response) -> Self {
+        match &res.body {
+            ResponseBody::Body(bytes) => {
+                let array = Uint8Array::new_with_length(bytes.len() as u32);
+                array.copy_from(bytes);
+
+                EdgeResponse::new_with_opt_u8_array_and_init(
+                    Some(array),
+                    &ResponseInit {
+                        status: res.status_code,
+                        headers: res.headers.clone(),
+                        websocket: res.websocket.clone(),
+                    }
+                    .into(),
+                )
+                .unwrap()
+            }
+            ResponseBody::Stream(stream) => EdgeResponse::new_with_opt_stream_and_init(
+                Some(stream.clone()),
+                &ResponseInit {
+                    status: res.status_code,
+                    headers: res.headers.clone(),
+                    websocket: res.websocket.clone(),
+                }
+                .into(),
+            )
+            .unwrap(),
+            ResponseBody::Empty => EdgeResponse::new_with_opt_str_and_init(
+                None,
+                &ResponseInit {
+                    status: res.status_code,
+                    headers: res.headers.clone(),
+                    websocket: res.websocket.clone(),
+                }
+                .into(),
+            )
+            .unwrap(),
+        }
+    }
+}
+
 impl From<EdgeResponse> for Response {
     fn from(res: EdgeResponse) -> Self {
         Self {
@@ -377,7 +438,7 @@ impl From<EdgeResponse> for Response {
             status_code: res.status(),
             websocket: res.websocket().map(|ws| ws.into()),
             body: match res.body() {
-                Some(_) => ResponseBody::Stream(res),
+                Some(stream) => ResponseBody::Stream(stream),
                 None => ResponseBody::Empty,
             },
         }

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -207,7 +207,7 @@ impl Response {
             ResponseBody::Stream(_) => {
                 let bytes = self.bytes().await?;
                 String::from_utf8(bytes).map_err(|e| Error::RustError(e.to_string()))
-            },
+            }
         }
     }
 


### PR DESCRIPTION
Adds the ability to clone [Response](https://docs.rs/worker/latest/worker/struct.Response.html)s. As a part of this commit we also refactor [ResponseBody](https://docs.rs/worker/latest/worker/enum.ResponseBody.html) to not include a whole request as part of the [Stream](https://docs.rs/worker/latest/worker/enum.ResponseBody.html#variant.Stream) variant. This is a breaking change, but makes a lot more sense.