### PR TITLE
Clean up wasmbindgen macro usage

### DIFF
--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -474,7 +474,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
             let signal = controller.signal();
 
             let fetch_fut = async {
-                let fetch = Fetch::Url("http://localhost:8787/wait/2000".parse().unwrap());
+                let fetch = Fetch::Url("http://localhost:8787/wait/10000".parse().unwrap());
                 let mut res = fetch.send_with_signal(&signal).await?;
                 let text = res.text().await?;
                 Ok::<String, worker::Error>(text)

--- a/worker-sys/src/ext/abort_controller.rs
+++ b/worker-sys/src/ext/abort_controller.rs
@@ -5,21 +5,21 @@ mod glue {
 
     #[wasm_bindgen]
     extern "C" {
-        #[wasm_bindgen(js_name=AbortController)]
-        pub type AbortControllerExt;
+        #[wasm_bindgen]
+        pub type AbortController;
 
-        #[wasm_bindgen(method, structural, js_class=AbortController, js_name=abort)]
-        pub fn abort_with_reason(this: &AbortControllerExt, reason: JsValue);
+        #[wasm_bindgen(method, js_name=abort)]
+        pub fn abort_with_reason(this: &AbortController, reason: &JsValue);
     }
 }
 
 pub trait AbortControllerExt {
-    fn abort_with_reason(&self, reason: JsValue);
+    fn abort_with_reason(&self, reason: &JsValue);
 }
 
 impl AbortControllerExt for web_sys::AbortController {
-    fn abort_with_reason(&self, reason: JsValue) {
-        self.unchecked_ref::<glue::AbortControllerExt>()
+    fn abort_with_reason(&self, reason: &JsValue) {
+        self.unchecked_ref::<glue::AbortController>()
             .abort_with_reason(reason)
     }
 }

--- a/worker-sys/src/ext/abort_signal.rs
+++ b/worker-sys/src/ext/abort_signal.rs
@@ -5,29 +5,38 @@ mod glue {
 
     #[wasm_bindgen]
     extern "C" {
-        #[wasm_bindgen(js_name=AbortSignal)]
-        pub type AbortSignalExt;
+        #[wasm_bindgen]
+        pub type AbortSignal;
 
-        #[wasm_bindgen(structural, method, getter, js_class=AbortSignal, js_name=reason)]
-        pub fn reason(this: &AbortSignalExt) -> JsValue;
+        #[wasm_bindgen(method, getter)]
+        pub fn reason(this: &AbortSignal) -> JsValue;
 
-        #[wasm_bindgen(static_method_of=AbortSignalExt, js_name=abort)]
-        pub fn abort(reason: JsValue) -> web_sys::AbortSignal;
+        #[wasm_bindgen(static_method_of=AbortSignal)]
+        pub fn abort() -> web_sys::AbortSignal;
+
+        #[wasm_bindgen(static_method_of=AbortSignal, js_name=abort)]
+        pub fn abort_with_reason(reason: &JsValue) -> web_sys::AbortSignal;
     }
 }
 
 pub trait AbortSignalExt {
     fn reason(&self) -> JsValue;
 
-    fn abort(reason: JsValue) -> web_sys::AbortSignal;
+    fn abort() -> web_sys::AbortSignal;
+
+    fn abort_with_reason(reason: &JsValue) -> web_sys::AbortSignal;
 }
 
 impl AbortSignalExt for web_sys::AbortSignal {
     fn reason(&self) -> JsValue {
-        self.unchecked_ref::<glue::AbortSignalExt>().reason()
+        self.unchecked_ref::<glue::AbortSignal>().reason()
     }
 
-    fn abort(reason: JsValue) -> web_sys::AbortSignal {
-        glue::AbortSignalExt::abort(reason)
+    fn abort() -> web_sys::AbortSignal {
+        glue::AbortSignal::abort()
+    }
+
+    fn abort_with_reason(reason: &JsValue) -> web_sys::AbortSignal {
+        glue::AbortSignal::abort_with_reason(reason)
     }
 }

--- a/worker-sys/src/ext/cache_storage.rs
+++ b/worker-sys/src/ext/cache_storage.rs
@@ -5,11 +5,11 @@ mod glue {
 
     #[wasm_bindgen]
     extern "C" {
-        #[wasm_bindgen(js_name=CacheStorage)]
-        pub type CacheStorageExt;
+        #[wasm_bindgen]
+        pub type CacheStorage;
 
-        #[wasm_bindgen(method, structural, getter, js_class=CacheStorage)]
-        pub fn default(this: &CacheStorageExt) -> web_sys::Cache;
+        #[wasm_bindgen(method, getter)]
+        pub fn default(this: &CacheStorage) -> web_sys::Cache;
     }
 }
 
@@ -19,6 +19,6 @@ pub trait CacheStorageExt {
 
 impl CacheStorageExt for web_sys::CacheStorage {
     fn default(&self) -> web_sys::Cache {
-        self.unchecked_ref::<glue::CacheStorageExt>().default()
+        self.unchecked_ref::<glue::CacheStorage>().default()
     }
 }

--- a/worker-sys/src/ext/headers.rs
+++ b/worker-sys/src/ext/headers.rs
@@ -5,17 +5,17 @@ mod glue {
 
     #[wasm_bindgen]
     extern "C" {
-        #[wasm_bindgen(extends=js_sys::Object, js_name=Headers)]
-        pub type HeadersExt;
+        #[wasm_bindgen(extends=js_sys::Object)]
+        pub type Headers;
 
-        #[wasm_bindgen(catch, method, structural, js_class=Headers, js_name=entries)]
-        pub fn entries(this: &HeadersExt) -> Result<js_sys::Iterator, JsValue>;
+        #[wasm_bindgen(method, catch)]
+        pub fn entries(this: &Headers) -> Result<js_sys::Iterator, JsValue>;
 
-        #[wasm_bindgen(catch, method, structural, js_class=Headers, js_name=keys)]
-        pub fn keys(this: &HeadersExt) -> Result<js_sys::Iterator, JsValue>;
+        #[wasm_bindgen(method, catch)]
+        pub fn keys(this: &Headers) -> Result<js_sys::Iterator, JsValue>;
 
-        #[wasm_bindgen(catch, method, structural, js_class=Headers, js_name=values)]
-        pub fn values(this: &HeadersExt) -> Result<js_sys::Iterator, JsValue>;
+        #[wasm_bindgen(method, catch)]
+        pub fn values(this: &Headers) -> Result<js_sys::Iterator, JsValue>;
     }
 }
 
@@ -29,14 +29,14 @@ pub trait HeadersExt {
 
 impl HeadersExt for web_sys::Headers {
     fn entries(&self) -> Result<js_sys::Iterator, JsValue> {
-        self.unchecked_ref::<glue::HeadersExt>().entries()
+        self.unchecked_ref::<glue::Headers>().entries()
     }
 
     fn keys(&self) -> Result<js_sys::Iterator, JsValue> {
-        self.unchecked_ref::<glue::HeadersExt>().keys()
+        self.unchecked_ref::<glue::Headers>().keys()
     }
 
     fn values(&self) -> Result<js_sys::Iterator, JsValue> {
-        self.unchecked_ref::<glue::HeadersExt>().values()
+        self.unchecked_ref::<glue::Headers>().values()
     }
 }

--- a/worker-sys/src/ext/request.rs
+++ b/worker-sys/src/ext/request.rs
@@ -7,21 +7,21 @@ mod glue {
 
     #[wasm_bindgen]
     extern "C" {
-        #[wasm_bindgen(js_name=Request)]
-        pub type RequestExt;
+        #[wasm_bindgen]
+        pub type Request;
 
-        #[wasm_bindgen(structural, method, getter, js_class=Request, js_name=cf)]
-        pub fn cf(this: &RequestExt) -> IncomingRequestCfProperties;
+        #[wasm_bindgen(method, getter)]
+        pub fn cf(this: &Request) -> Option<IncomingRequestCfProperties>;
     }
 }
 
 pub trait RequestExt {
     /// Get the Cloudflare Properties from this request
-    fn cf(&self) -> IncomingRequestCfProperties;
+    fn cf(&self) -> Option<IncomingRequestCfProperties>;
 }
 
 impl RequestExt for web_sys::Request {
-    fn cf(&self) -> IncomingRequestCfProperties {
-        self.unchecked_ref::<glue::RequestExt>().cf()
+    fn cf(&self) -> Option<IncomingRequestCfProperties> {
+        self.unchecked_ref::<glue::Request>().cf()
     }
 }

--- a/worker-sys/src/ext/response.rs
+++ b/worker-sys/src/ext/response.rs
@@ -5,11 +5,11 @@ mod glue {
 
     #[wasm_bindgen]
     extern "C" {
-        #[wasm_bindgen(js_name=Response)]
-        pub type ResponseExt;
+        #[wasm_bindgen]
+        pub type Response;
 
-        #[wasm_bindgen(structural, method, getter, js_class=Response, js_name=webSocket)]
-        pub fn websocket(this: &ResponseExt) -> Option<web_sys::WebSocket>;
+        #[wasm_bindgen(method, getter)]
+        pub fn websocket(this: &Response) -> Option<web_sys::WebSocket>;
     }
 }
 
@@ -20,6 +20,6 @@ pub trait ResponseExt {
 
 impl ResponseExt for web_sys::Response {
     fn websocket(&self) -> Option<web_sys::WebSocket> {
-        self.unchecked_ref::<glue::ResponseExt>().websocket()
+        self.unchecked_ref::<glue::Response>().websocket()
     }
 }

--- a/worker-sys/src/ext/websocket.rs
+++ b/worker-sys/src/ext/websocket.rs
@@ -5,11 +5,11 @@ mod glue {
 
     #[wasm_bindgen]
     extern "C" {
-        #[wasm_bindgen(js_name=WebSocket)]
-        pub type WebSocketExt;
+        #[wasm_bindgen]
+        pub type WebSocket;
 
-        #[wasm_bindgen(catch, structural, method, js_class=WebSocket, js_name=accept)]
-        pub fn accept(this: &WebSocketExt) -> Result<(), JsValue>;
+        #[wasm_bindgen(method, catch)]
+        pub fn accept(this: &WebSocket) -> Result<(), JsValue>;
     }
 }
 
@@ -22,6 +22,6 @@ pub trait WebSocketExt {
 
 impl WebSocketExt for web_sys::WebSocket {
     fn accept(&self) -> Result<(), JsValue> {
-        self.unchecked_ref::<glue::WebSocketExt>().accept()
+        self.unchecked_ref::<glue::WebSocket>().accept()
     }
 }

--- a/worker-sys/src/types/context.rs
+++ b/worker-sys/src/types/context.rs
@@ -2,13 +2,13 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=Context)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, PartialEq, Eq)]
     pub type Context;
 
-    #[wasm_bindgen(method, structural, js_name=waitUntil)]
+    #[wasm_bindgen(method, js_name=waitUntil)]
     pub fn wait_until(this: &Context, promise: &js_sys::Promise);
 
-    #[wasm_bindgen(method, structural, js_name=passThroughOnException)]
+    #[wasm_bindgen(method, js_name=passThroughOnException)]
     pub fn pass_through_on_exception(this: &Context);
 }

--- a/worker-sys/src/types/durable_object.rs
+++ b/worker-sys/src/types/durable_object.rs
@@ -14,12 +14,12 @@ pub use transaction::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=DurableObject)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     pub type DurableObject;
 
-    #[wasm_bindgen(method, js_class=DurableObject, js_name=fetch)]
+    #[wasm_bindgen(method, js_name=fetch)]
     pub fn fetch_with_request(this: &DurableObject, req: &web_sys::Request) -> js_sys::Promise;
 
-    #[wasm_bindgen(method, js_class=DurableObject, js_name=fetch)]
+    #[wasm_bindgen(method, js_name=fetch)]
     pub fn fetch_with_str(this: &DurableObject, url: &str) -> js_sys::Promise;
 }

--- a/worker-sys/src/types/durable_object/id.rs
+++ b/worker-sys/src/types/durable_object/id.rs
@@ -2,9 +2,9 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=DurableObjectId)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     pub type DurableObjectId;
 
-    #[wasm_bindgen(method, js_class=DurableObjectId, js_name=toString)]
+    #[wasm_bindgen(method, js_name=toString)]
     pub fn to_string(this: &DurableObjectId) -> String;
 }

