### PR TITLE
Add DO Alarm API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,18 +825,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/worker-build/src/install.rs
+++ b/worker-build/src/install.rs
@@ -11,7 +11,7 @@ pub fn is_installed(name: &str) -> Result<Option<PathBuf>> {
             .ok()
             .map(|meta| meta.is_dir())
             .unwrap_or(false)
-            .then(|| path)
+            .then_some(path)
     });
 
     for dir in path_directories {

--- a/worker-sandbox/src/alarm.rs
+++ b/worker-sandbox/src/alarm.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+use worker::*;
+
+#[durable_object]
+pub struct AlarmObject {
+    state: State,
+}
+
+#[durable_object]
+impl DurableObject for AlarmObject {
+    fn new(state: State, _: Env) -> Self {
+        Self { state }
+    }
+
+    async fn fetch(&mut self, _: Request) -> Result<Response> {
+        let alarmed: bool = match self.state.storage().get("alarmed").await {
+            Ok(alarmed) => alarmed,
+            Err(e) if e.to_string() == "No such value in storage." => {
+                // Trigger our alarm method in 100ms.
+                self.state
+                    .storage()
+                    .set_alarm(Duration::from_millis(100))
+                    .await?;
+
+                false
+            }
+            Err(e) => return Err(e),
+        };
+
+        Response::ok(&alarmed.to_string())
+    }
+
+    async fn alarm(&mut self) -> Result<Response> {
+        self.state.storage().put("alarmed", true).await?;
+
+        console_log!("Alarm has been triggered!");
+
+        Response::ok("ALARMED")
+    }
+}

--- a/worker-sandbox/src/counter.rs
+++ b/worker-sandbox/src/counter.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use worker::*;
 
 #[durable_object]
@@ -19,7 +20,7 @@ impl DurableObject for Counter {
         }
     }
 
-    async fn fetch(&mut self, _req: Request) -> Result<Response> {
+    async fn fetch(&mut self, req: Request) -> Result<Response> {
         if !self.initialized {
             self.initialized = true;
             self.count = self.state.storage().get("count").await.unwrap_or(0);
@@ -27,10 +28,27 @@ impl DurableObject for Counter {
 
         self.count += 10;
         self.state.storage().put("count", self.count).await?;
+
+        if req.path().contains("alarm") {
+            // Set an alarm to trigger in 500 ms:
+            let now = Utc::now();
+            self.state
+                .storage()
+                .set_alarm(now + chrono::Duration::milliseconds(500))
+                .await?;
+        }
+
         Response::ok(&format!(
             "[durable_object]: self.count: {}, secret value: {}",
             self.count,
             self.env.secret("SOME_SECRET")?.to_string()
         ))
+    }
+
+    async fn alarm(&mut self) -> Result<Response> {
+        self.count = 32;
+        self.state.storage().put("count", 32).await?;
+
+        Response::ok("ALARMED")
     }
 }

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -9,6 +9,7 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use worker::*;
 
+mod alarm;
 mod counter;
 mod test;
 mod utils;
@@ -348,7 +349,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
             Fetch::Url(url.parse()?).send().await
         })
         .get_async("/durable/alarm", |_req, ctx| async move {
-            let namespace = ctx.durable_object("COUNTER")?;
+            let namespace = ctx.durable_object("ALARM")?;
             let stub = namespace.id_from_name("alarm")?.get_stub()?;
             // when calling fetch to a Durable Object, a full URL must be used. Alternatively, a
             // compatibility flag can be provided in wrangler.toml to opt-in to older behavior:

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -347,6 +347,14 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
 
             Fetch::Url(url.parse()?).send().await
         })
