### PR TITLE
chore: fix new clippy lints

### DIFF
--- a/worker-build/src/main.rs
+++ b/worker-build/src/main.rs
@@ -152,7 +152,7 @@ fn remove_unused_js() -> Result<()> {
     }
 
     for to_remove in [
-        format!("{}_bg.js", OUT_NAME),
+        format!("{OUT_NAME}_bg.js"),
         "shim.js".into(),
         "glue.js".into(),
     ] {

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -290,7 +290,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         })
         .get("/user/:id/test", |_req, ctx| {
             if let Some(id) = ctx.param("id") {
-                return Response::ok(format!("TEST user id: {}", id));
+                return Response::ok(format!("TEST user id: {id}"));
             }
 
             Response::error("Error", 500)
@@ -594,7 +594,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         .get_async("/cache-api/get/:key", |_req, ctx| async move {
             if let Some(key) = ctx.param("key") {
                 let cache = Cache::default();
-                if let Some(resp) = cache.get(format!("https://{}", key), true).await? {
+                if let Some(resp) = cache.get(format!("https://{key}"), true).await? {
                     return Ok(resp);
                 } else {
                     return Response::ok("cache miss");
@@ -611,7 +611,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
                 // Cache API respects Cache-Control headers. Setting s-max-age to 10
                 // will limit the response to be in cache for 10 seconds max
                 resp.headers_mut().set("cache-control", "s-maxage=10")?;
-                cache.put(format!("https://{}", key), resp.cloned()?).await?;
+                cache.put(format!("https://{key}"), resp.cloned()?).await?;
                 return Ok(resp);
             }
             Response::error("key missing", 400)
@@ -620,7 +620,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
             if let Some(key) = ctx.param("key") {
                 let cache = Cache::default();
 
-                let res = cache.delete(format!("https://{}", key), true).await?;
+                let res = cache.delete(format!("https://{key}"), true).await?;
                 return Response::ok(serde_json::to_string(&res)?);
             }
             Response::error("key missing", 400)

--- a/worker-sandbox/src/test/export_durable_object.rs
+++ b/worker-sandbox/src/test/export_durable_object.rs
@@ -43,7 +43,7 @@ impl DurableObject for MyClass {
 
                     ensure!(
                         keys == vec!["anything", "array", "map"],
-                        format!("Didn't list all of the keys: {:?}", keys)
+                        format!("Didn't list all of the keys: {keys:?}")
                     );
                     let vals = storage
                         .get_multiple(keys)

--- a/worker-sandbox/tests/requests.rs
+++ b/worker-sandbox/tests/requests.rs
@@ -441,9 +441,9 @@ fn cache_stream() {
 #[test]
 fn cache_api() {
     let key = "example.org";
-    let get_endpoint = format!("cache-api/get/{}", key);
-    let put_endpoint = format!("cache-api/put/{}", key);
-    let delete_endpoint = format!("cache-api/delete/{}", key);
+    let get_endpoint = format!("cache-api/get/{key}");
+    let put_endpoint = format!("cache-api/put/{key}");
+    let delete_endpoint = format!("cache-api/delete/{key}");
 
     // First time should result in cache miss
     let body = get(get_endpoint.as_str(), |r| r).text().unwrap();

--- a/worker/src/cors.rs
+++ b/worker/src/cors.rs
@@ -88,7 +88,7 @@ impl Cors {
             headers.set("Access-Control-Allow-Credentials", "true")?;
         }
         if let Some(ref max_age) = self.max_age {
-            headers.set("Access-Control-Max-Age", format!("{}", max_age).as_str())?;
+            headers.set("Access-Control-Max-Age", format!("{max_age}").as_str())?;
         }
         if !self.origins.is_empty() {
             headers.set(

--- a/worker/src/env.rs
+++ b/worker/src/env.rs
@@ -16,9 +16,9 @@ extern "C" {
 impl Env {
     fn get_binding<T: EnvBinding>(&self, name: &str) -> Result<T> {
         let binding = js_sys::Reflect::get(self, &JsValue::from(name))
-            .map_err(|_| Error::JsError(format!("Env does not contain binding `{}`", name)))?;
+            .map_err(|_| Error::JsError(format!("Env does not contain binding `{name}`")))?;
         if binding.is_undefined() {
-            Err(format!("Binding `{}` is undefined.", name).into())
+            Err(format!("Binding `{name}` is undefined.").into())
         } else {
             // Can't just use JsCast::dyn_into here because the type name might not be in scope
             // resulting in a terribly annoying javascript error which can't be caught

--- a/worker/src/error.rs
+++ b/worker/src/error.rs
@@ -43,17 +43,17 @@ impl std::fmt::Display for Error {
         match self {
             Error::BadEncoding => write!(f, "content-type mismatch"),
             Error::BodyUsed => write!(f, "body has already been read"),
-            Error::Json((msg, status)) => write!(f, "{} (status: {})", msg, status),
+            Error::Json((msg, status)) => write!(f, "{msg} (status: {status})"),
             Error::JsError(s) | Error::RustError(s) => {
-                write!(f, "{}", s)
+                write!(f, "{s}")
             }
             Error::Internal(_) => write!(f, "unrecognized JavaScript object"),
-            Error::BindingError(name) => write!(f, "no binding found for `{}`", name),
-            Error::RouteInsertError(e) => write!(f, "failed to insert route: {}", e),
+            Error::BindingError(name) => write!(f, "no binding found for `{name}`"),
+            Error::RouteInsertError(e) => write!(f, "failed to insert route: {e}"),
             Error::RouteNoDataError => write!(f, "route has no corresponding shared data"),
-            Error::SerdeJsonError(e) => write!(f, "Serde Error: {}", e),
+            Error::SerdeJsonError(e) => write!(f, "Serde Error: {e}"),
             #[cfg(feature = "queue")]
-            Error::SerdeWasmBindgenError(e) => write!(f, "Serde Error: {}", e),
+            Error::SerdeWasmBindgenError(e) => write!(f, "Serde Error: {e}"),
         }
     }
 }

--- a/worker/src/headers.rs
+++ b/worker/src/headers.rs
@@ -19,7 +19,7 @@ impl std::fmt::Debug for Headers {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("Headers {\n")?;
         for (k, v) in self.entries() {
-            f.write_str(&format!("{} = {}\n", k, v))?;
+            f.write_str(&format!("{k} = {v}\n"))?;
         }
         f.write_str("}\n")
     }

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -230,7 +230,7 @@ impl Request {
     pub fn url(&self) -> Result<Url> {
         let url = self.edge_request.url();
         url.parse()
-            .map_err(|e| Error::RustError(format!("failed to parse Url from {}: {}", e, url)))
+            .map_err(|e| Error::RustError(format!("failed to parse Url from {e}: {url}")))
     }
 
     #[allow(clippy::should_implement_trait)]


### PR DESCRIPTION
Recently clippy added a lint requiring the new format syntax, causing all CI runs to fail.