--- a/worker-sys/src/types/durable_object/namespace.rs
+++ b/worker-sys/src/types/durable_object/namespace.rs
@@ -4,31 +4,31 @@ use crate::types::{DurableObject, DurableObjectId};
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=DurableObjectNamespace)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     pub type DurableObjectNamespace;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectNamespace, js_name=idFromName)]
+    #[wasm_bindgen(method, catch, js_name=idFromName)]
     pub fn id_from_name(
         this: &DurableObjectNamespace,
         name: &str,
     ) -> Result<DurableObjectId, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectNamespace, js_name=idFromString)]
+    #[wasm_bindgen(method, catch, js_name=idFromString)]
     pub fn id_from_string(
         this: &DurableObjectNamespace,
         string: &str,
     ) -> Result<DurableObjectId, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectNamespace, js_name=newUniqueId)]
+    #[wasm_bindgen(method, catch, js_name=newUniqueId)]
     pub fn new_unique_id(this: &DurableObjectNamespace) -> Result<DurableObjectId, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectNamespace, js_name=newUniqueId)]
+    #[wasm_bindgen(method, catch, js_name=newUniqueId)]
     pub fn new_unique_id_with_options(
         this: &DurableObjectNamespace,
         options: &JsValue,
     ) -> Result<DurableObjectId, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectNamespace, js_name=get)]