+        .get_async("/durable/alarm", |_req, ctx| async move {
+            let namespace = ctx.durable_object("COUNTER")?;
+            let stub = namespace.id_from_name("alarm")?.get_stub()?;
+            // when calling fetch to a Durable Object, a full URL must be used. Alternatively, a
+            // compatibility flag can be provided in wrangler.toml to opt-in to older behavior:
+            // https://developers.cloudflare.com/workers/platform/compatibility-dates#durable-object-stubfetch-requires-a-full-url
+            stub.fetch_with_str("https://fake-host/alarm").await
+        })
         .get_async("/durable/:id", |_req, ctx| async move {
             let namespace = ctx.durable_object("COUNTER")?;
             let stub = namespace.id_from_name("A")?.get_stub()?;

--- a/worker-sandbox/tests/requests.rs
+++ b/worker-sandbox/tests/requests.rs
@@ -144,6 +144,18 @@ fn durable_id() {
 }
 
 #[test]
+fn durable_alarm() {
+    let body = get("durable/alarm", |r| r).text().unwrap();
+    assert!(body.contains("self.count: 10"));
+
+    // Sleep for 750 milliseconds to make sure the alarm is triggered.
+    std::thread::sleep(std::time::Duration::from_millis(750));
+
+    let body = get("durable/alarm", |r| r).text().unwrap();
+    assert!(body.contains("self.count: 42"));
+}
+
+#[test]
 fn some_secret() {
     let body = get("secret", |r| r).text().unwrap();
     assert_eq!(body, "secret!");

--- a/worker-sandbox/tests/requests.rs
+++ b/worker-sandbox/tests/requests.rs
@@ -146,13 +146,13 @@ fn durable_id() {
 #[test]
 fn durable_alarm() {
     let body = get("durable/alarm", |r| r).text().unwrap();
-    assert!(body.contains("self.count: 10"));
+    assert_eq!(body, "false");
 
-    // Sleep for 750 milliseconds to make sure the alarm is triggered.
-    std::thread::sleep(std::time::Duration::from_millis(750));
+    // Sleep for 200 milliseconds to make sure the alarm is triggered.
+    std::thread::sleep(std::time::Duration::from_millis(200));
 
     let body = get("durable/alarm", |r| r).text().unwrap();
-    assert!(body.contains("self.count: 42"));
+    assert_eq!(body, "true");
 }
 
 #[test]

--- a/worker-sandbox/wrangler.toml
+++ b/worker-sandbox/wrangler.toml
@@ -4,8 +4,8 @@ workers_dev = true
 compatibility_date = "2021-11-27" # required
 
 kv_namespaces = [
-    { binding = "SOME_NAMESPACE", id = "A", preview_id = "B" },
-    { binding = "FILE_SIZES", id = "C", preview_id = "D" },
+    { binding = "SOME_NAMESPACE", id = "", preview_id = "" },
+    { binding = "FILE_SIZES", id = "", preview_id = "" },
 ]
 
 vars = { SOME_VARIABLE = "some value" }

--- a/worker-sandbox/wrangler.toml
+++ b/worker-sandbox/wrangler.toml
@@ -4,8 +4,8 @@ workers_dev = true
 compatibility_date = "2021-11-27" # required
 
 kv_namespaces = [
-    { binding = "SOME_NAMESPACE", id = "", preview_id = "" },
-    { binding = "FILE_SIZES", id = "", preview_id = "" },
+    { binding = "SOME_NAMESPACE", id = "A", preview_id = "B" },
+    { binding = "FILE_SIZES", id = "C", preview_id = "D" },
 ]
 
 vars = { SOME_VARIABLE = "some value" }

--- a/worker-sandbox/wrangler.toml
+++ b/worker-sandbox/wrangler.toml
@@ -11,7 +11,7 @@ kv_namespaces = [
 vars = { SOME_VARIABLE = "some value" }
 
 [durable_objects]
-bindings = [{ name = "COUNTER", class_name = "Counter" }]
+bindings = [{ name = "COUNTER", class_name = "Counter" }, { name = "ALARM", class_name = "AlarmObject" }]
 
 [build]
 command = "worker-build --release"

--- a/worker-sys/src/cache.rs
+++ b/worker-sys/src/cache.rs
@@ -6,7 +6,7 @@ use crate::{Request, Response};
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(extends = ::js_sys::Object, js_name = Cache)]
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Cache;
 
     #[wasm_bindgen(structural, method, js_class=Cache, js_name = put)]

--- a/worker-sys/src/durable_object.rs
+++ b/worker-sys/src/durable_object.rs
@@ -115,6 +115,18 @@ extern "C" {
         this: &ObjectStorage,
         closure: &Closure<dyn FnMut(ObjectTransaction)>,
     ) -> StdResult<::js_sys::Promise, JsValue>;
+
+    #[wasm_bindgen(catch, method, js_class = "DurableObjectStorage", js_name = getAlarm)]
+    pub fn get_alarm_internal(this: &ObjectStorage) -> StdResult<::js_sys::Promise, JsValue>;
+
+    #[wasm_bindgen(catch, method, js_class = "DurableObjectStorage", js_name = setAlarm)]
+    pub fn set_alarm_internal(
+        this: &ObjectStorage,
+        scheduled_time: js_sys::Date,
+    ) -> StdResult<::js_sys::Promise, JsValue>;
+
+    #[wasm_bindgen(catch, method, js_class = "DurableObjectStorage", js_name = deleteAlarm)]
+    pub fn delete_alarm_internal(this: &ObjectStorage) -> StdResult<::js_sys::Promise, JsValue>;
 }
 
 #[wasm_bindgen]

--- a/worker-sys/src/durable_object.rs
+++ b/worker-sys/src/durable_object.rs
@@ -117,16 +117,23 @@ extern "C" {
     ) -> StdResult<::js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(catch, method, js_class = "DurableObjectStorage", js_name = getAlarm)]
-    pub fn get_alarm_internal(this: &ObjectStorage) -> StdResult<::js_sys::Promise, JsValue>;
+    pub fn get_alarm_internal(
+        this: &ObjectStorage,
+        options: ::js_sys::Object,
+    ) -> StdResult<::js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(catch, method, js_class = "DurableObjectStorage", js_name = setAlarm)]
     pub fn set_alarm_internal(
         this: &ObjectStorage,
-        scheduled_time: js_sys::Date,
+        scheduled_time: ::js_sys::Date,
+        options: ::js_sys::Object,
     ) -> StdResult<::js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(catch, method, js_class = "DurableObjectStorage", js_name = deleteAlarm)]
