### PR TITLE
Method for easily getting query parameters

### DIFF
--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -232,8 +232,11 @@ impl Request {
 
 /// Used to add additional helper functions to url::Url
 pub trait UrlExt {
+    /// Given a query parameter, returns an Iterator of values for that parameter in the url's
+    /// query string
     fn param<'a>(&'a self, key: &'a str) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a>;
 }
+
 impl UrlExt for Url {
     fn param<'a>(&'a self, key: &'a str) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a> {
         Box::new(


### PR DESCRIPTION
Thought I'd do a try of #179 

`Url` is actually a foreign type, so a trait is required to extend its functionality, unless this is sent upstream instead. 

Because a query may have multiple values for a key, the function returns an iterator. For assumed-unique parameters, perhaps a
```rust
fn first_value_of(&self, key: &str) -> Option<Cow<'a, str>>
```
 function might also be useful.