+    #[wasm_bindgen(method, catch)]
     pub fn get(
         this: &DurableObjectNamespace,
         id: &DurableObjectId,

--- a/worker-sys/src/types/durable_object/state.rs
+++ b/worker-sys/src/types/durable_object/state.rs
@@ -4,12 +4,12 @@ use crate::types::{DurableObjectId, DurableObjectStorage};
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=DurableObjectState)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     pub type DurableObjectState;
 
-    #[wasm_bindgen(method, getter, js_class=DurableObjectState, js_name=id)]
+    #[wasm_bindgen(method, getter)]
     pub fn id(this: &DurableObjectState) -> DurableObjectId;
 
-    #[wasm_bindgen(method, getter, js_class=DurableObjectState, js_name=storage)]
+    #[wasm_bindgen(method, getter)]
     pub fn storage(this: &DurableObjectState) -> DurableObjectStorage;
 }

--- a/worker-sys/src/types/durable_object/storage.rs
+++ b/worker-sys/src/types/durable_object/storage.rs
@@ -4,72 +4,72 @@ use crate::types::DurableObjectTransaction;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=DurableObjectStorage)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     pub type DurableObjectStorage;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=get)]
+    #[wasm_bindgen(method, catch)]
     pub fn get(this: &DurableObjectStorage, key: &str) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=get)]
+    #[wasm_bindgen(method, catch, js_name=get)]
     pub fn get_multiple(
         this: &DurableObjectStorage,
         keys: Vec<JsValue>,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=put)]
+    #[wasm_bindgen(method, catch)]
     pub fn put(
         this: &DurableObjectStorage,
         key: &str,
         value: JsValue,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=put)]
+    #[wasm_bindgen(method, catch, js_name=put)]
     pub fn put_multiple(
         this: &DurableObjectStorage,
         value: JsValue,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=delete)]
+    #[wasm_bindgen(method, catch)]
     pub fn delete(this: &DurableObjectStorage, key: &str) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=delete)]
