### PR TITLE
fix: export Var and Secret

### DIFF
--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::cors::Cors;
 pub use crate::date::{Date, DateInit};
 pub use crate::delay::Delay;
 pub use crate::durable::*;
-pub use crate::env::Env;
+pub use crate::env::{Env, Secret, Var};
 pub use crate::error::Error;
 pub use crate::formdata::*;
 pub use crate::global::Fetch;


### PR DESCRIPTION
Previously these could be obtained via return types but the the actual type was not exported by the crate, making it impossible to use in a case where you need static typing.

Fixes #192