### PR TITLE
Add support for multipart uploads to the R2 bindings

### DIFF
--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -699,6 +699,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         .get_async("/r2/get", r2::get)
         .put_async("/r2/put", r2::put)
         .put_async("/r2/put-properties", r2::put_properties)
+        .put_async("/r2/put-multipart", r2::put_multipart)
         .delete_async("/r2/delete", r2::delete)
         .or_else_any_method_async("/*catchall", |_, ctx| async move {
             console_log!(

--- a/worker-sys/src/r2.rs
+++ b/worker-sys/src/r2.rs
@@ -21,6 +21,14 @@ extern "C" {
     pub fn delete(this: &R2Bucket, key: String) -> ::js_sys::Promise;
     #[wasm_bindgen(structural, method, js_class=R2Bucket, js_name = list)]
     pub fn list(this: &R2Bucket, options: JsValue) -> ::js_sys::Promise;
+    #[wasm_bindgen(structural, method, js_class=R2Bucket, js_name = createMultipartUpload)]
+    pub fn create_multipart_upload(
+        this: &R2Bucket,
+        key: String,
+        options: JsValue,
+    ) -> ::js_sys::Promise;
+    #[wasm_bindgen(structural, method, js_class=R2Bucket, js_name = resumeMultipartUpload)]
+    pub fn resume_multipart_upload(this: &R2Bucket, key: String, upload_id: String) -> JsValue;
 }
 
 #[wasm_bindgen]
@@ -61,6 +69,40 @@ extern "C" {
     pub fn body(this: &R2ObjectBody) -> ReadableStream;
     #[wasm_bindgen(structural, method, getter, js_class=R2ObjectBody, js_name = bodyUsed)]
     pub fn body_used(this: &R2ObjectBody) -> bool;
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends=::js_sys::Object, js_name=R2UploadedPart)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub type R2UploadedPart;
+
+    #[wasm_bindgen(structural, method, getter, js_class=R2UploadedPart, js_name = partNumber)]
+    pub fn part_number(this: &R2UploadedPart) -> u16;
+    #[wasm_bindgen(structural, method, getter, js_class=R2UploadedPart, js_name = etag)]
+    pub fn etag(this: &R2UploadedPart) -> String;
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends=::js_sys::Object, js_name=R2MultipartUpload)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub type R2MultipartUpload;
+
+    #[wasm_bindgen(structural, method, getter, js_class=R2MultipartUpload, js_name = key)]
+    pub fn key(this: &R2MultipartUpload) -> String;
+    #[wasm_bindgen(structural, method, getter, js_class=R2MultipartUpload, js_name = uploadId)]
+    pub fn upload_id(this: &R2MultipartUpload) -> String;
+    #[wasm_bindgen(structural, method, js_class=R2MultipartUpload, js_name = uploadPart)]
+    pub fn upload_part(
+        this: &R2MultipartUpload,
+        part_number: u16,
+        value: JsValue,
+    ) -> ::js_sys::Promise;
+    #[wasm_bindgen(structural, method, js_class=R2MultipartUpload, js_name = abort)]
+    pub fn abort(this: &R2MultipartUpload) -> ::js_sys::Promise;
+    #[wasm_bindgen(structural, method, js_class=R2MultipartUpload, js_name = complete)]
+    pub fn complete(this: &R2MultipartUpload, uploaded_parts: Vec<JsValue>) -> ::js_sys::Promise;
 }
 
 #[wasm_bindgen]

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -358,11 +358,15 @@ impl MultipartUpload {
     /// When the future is ready, the object is immediately accessible globally by any subsequent read operation.
     pub async fn complete(
         self,
-        uploaded_parts: impl Iterator<Item = UploadedPart>,
+        uploaded_parts: impl IntoIterator<Item = UploadedPart>,
     ) -> Result<Object> {
         let object = JsFuture::from(
-            self.inner
-                .complete(uploaded_parts.map(|part| part.inner.into()).collect()),
+            self.inner.complete(
+                uploaded_parts
+                    .into_iter()
+                    .map(|part| part.inner.into())
+                    .collect(),
+            ),
         )
         .await?;
         Ok(Object {


### PR DESCRIPTION
This extends the [recently implemented R2 bindings](https://github.com/cloudflare/workers-rs/pull/215) with support for [multipart upload](https://developers.cloudflare.com/r2/data-access/workers-api/workers-api-reference/#r2multipartupload-definition).