+    #[wasm_bindgen(method, catch, js_name=delete)]
     pub fn delete_multiple(
         this: &DurableObjectStorage,
         keys: Vec<JsValue>,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=deleteAll)]
+    #[wasm_bindgen(method, catch, js_name=deleteAll)]
     pub fn delete_all(this: &DurableObjectStorage) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=list)]
+    #[wasm_bindgen(method, catch)]
     pub fn list(this: &DurableObjectStorage) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=list)]
+    #[wasm_bindgen(method, catch, js_name=list)]
     pub fn list_with_options(
         this: &DurableObjectStorage,
         options: js_sys::Object,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=transaction)]
+    #[wasm_bindgen(method, catch)]
     pub fn transaction(
         this: &DurableObjectStorage,
         closure: &Closure<dyn FnMut(DurableObjectTransaction)>,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=getAlarm)]
+    #[wasm_bindgen(method, catch, js_name=getAlarm)]
     pub fn get_alarm(
         this: &DurableObjectStorage,
         options: js_sys::Object,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=setAlarm)]
+    #[wasm_bindgen(method, catch, js_name=setAlarm)]
     pub fn set_alarm(
         this: &DurableObjectStorage,
         scheduled_time: js_sys::Date,
         options: js_sys::Object,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectStorage, js_name=deleteAlarm)]
+    #[wasm_bindgen(method, catch, js_name=deleteAlarm)]
     pub fn delete_alarm(
         this: &DurableObjectStorage,
         options: js_sys::Object,

--- a/worker-sys/src/types/durable_object/transaction.rs
+++ b/worker-sys/src/types/durable_object/transaction.rs
@@ -2,52 +2,52 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=DurableObjectTransaction)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     pub type DurableObjectTransaction;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectTransaction, js_name=get)]
+    #[wasm_bindgen(method, catch)]
     pub fn get(this: &DurableObjectTransaction, key: &str) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectTransaction, js_name=get)]
+    #[wasm_bindgen(method, catch, js_name=get)]
     pub fn get_multiple(
         this: &DurableObjectTransaction,
         keys: Vec<JsValue>,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectTransaction, js_name=put)]
+    #[wasm_bindgen(method, catch)]
     pub fn put(
         this: &DurableObjectTransaction,
         key: &str,
         value: JsValue,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectTransaction, js_name=put)]
+    #[wasm_bindgen(method, catch, js_name=put)]
     pub fn put_multiple(
         this: &DurableObjectTransaction,
         value: JsValue,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectTransaction, js_name=delete)]
+    #[wasm_bindgen(method, catch)]
     pub fn delete(this: &DurableObjectTransaction, key: &str) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectTransaction, js_name=delete)]
+    #[wasm_bindgen(method, catch, js_name=delete)]
     pub fn delete_multiple(
         this: &DurableObjectTransaction,
         keys: Vec<JsValue>,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectTransaction, js_name=deleteAll)]
+    #[wasm_bindgen(method, catch, js_name=deleteAll)]
     pub fn delete_all(this: &DurableObjectTransaction) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectTransaction, js_name=list)]
+    #[wasm_bindgen(method, catch)]
     pub fn list(this: &DurableObjectTransaction) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectTransaction, js_name=list)]
+    #[wasm_bindgen(method, catch, js_name=list)]
     pub fn list_with_options(
         this: &DurableObjectTransaction,
         options: js_sys::Object,
     ) -> Result<js_sys::Promise, JsValue>;
 
-    #[wasm_bindgen(catch, method, js_class=DurableObjectTransaction, js_name=rollback)]
+    #[wasm_bindgen(method, catch)]
     pub fn rollback(this: &DurableObjectTransaction) -> Result<(), JsValue>;
 }

--- a/worker-sys/src/types/dynamic_dispatcher.rs
+++ b/worker-sys/src/types/dynamic_dispatcher.rs
@@ -4,11 +4,11 @@ use crate::types::Fetcher;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=DynamicDispatcher)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type DynamicDispatcher;
 
-    #[wasm_bindgen(structural, method, js_class=DynamicDispatcher, js_name=get, catch)]
+    #[wasm_bindgen(method, catch)]
     pub fn get(
         this: &DynamicDispatcher,
         name: String,

--- a/worker-sys/src/types/fetcher.rs
+++ b/worker-sys/src/types/fetcher.rs
@@ -2,24 +2,24 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=Fetcher)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Fetcher;
 
-    #[wasm_bindgen(structural, method, js_class=Fetcher, js_name=fetch)]
+    #[wasm_bindgen(method)]
     pub fn fetch(this: &Fetcher, input: &web_sys::Request) -> js_sys::Promise;
 
-    #[wasm_bindgen(structural, method, js_class=Fetcher, js_name=fetch)]
+    #[wasm_bindgen(method, js_name=fetch)]
     pub fn fetch_with_str(this: &Fetcher, input: &str) -> js_sys::Promise;
 
-    #[wasm_bindgen(structural, method, js_class=Fetcher, js_name=fetch)]
+    #[wasm_bindgen(method, js_name=fetch)]
     pub fn fetch_with_init(
         this: &Fetcher,
         input: &web_sys::Request,
         init: &web_sys::RequestInit,
     ) -> js_sys::Promise;
 