-    pub fn delete_alarm_internal(this: &ObjectStorage) -> StdResult<::js_sys::Promise, JsValue>;
+    pub fn delete_alarm_internal(
+        this: &ObjectStorage,
+        options: ::js_sys::Object,
+    ) -> StdResult<::js_sys::Promise, JsValue>;
 }
 
 #[wasm_bindgen]

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -20,7 +20,7 @@ futures-util = { version = "0.3.21", default-features = false }
 http = "0.2.8"
 js-sys = "0.3.57"
 matchit = "0.4.2"
-pin-project = "1.0.10"
+pin-project = "1.0.12"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 url = "2.2.2"

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -565,7 +565,7 @@ impl<'a> ListOptions<'a> {
 }
 
 /// Determines when a Durable Object alarm should be ran, based on a timestamp or with a delay.
-/// 
+///
 /// Implements [From] for [Duration], [DateTime], and [i64].
 pub struct ScheduledTime {
     date: js_sys::Date,

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -564,6 +564,9 @@ impl<'a> ListOptions<'a> {
     }
 }
 
+/// Determines when a Durable Object alarm should be ran, based on a timestamp or with a delay.
+/// 
+/// Implements [From] for [Duration], [DateTime], and [i64].
 pub struct ScheduledTime {
     date: js_sys::Date,
 }
@@ -598,18 +601,18 @@ impl From<Duration> for ScheduledTime {
     }
 }
 
-#[derive(Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct GetAlarmOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
-    allow_concurrency: Option<bool>,
+    pub allow_concurrency: Option<bool>,
 }
 
-#[derive(Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct SetAlarmOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
-    allow_concurrency: Option<bool>,
+    pub allow_concurrency: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    allow_unconfirmed: Option<bool>,
+    pub allow_unconfirmed: Option<bool>,
 }
 
 impl EnvBinding for ObjectNamespace {

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -10,7 +10,7 @@
 //! [Learn more](https://developers.cloudflare.com/workers/learning/using-durable-objects) about
 //! using Durable Objects.
 
-use std::ops::Deref;
+use std::{ops::Deref, time::Duration};
 
 use crate::{
     env::{Env, EnvBinding},
@@ -575,9 +575,9 @@ impl ScheduledTime {
 }
 
 impl From<i64> for ScheduledTime {
-    fn from(timestamp: i64) -> Self {
+    fn from(offset: i64) -> Self {
         ScheduledTime {
-            date: js_sys::Date::new(&Number::from(timestamp as f64)),
+            date: js_sys::Date::new(&Number::from(offset as f64)),
         }
     }
 }
@@ -586,6 +586,14 @@ impl From<DateTime<Utc>> for ScheduledTime {
     fn from(date: DateTime<Utc>) -> Self {
         ScheduledTime {
             date: js_sys::Date::new(&Number::from(date.timestamp_millis() as f64)),
+        }
+    }
+}
+
+impl From<Duration> for ScheduledTime {
+    fn from(offset: Duration) -> Self {
+        ScheduledTime {
+            date: js_sys::Date::new(&Number::from(offset.as_millis() as f64)),
         }
     }
 }

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -63,7 +63,7 @@ impl TryFrom<&Request> for EdgeRequest {
 impl Request {
     /// Construct a new `Request` with an HTTP Method.
     pub fn new(uri: &str, method: Method) -> Result<Self> {
-        EdgeRequest::new_with_str_and_init(uri, EdgeRequestInit::new().method(&method.to_string()))
+        EdgeRequest::new_with_str_and_init(uri, EdgeRequestInit::new().method(method.as_ref()))
             .map(|req| {
                 let mut req: Request = req.into();
                 req.immutable = false;

--- a/worker/src/request_init.rs
+++ b/worker/src/request_init.rs
@@ -58,7 +58,7 @@ impl From<&RequestInit> for worker_sys::RequestInit {
     fn from(req: &RequestInit) -> Self {
         let mut inner = worker_sys::RequestInit::new();
         inner.headers(req.headers.as_ref());
-        inner.method(&req.method.to_string());
+        inner.method(req.method.as_ref());
         inner.redirect(req.redirect.into());
         inner.body(req.body.as_ref());
 


### PR DESCRIPTION
This PR implements the DO Alarm API based off of the signatures found in the [storage docs](https://developers.cloudflare.com/workers/runtime-apis/durable-objects/#methods).

I think there's a bug in the way I've implemented the binding for `getAlarm`. When an alarm does not exist, I expect `getAlarm` to return `null` and in rust `Ok(None)`, however I seem to be getting an error instead. When the alarm does exist (`set_alarm` immediately followed by a `get_alarm`) I get the expected output.

I haven't been able to test that the alarm does trigger, however everything compiles and it looks like the generated shim has the required methods. I'll be testing later tonight.

Also, I have `set_alarm` take in a `DateTime<Utc>` whereas `get_alarm` returns an `i64`. 
* Thoughts on having both a `set_alarm` and `set_alarm_datetime`? 
* Should there also be a `get_alarm_datetime` for convenience? 
* Should we have inputs and outputs just be `DateTime<Utc>`s?