### PR TITLE
Use new template link

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
 
 The project uses [wrangler](https://github.com/cloudflare/wrangler2) version 2.x for running and publishing your Worker.
 
-Get the Rust worker project [template](https://github.com/cloudflare/templates/tree/main/worker-rust) manually, or run the following command:
+Get the Rust worker project [template](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-rust) manually, or run the following command:
 ```bash
 npm init cloudflare project_name worker-rust
 cd project_name


### PR DESCRIPTION
Looks like the templates repository is no longer used and templates have been moved.
Just stumbled over this when looking up the template.