-    #[wasm_bindgen(structural, method, js_class=Fetcher, js_name=fetch)]
+    #[wasm_bindgen(method, js_name=fetch)]
     pub fn fetch_with_str_and_init(
         this: &Fetcher,
         input: &str,

--- a/worker-sys/src/types/fixed_length_stream.rs
+++ b/worker-sys/src/types/fixed_length_stream.rs
@@ -2,16 +2,16 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=web_sys::TransformStream, js_name=FixedLengthStream)]
+    #[wasm_bindgen(extends=web_sys::TransformStream)]
     #[derive(Debug, Clone)]
     pub type FixedLengthStream;
 
-    #[wasm_bindgen(constructor, js_class=FixedLengthStream)]
+    #[wasm_bindgen(constructor)]
     pub fn new(length: u32) -> FixedLengthStream;
 
-    #[wasm_bindgen(constructor, js_class=FixedLengthStream)]
+    #[wasm_bindgen(constructor)]
     pub fn new_big_int(length: js_sys::BigInt) -> FixedLengthStream;
 
-    #[wasm_bindgen(structural, method, getter, js_class=FixedLengthStream, js_name=cron)]
+    #[wasm_bindgen(method, getter)]
     pub fn cron(this: &FixedLengthStream) -> String;
 }

--- a/worker-sys/src/types/incoming_request_cf_properties.rs
+++ b/worker-sys/src/types/incoming_request_cf_properties.rs
@@ -4,61 +4,61 @@ use crate::types::TlsClientAuth;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=IncomingRequestCfProperties)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type IncomingRequestCfProperties;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=colo)]
+    #[wasm_bindgen(method, getter)]
     pub fn colo(this: &IncomingRequestCfProperties) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=asn)]
+    #[wasm_bindgen(method, getter)]
     pub fn asn(this: &IncomingRequestCfProperties) -> u32;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=country)]
+    #[wasm_bindgen(method, getter)]
     pub fn country(this: &IncomingRequestCfProperties) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=httpProtocol)]
+    #[wasm_bindgen(method, getter, js_name=httpProtocol)]
     pub fn http_protocol(this: &IncomingRequestCfProperties) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=requestPriority)]
+    #[wasm_bindgen(method, getter, js_name=requestPriority)]
     pub fn request_priority(this: &IncomingRequestCfProperties) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=tlsClientAuth)]
+    #[wasm_bindgen(method, getter, js_name=tlsClientAuth)]
     pub fn tls_client_auth(this: &IncomingRequestCfProperties) -> Option<TlsClientAuth>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=tlsCipher)]
+    #[wasm_bindgen(method, getter, js_name=tlsCipher)]
     pub fn tls_cipher(this: &IncomingRequestCfProperties) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=tlsVersion)]
+    #[wasm_bindgen(method, getter, js_name=tlsVersion)]
     pub fn tls_version(this: &IncomingRequestCfProperties) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=city)]
+    #[wasm_bindgen(method, getter)]
     pub fn city(this: &IncomingRequestCfProperties) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=continent)]
+    #[wasm_bindgen(method, getter)]
     pub fn continent(this: &IncomingRequestCfProperties) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=latitude)]
+    #[wasm_bindgen(method, getter)]
     pub fn latitude(this: &IncomingRequestCfProperties) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=longitude)]
+    #[wasm_bindgen(method, getter)]
     pub fn longitude(this: &IncomingRequestCfProperties) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=postalCode)]
+    #[wasm_bindgen(method, getter, js_name=postalCode)]
     pub fn postal_code(this: &IncomingRequestCfProperties) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=metroCode)]
+    #[wasm_bindgen(method, getter, js_name=metroCode)]
     pub fn metro_code(this: &IncomingRequestCfProperties) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=region)]
+    #[wasm_bindgen(method, getter)]
     pub fn region(this: &IncomingRequestCfProperties) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=regionCode)]
+    #[wasm_bindgen(method, getter, js_name=regionCode)]
     pub fn region_code(this: &IncomingRequestCfProperties) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=timezone)]
+    #[wasm_bindgen(method, getter)]
     pub fn timezone(this: &IncomingRequestCfProperties) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_class=IncomingRequestCfProperties, js_name=isEUCountry)]
+    #[wasm_bindgen(method, getter, js_name=isEUCountry)]
     pub fn is_eu_country(this: &IncomingRequestCfProperties) -> Option<String>;
 }

--- a/worker-sys/src/types/queue.rs
+++ b/worker-sys/src/types/queue.rs
@@ -2,26 +2,26 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=MessageBatch)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type MessageBatch;
 
-    #[wasm_bindgen(method, getter,  js_class=MessageBatch, js_name=queue)]
+    #[wasm_bindgen(method, getter)]
     pub fn queue(this: &MessageBatch) -> String;
 
-    #[wasm_bindgen(method, getter, js_class=MessageBatch, js_name=messages)]
+    #[wasm_bindgen(method, getter)]
     pub fn messages(this: &MessageBatch) -> js_sys::Array;
 
-    #[wasm_bindgen(structural, method, js_class=MessageBatch, js_name=retryAll)]
+    #[wasm_bindgen(method, js_name=retryAll)]
     pub fn retry_all(this: &MessageBatch);
 }
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen (extends=js_sys::Object, js_name=Queue)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Queue;
 
