### PR TITLE
Add support for isEUCountry binding

### DIFF
--- a/worker-sys/src/cf.rs
+++ b/worker-sys/src/cf.rs
@@ -56,6 +56,9 @@ extern "C" {
 
     #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=timezone)]
     pub fn timezone(this: &Cf) -> String;
+
+    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=isEUCountry)]
+    pub fn is_eu_country(this: &Cf) -> Option<String>;
 }
 
 #[wasm_bindgen]

--- a/worker/src/cf.rs
+++ b/worker/src/cf.rs
@@ -140,6 +140,11 @@ impl Cf {
         let tz = self.inner.timezone();
         tz.parse::<chrono_tz::Tz>().unwrap()
     }
+
+    /// Whether the country of the incoming request is in the EU
+    pub fn is_eu_country(&self) -> bool {
+        self.inner.is_eu_country() == Some("1".to_string())
+    }
 }
 
 /// Browser-requested prioritization information.


### PR DESCRIPTION
Makes the `isEUCountry` binding available in Rust.

Docs: https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties

See also: https://github.com/cloudflare/workers-types/pull/245 for the TypeScript analogue.