### PR TITLE
Add Github templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: 🐞 Bug Report
+description: File a bug/issue
+title: "[BUG] <title>"
+body:
+- type: markdown
+  attributes:
+    value: |
+      ## Bug Report Form
+      Thank you for taking the time to file a bug report! Please fill out this form as completely as possible.
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: input
+  attributes:
+    label: What version of `workers-rs` are you using?
+    placeholder: 0.0.0
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description: A concise description of what you're experiencing and the expected behavior.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. In this environment...
+      2. With this config...
+      3. Run '...'
+      4. See error...
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: ⭐ Feature Request
+description: Submit a feature request
+title: "[Feature] <title>"
+body:
+- type: markdown
+  attributes:
+    value: |
+      ## Feature Request Form
+      Thanks for submitting a feature request! Please fill out this form as completely as possible.
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Description
+    description: A concise description of the feature requested.
+  validations:
+    required: true


### PR DESCRIPTION
Adds Github templates for reporting bugs and requesting features.

Bug report form looks like the following:
<img width="996" alt="Screen Shot 2022-05-17 at 3 21 25 PM" src="https://user-images.githubusercontent.com/46542932/168921928-b82e60f6-e904-4099-af0e-a927e2e2f6b4.png">

Feature request form looks like the following:
<img width="959" alt="Screen Shot 2022-05-17 at 3 23 15 PM" src="https://user-images.githubusercontent.com/46542932/168922101-a8b6e2a9-cb49-4025-bc8d-27f6674d8016.png">