-    #[wasm_bindgen(structural, method, js_class=Queue, js_name=send)]
+    #[wasm_bindgen(method)]
     pub fn send(this: &Queue, mesage: JsValue) -> js_sys::Promise;
 }

--- a/worker-sys/src/types/r2/bucket.rs
+++ b/worker-sys/src/types/r2/bucket.rs
@@ -2,32 +2,32 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=R2Bucket)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2Bucket;
 
-    #[wasm_bindgen(structural, method, js_class=R2Bucket, js_name=head)]
+    #[wasm_bindgen(method)]
     pub fn head(this: &R2Bucket, key: String) -> js_sys::Promise;
 
-    #[wasm_bindgen(structural, method, js_class=R2Bucket, js_name=get)]
+    #[wasm_bindgen(method)]
     pub fn get(this: &R2Bucket, key: String, options: JsValue) -> js_sys::Promise;
 
-    #[wasm_bindgen(structural, method, js_class=R2Bucket, js_name=put)]
+    #[wasm_bindgen(method)]
     pub fn put(this: &R2Bucket, key: String, value: JsValue, options: JsValue) -> js_sys::Promise;
 
-    #[wasm_bindgen(structural, method, js_class=R2Bucket, js_name=delete)]
+    #[wasm_bindgen(method)]
     pub fn delete(this: &R2Bucket, key: String) -> js_sys::Promise;
 
-    #[wasm_bindgen(structural, method, js_class=R2Bucket, js_name=list)]
+    #[wasm_bindgen(method)]
     pub fn list(this: &R2Bucket, options: JsValue) -> js_sys::Promise;
 
-    #[wasm_bindgen(structural, method, js_class=R2Bucket, js_name=createMultipartUpload)]
+    #[wasm_bindgen(method, js_name=createMultipartUpload)]
     pub fn create_multipart_upload(
         this: &R2Bucket,
         key: String,
         options: JsValue,
     ) -> js_sys::Promise;
 
-    #[wasm_bindgen(structural, method, js_class=R2Bucket, js_name=resumeMultipartUpload)]
+    #[wasm_bindgen(method, js_name=resumeMultipartUpload)]
     pub fn resume_multipart_upload(this: &R2Bucket, key: String, upload_id: String) -> JsValue;
 }

--- a/worker-sys/src/types/r2/http_metadata.rs
+++ b/worker-sys/src/types/r2/http_metadata.rs
@@ -2,25 +2,25 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=R2HttpMetadata)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2HttpMetadata;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2HttpMetadata, js_name=contentType)]
+    #[wasm_bindgen(method, getter, js_name=contentType)]
     pub fn content_type(this: &R2HttpMetadata) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2HttpMetadata, js_name=contentLanguage)]
+    #[wasm_bindgen(method, getter, js_name=contentLanguage)]
     pub fn content_language(this: &R2HttpMetadata) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2HttpMetadata, js_name=contentDisposition)]
+    #[wasm_bindgen(method, getter, js_name=contentDisposition)]
     pub fn content_disposition(this: &R2HttpMetadata) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2HttpMetadata, js_name=contentEncoding)]
+    #[wasm_bindgen(method, getter, js_name=contentEncoding)]
     pub fn content_encoding(this: &R2HttpMetadata) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2HttpMetadata, js_name=cacheControl)]
+    #[wasm_bindgen(method, getter, js_name=cacheControl)]
     pub fn cache_control(this: &R2HttpMetadata) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2HttpMetadata, js_name=cacheExpiry)]
+    #[wasm_bindgen(method, getter, js_name=cacheExpiry)]
     pub fn cache_expiry(this: &R2HttpMetadata) -> Option<js_sys::Date>;
 }

--- a/worker-sys/src/types/r2/multipart_upload.rs
+++ b/worker-sys/src/types/r2/multipart_upload.rs
@@ -2,26 +2,26 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=R2MultipartUpload)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2MultipartUpload;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2MultipartUpload, js_name=key)]
+    #[wasm_bindgen(method, getter)]
     pub fn key(this: &R2MultipartUpload) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2MultipartUpload, js_name=uploadId)]
+    #[wasm_bindgen(method, getter, js_name=uploadId)]
     pub fn upload_id(this: &R2MultipartUpload) -> String;
 
-    #[wasm_bindgen(structural, method, js_class=R2MultipartUpload, js_name=uploadPart)]
+    #[wasm_bindgen(method, js_name=uploadPart)]
     pub fn upload_part(
         this: &R2MultipartUpload,
         part_number: u16,
         value: JsValue,
     ) -> js_sys::Promise;
 
-    #[wasm_bindgen(structural, method, js_class=R2MultipartUpload, js_name=abort)]
+    #[wasm_bindgen(method)]
     pub fn abort(this: &R2MultipartUpload) -> js_sys::Promise;
 
-    #[wasm_bindgen(structural, method, js_class=R2MultipartUpload, js_name=complete)]
+    #[wasm_bindgen(method)]
     pub fn complete(this: &R2MultipartUpload, uploaded_parts: Vec<JsValue>) -> js_sys::Promise;
 }

--- a/worker-sys/src/types/r2/object.rs
+++ b/worker-sys/src/types/r2/object.rs
@@ -4,38 +4,38 @@ use crate::types::{R2HttpMetadata, R2Range};
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=R2Object)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2Object;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Object, js_name=key)]
+    #[wasm_bindgen(method, getter)]
     pub fn key(this: &R2Object) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Object, js_name = version)]
