### PR TITLE
Add Service Bindings support

### DIFF
--- a/worker-sys/src/lib.rs
+++ b/worker-sys/src/lib.rs
@@ -16,6 +16,7 @@ pub mod request_init;
 pub mod response;
 pub mod response_init;
 pub mod schedule;
+pub mod service;
 pub mod websocket;
 
 /// When debugging your Worker via `wrangler dev`, `wrangler tail`, or from the Workers Dashboard,
@@ -76,5 +77,6 @@ pub use request_init::*;
 pub use response::Response;
 pub use response_init::ResponseInit;
 pub use schedule::*;
+pub use service::*;
 pub use web_sys::{CloseEvent, ErrorEvent, MessageEvent};
 pub use websocket::*;

--- a/worker-sys/src/service.rs
+++ b/worker-sys/src/service.rs
@@ -1,0 +1,14 @@
+use crate::Request;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen (extends = ::js_sys::Object, js_name = Fetcher)]
+    pub type Service;
+
+    #[wasm_bindgen (method, js_class = "Fetcher", js_name = fetch)]
+    pub fn fetch_with_request(this: &Service, req: &Request) -> ::js_sys::Promise;
+
+    #[wasm_bindgen (method, js_class = "Fetcher", js_name = fetch)]
+    pub fn fetch_with_url(this: &Service, url: &str) -> ::js_sys::Promise;
+}

--- a/worker/src/env.rs
+++ b/worker/src/env.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use crate::service::Service;
 use crate::Result;
 use crate::{durable::ObjectNamespace, DynamicDispatcher};
 
@@ -49,6 +50,10 @@ impl Env {
 
     /// Access a Dynamic Dispatcher for dispatching events to other workers.
     pub fn dynamic_dispatcher(&self, binding: &str) -> Result<DynamicDispatcher> {
+        self.get_binding(binding)
+    }
+
+    pub fn service(&self, binding: &str) -> Result<Service> {
         self.get_binding(binding)
     }
 }

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -65,6 +65,7 @@ mod request_init;
 mod response;
 mod router;
 mod schedule;
+mod service;
 mod streams;
 mod websocket;
 

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -10,6 +10,7 @@ use crate::{
     http::Method,
     request::Request,
     response::Response,
+    service::Service,
     Result,
 };
 
@@ -93,6 +94,10 @@ impl<D> RouteContext<D> {
     /// Get a URL parameter parsed by the router, by the name of its match or wildecard placeholder.
     pub fn param(&self, key: &str) -> Option<&String> {
         self.params.get(key)
+    }
+
+    pub fn service(&self, binding: &str) -> Result<Service> {
+        self.env.service(binding)
     }
 }
 

--- a/worker/src/service.rs
+++ b/worker/src/service.rs
@@ -1,0 +1,58 @@
+use js_sys::Promise;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+
+use crate::{env::EnvBinding, Request, Response, Result};
+
+pub struct Service {
+    service: worker_sys::Service,
+}
+
+async fn as_response(promise: Promise) -> Result<Response> {
+    let response = JsFuture::from(promise).await?;
+    Ok(response.dyn_into::<worker_sys::Response>()?.into())
+}
+
+impl Service {
+    pub async fn fetch_with_request(&self, req: Request) -> Result<Response> {
+        let promise = self.service.fetch_with_request(req.inner());
+        as_response(promise).await
+    }
+
+    pub async fn fetch_with_url(&self, url: &str) -> Result<Response> {
+        let promise = self.service.fetch_with_url(url);
+        as_response(promise).await
+    }
+}
+
+impl JsCast for Service {
+    fn instanceof(val: &wasm_bindgen::JsValue) -> bool {
+        val.is_instance_of::<Service>()
+    }
+
+    fn unchecked_from_js(val: wasm_bindgen::JsValue) -> Self {
+        Self {
+            service: val.into(),
+        }
+    }
+
+    fn unchecked_from_js_ref(val: &wasm_bindgen::JsValue) -> &Self {
+        unsafe { &*(val as *const JsValue as *const Self) }
+    }
+}
+
+impl From<Service> for JsValue {
+    fn from(service: Service) -> Self {
+        JsValue::from(service.service)
+    }
+}
+
+impl AsRef<wasm_bindgen::JsValue> for Service {
+    fn as_ref(&self) -> &wasm_bindgen::JsValue {
+        &self.service
+    }
+}
+
+impl EnvBinding for Service {
+    const TYPE_NAME: &'static str = "Fetcher";
+}


### PR DESCRIPTION
CloudFlare Workers Service Bindings:
https://developers.cloudflare.com/workers/platform/bindings/about-service-bindings/

Inspiration:
https://github.com/cloudflare/workers-rs/pull/183

This implementation was verified to work against live CloudFlare workers.
