### PR TITLE
Allow cloned Requests to be mutable

### DIFF
--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -237,7 +237,11 @@ impl Request {
     pub fn clone(&self) -> Result<Self> {
         self.edge_request
             .clone()
-            .map(|req| req.into())
+            .map(|req| {
+                let mut req: Request = req.into();
+                req.immutable = false;
+                req
+            })
             .map_err(Error::from)
     }
 

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -301,7 +301,11 @@ fn url_param_works() {
 
 #[test]
 fn clone_mut_works() {
-    let req = Request::new("https://example.com/foo.html?a=foo&b=bar&a=baz", crate::Method::Get).unwrap();
+    let req = Request::new(
+        "https://example.com/foo.html?a=foo&b=bar&a=baz",
+        crate::Method::Get,
+    )
+    .unwrap();
     assert_eq!(req.immutable, false);
     let mut_req = req.clone_mut().unwrap();
     assert_eq!(mut_req.immutable, true);

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -306,7 +306,7 @@ fn clone_mut_works() {
         crate::Method::Get,
     )
     .unwrap();
-    assert_eq!(req.immutable, false);
+    assert!(!req.immutable);
     let mut_req = req.clone_mut().unwrap();
-    assert_eq!(mut_req.immutable, true);
+    assert!(mut_req.immutable);
 }

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -237,6 +237,13 @@ impl Request {
     pub fn clone(&self) -> Result<Self> {
         self.edge_request
             .clone()
+            .map(|req| req.into())
+            .map_err(Error::from)
+    }
+
+    pub fn clone_mut(&self) -> Result<Self> {
+        self.edge_request
+            .clone()
             .map(|req| {
                 let mut req: Request = req.into();
                 req.immutable = false;

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -242,14 +242,9 @@ impl Request {
     }
 
     pub fn clone_mut(&self) -> Result<Self> {
-        self.edge_request
-            .clone()
-            .map(|req| {
-                let mut req: Request = req.into();
-                req.immutable = false;
-                req
-            })
-            .map_err(Error::from)
+        let mut req: Request = EdgeRequest::new_with_request(&self.edge_request)?.into();
+        req.immutable = false;
+        Ok(req)
     }
 
     pub fn inner(&self) -> &EdgeRequest {
@@ -302,4 +297,12 @@ fn url_param_works() {
     assert_eq!(a_values.next().as_deref(), Some("foo"));
     assert_eq!(a_values.next().as_deref(), Some("baz"));
     assert_eq!(a_values.next(), None);
+}
+
+#[test]
+fn clone_mut_works() {
+    let req = Request::new("https://example.com/foo.html?a=foo&b=bar&a=baz", crate::Method::Get).unwrap();
+    assert_eq!(req.immutable, false);
+    let mut_req = req.clone_mut().unwrap();
+    assert_eq!(mut_req.immutable, true);
 }


### PR DESCRIPTION
Fixes #263 by setting `immutable` to false when a `Request` is cloned, bringing it in line with the JS implementation.