### PR TITLE
Expose `TlsClientAuth` struct in the public API

### DIFF
--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -15,7 +15,7 @@ pub use wasm_bindgen;
 pub use wasm_bindgen_futures;
 pub use worker_kv as kv;
 
-pub use cf::Cf;
+pub use cf::{Cf, TlsClientAuth};
 pub use worker_macros::{durable_object, event};
 #[doc(hidden)]
 pub use worker_sys;


### PR DESCRIPTION
Plumb the TLS client certificate information through the API. This is currently possible via `req.cf().tls_client_auth()`, but it is useful to be to reference the `TlsClinetAuth` structure itself in struct/enum definitions.