+    #[wasm_bindgen(method, getter)]
     pub fn version(this: &R2Object) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Object, js_name=size)]
+    #[wasm_bindgen(method, getter)]
     pub fn size(this: &R2Object) -> u32;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Object, js_name=etag)]
+    #[wasm_bindgen(method, getter)]
     pub fn etag(this: &R2Object) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Object, js_name=httpEtag)]
+    #[wasm_bindgen(method, getter, js_name=httpEtag)]
     pub fn http_etag(this: &R2Object) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Object, js_name=uploaded)]
+    #[wasm_bindgen(method, getter)]
     pub fn uploaded(this: &R2Object) -> js_sys::Date;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Object, js_name=httpMetadata)]
+    #[wasm_bindgen(method, getter, js_name=httpMetadata)]
     pub fn http_metadata(this: &R2Object) -> R2HttpMetadata;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Object, js_name=customMetadata)]
+    #[wasm_bindgen(method, getter, js_name=customMetadata)]
     pub fn custom_metadata(this: &R2Object) -> js_sys::Object;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Object, js_name=range)]
+    #[wasm_bindgen(method, getter)]
     pub fn range(this: &R2Object) -> R2Range;
 
-    #[wasm_bindgen(structural, method, js_class=R2Object, js_name=writeHttpMetadata, catch)]
+    #[wasm_bindgen(method, catch, js_name=writeHttpMetadata)]
     pub fn write_http_metadata(
         this: &R2Object,
         headers: web_sys::Headers,

--- a/worker-sys/src/types/r2/object_body.rs
+++ b/worker-sys/src/types/r2/object_body.rs
@@ -4,16 +4,16 @@ use crate::types::R2Object;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=R2Object, js_name=R2ObjectBody)]
+    #[wasm_bindgen(extends=R2Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2ObjectBody;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2ObjectBody, js_name=body)]
+    #[wasm_bindgen(method, getter)]
     pub fn body(this: &R2ObjectBody) -> web_sys::ReadableStream;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2ObjectBody, js_name=bodyUsed)]
+    #[wasm_bindgen(method, getter, js_name=bodyUsed)]
     pub fn body_used(this: &R2ObjectBody) -> bool;
 
-    #[wasm_bindgen(structural, method, js_class=R2ObjectBody, js_name=arrayBuffer)]
+    #[wasm_bindgen(method, js_name=arrayBuffer)]
     pub fn array_buffer(this: &R2ObjectBody) -> js_sys::Promise;
 }

--- a/worker-sys/src/types/r2/objects.rs
+++ b/worker-sys/src/types/r2/objects.rs
@@ -4,19 +4,19 @@ use crate::types::R2Object;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=R2Objects)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2Objects;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Objects, js_name=objects)]
+    #[wasm_bindgen(method, getter)]
     pub fn objects(this: &R2Objects) -> Vec<R2Object>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Objects, js_name=truncated)]
+    #[wasm_bindgen(method, getter)]
     pub fn truncated(this: &R2Objects) -> bool;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Objects, js_name=cursor)]
+    #[wasm_bindgen(method, getter)]
     pub fn cursor(this: &R2Objects) -> Option<String>;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2Objects, js_name=delimitedPrefixes)]
+    #[wasm_bindgen(method, getter, js_name=delimitedPrefixes)]
     pub fn delimited_prefixes(this: &R2Objects) -> Vec<js_sys::JsString>;
 }

--- a/worker-sys/src/types/r2/uploaded_part.rs
+++ b/worker-sys/src/types/r2/uploaded_part.rs
@@ -2,13 +2,13 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=R2UploadedPart)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2UploadedPart;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2UploadedPart, js_name=partNumber)]
+    #[wasm_bindgen(method, getter, js_name=partNumber)]
     pub fn part_number(this: &R2UploadedPart) -> u16;
 
-    #[wasm_bindgen(structural, method, getter, js_class=R2UploadedPart, js_name=etag)]
+    #[wasm_bindgen(method, getter)]
     pub fn etag(this: &R2UploadedPart) -> String;
 }

--- a/worker-sys/src/types/schedule.rs
+++ b/worker-sys/src/types/schedule.rs
@@ -2,24 +2,24 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=ScheduledEvent)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type ScheduledEvent;
 
-    #[wasm_bindgen(structural, method, getter, js_class=ScheduledEvent, js_name=scheduledTime)]
+    #[wasm_bindgen(method, getter, js_name=scheduledTime)]
     pub fn scheduled_time(this: &ScheduledEvent) -> f64;
 
-    #[wasm_bindgen(structural, method, getter, js_class=ScheduledEvent, js_name=cron)]
+    #[wasm_bindgen(method, getter)]
     pub fn cron(this: &ScheduledEvent) -> String;
 }
 
 /// [Context](https://developers.cloudflare.com/workers/runtime-apis/scheduled-event#syntax-module-worker)
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=ScheduleContext)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone)]
     pub type ScheduleContext;
 
-    #[wasm_bindgen(structural, method, js_class=ScheduleContext, js_name=waitUntil)]
+    #[wasm_bindgen(method, js_name=waitUntil)]
     pub fn wait_until(this: &ScheduleContext, promise: js_sys::Promise);
 }

