### PR TITLE
fix: Use range to calculate capacity of Vec in ObjectBody::bytes

### DIFF
--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -257,7 +257,8 @@ impl<'body> ObjectBody<'body> {
             .length
             .or(range.suffix)
             .or(range.offset.map(|offset| size - offset))
-            .unwrap_or(size) as usize;
+            .unwrap_or(size)
+            .min(size) as usize;
 
         let mut bytes = Vec::with_capacity(capacity);
         let mut stream = self.stream()?;

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -256,7 +256,7 @@ impl<'body> ObjectBody<'body> {
         let capacity = range
             .length
             .or(range.suffix)
-            .or(range.offset.and_then(|offset| Some(size - offset)))
+            .or(range.offset.map(|offset| size - offset))
             .unwrap_or(size) as usize;
 
         let mut bytes = Vec::with_capacity(capacity);


### PR DESCRIPTION
This PR fixes #269 