### PR TITLE
Deps: remove usage of full `futures` in `worker-sandbox`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,21 +554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "futures"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,17 +568,6 @@ name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -630,7 +604,6 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -3542,7 +3515,8 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "console_error_panic_hook",
- "futures",
+ "futures-channel",
+ "futures-util",
  "getrandom",
  "hex",
  "http",

--- a/worker-sandbox/Cargo.toml
+++ b/worker-sandbox/Cargo.toml
@@ -28,11 +28,13 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 wee_alloc = { version = "0.4.5", optional = true }
 worker = { path = "../worker", version = "0.0.9" }
-futures = "0.3.21"
+futures-channel = "0.3.21"
+futures-util = { version = "0.3.21", default-features = false }
 rand = "0.8.5"
 
 [dev-dependencies]
-futures = "0.3.21"
+futures-channel = { version = "0.3.21", features = ["sink"] }
+futures-util = { version = "0.3.21", default-features = false, features = ["sink"] }
 reqwest = { version = "0.11.10", features = [
     "blocking",
     "json",

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use blake2::{Blake2b512, Digest};
-use futures::{future::Either, StreamExt, TryStreamExt};
+use futures_util::{future::Either, StreamExt, TryStreamExt};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use worker::*;
@@ -430,7 +430,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
             let controller = AbortController::default();
             let signal = controller.signal();
 
-            let (tx, rx) = futures::channel::oneshot::channel();
+            let (tx, rx) = futures_channel::oneshot::channel();
 
             // Spawns a future that'll make our fetch request and not block this function.
             wasm_bindgen_futures::spawn_local({
@@ -467,10 +467,10 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
                 Response::ok("Cancelled")
             };
 
-            futures::pin_mut!(fetch_fut);
-            futures::pin_mut!(delay_fut);
+            futures_util::pin_mut!(fetch_fut);
+            futures_util::pin_mut!(delay_fut);
 
-            match futures::future::select(delay_fut, fetch_fut).await {
+            match futures_util::future::select(delay_fut, fetch_fut).await {
                 Either::Left((res, cancelled_fut)) => {
                     // Ensure that the cancelled future returns an AbortError.
                     match cancelled_fut.await {
@@ -505,7 +505,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
             Response::ok((left == right).to_string())
         })
         .get_async("/cloned-stream", |_, _| async {
-            let stream = futures::stream::repeat(())
+            let stream = futures_util::stream::repeat(())
                 .take(10)
                 .enumerate()
                 .then(|(index, _)| async move {
@@ -618,7 +618,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
                 console_log!("Cache MISS!");
                 let mut rng = rand::thread_rng();
                 let count = rng.gen_range(0..10);
-                let stream = futures::stream::repeat("Hello, world!\n")
+                let stream = futures_util::stream::repeat("Hello, world!\n")
                     .take(count)
                     .then(|text| async move {
                         Delay::from(Duration::from_millis(50)).await;

--- a/worker-sandbox/tests/requests.rs
+++ b/worker-sandbox/tests/requests.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
-use futures::{channel::mpsc, SinkExt, StreamExt};
+use futures_channel::mpsc;
+use futures_util::{SinkExt, StreamExt};
 use http::StatusCode;
 use reqwest::{
     blocking::{


### PR DESCRIPTION
As a continuation of the work in #188, it occurred to me that I actually forgot to work on `worker-sandbox`. Thus, I have not _actually_ removed the `futures` crate from `Cargo.lock` _yet_. This PR resolves this issue.

Thanks! 🎉