--- a/worker-sys/src/types/tls_client_auth.rs
+++ b/worker-sys/src/types/tls_client_auth.rs
@@ -2,43 +2,42 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=tlsClientAuth)]
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq)]
     pub type TlsClientAuth;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certIssuerDNLegacy, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certIssuerDNLegacy)]
     pub fn cert_issuer_dn_legacy(this: &TlsClientAuth) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certIssuerDN, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certIssuerDN)]
     pub fn cert_issuer_dn(this: &TlsClientAuth) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certIssuerDNRFC2253, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certIssuerDNRFC2253)]
     pub fn cert_issuer_dn_rfc2253(this: &TlsClientAuth) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certSubjectDNLegacy, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certSubjectDNLegacy)]
     pub fn cert_subject_dn_legacy(this: &TlsClientAuth) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certVerified, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certVerified)]
     pub fn cert_verified(this: &TlsClientAuth) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certNotAfter, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certNotAfter)]
     pub fn cert_not_after(this: &TlsClientAuth) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certSubjectDN, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certSubjectDN)]
     pub fn cert_subject_dn(this: &TlsClientAuth) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certFingerprintSHA1, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certFingerprintSHA1)]
     pub fn cert_fingerprint_sha1(this: &TlsClientAuth) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certNotBefore, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certNotBefore)]
     pub fn cert_not_before(this: &TlsClientAuth) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certSerial, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certSerial)]
     pub fn cert_serial(this: &TlsClientAuth) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certPresented, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certPresented)]
     pub fn cert_presented(this: &TlsClientAuth) -> String;
 
-    #[wasm_bindgen(structural, method, getter, js_name=certSubjectDNRFC2253, js_class = "tlsClientAuth")]
+    #[wasm_bindgen(method, getter, js_name=certSubjectDNRFC2253)]
     pub fn cert_subject_dn_rfc2253(this: &TlsClientAuth) -> String;
 }

--- a/worker-sys/src/types/websocket_pair.rs
+++ b/worker-sys/src/types/websocket_pair.rs
@@ -2,23 +2,23 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends=js_sys::Object, js_name=WebSocketPair)]
+    #[wasm_bindgen(extends=js_sys::Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     /// The `WebSocketPair` dictionary.
     pub type WebSocketPair;
 
-    #[wasm_bindgen(constructor, js_class=WebSocketPair)]
+    #[wasm_bindgen(constructor)]
     pub fn new() -> WebSocketPair;
 }
 
 impl WebSocketPair {
     pub fn client(&mut self) -> Result<web_sys::WebSocket, JsValue> {
-        let value = js_sys::Reflect::get(self.as_ref(), &JsValue::from("0"))?;
+        let value = js_sys::Reflect::get_u32(self.as_ref(), 0)?;
         Ok(web_sys::WebSocket::from(value))
     }
 
     pub fn server(&mut self) -> Result<web_sys::WebSocket, JsValue> {
-        let value = js_sys::Reflect::get(self.as_ref(), &JsValue::from("1"))?;
+        let value = js_sys::Reflect::get_u32(self.as_ref(), 1)?;
         Ok(web_sys::WebSocket::from(value))
     }
 }

--- a/worker/src/abort.rs
+++ b/worker/src/abort.rs
@@ -23,7 +23,7 @@ impl AbortController {
     /// Aborts any operation using a [AbortSignal] created from this controller with the provided
     /// reason.
     pub fn abort_with_reason(self, reason: impl Into<JsValue>) {
-        self.inner.abort_with_reason(reason.into())
+        self.inner.abort_with_reason(&reason.into())
     }
 }
 
@@ -55,13 +55,13 @@ impl AbortSignal {
 
     /// Creates a [AbortSignal] that is already aborted.
     pub fn abort() -> Self {
-        Self::from(web_sys::AbortSignal::abort(JsValue::undefined()))
+        Self::from(web_sys::AbortSignal::abort())
     }
 
     /// Creates a [AbortSignal] that is already aborted with the provided reason.
     pub fn abort_with_reason(reason: impl Into<JsValue>) -> Self {
         let reason = reason.into();
-        Self::from(web_sys::AbortSignal::abort(reason))
+        Self::from(web_sys::AbortSignal::abort_with_reason(&reason))
     }
 }
 

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -18,7 +18,7 @@ pub struct Request {
     method: Method,
     path: String,
     headers: Headers,
-    cf: Cf,
+    cf: Option<Cf>,
     edge_request: web_sys::Request,
     body_used: bool,
     immutable: bool,
@@ -38,7 +38,7 @@ impl From<web_sys::Request> for Request {
                     u
                 }),
             headers: Headers(req.headers()),
-            cf: req.cf().into(),
+            cf: req.cf().map(Into::into),
             edge_request: req,
             body_used: false,
             immutable: true,
@@ -205,7 +205,7 @@ impl Request {
 
     /// Access this request's Cloudflare-specific properties.
     pub fn cf(&self) -> &Cf {
-        &self.cf
+        self.cf.as_ref().unwrap()
     }
 
     /// The HTTP Method associated with this `Request`.


### PR DESCRIPTION
- Remove usage of `js_name` and `js_class` where it's not needed
- Remove usage of `structural` as it's the default behavior https://rustwasm.github.io/wasm-bindgen/reference/attributes/on-js-imports/structural.html