### PR TITLE
adds curl/static-curl feature to wasm-pack install

### DIFF
--- a/worker-build/src/install.rs
+++ b/worker-build/src/install.rs
@@ -35,7 +35,7 @@ pub fn ensure_wasm_pack() -> Result<()> {
     if is_installed("wasm-pack")?.is_none() {
         println!("Installing wasm-pack...");
         let exit_status = Command::new("cargo")
-            .args(["install", "wasm-pack"])
+            .args(["install", "wasm-pack", "--features", "curl/static-curl"])
             .spawn()?
             .wait()?;
 


### PR DESCRIPTION
fixes #304

Worker-rs installs a version of wasm-pack that can be incompatible with some systems due to curl or libc incompatibilities. Installing it with this feature enabled solves this issue.

This can be done manually:  `cargo install wasm-pack --features curl/static-curl`

I am not sure this should be merged. 
This feature makes so curl gets statically linked in the wasm-pack binary. It is unlikely that it would cause issues on other machines. 
Also, it will not overwrite wasm-pack if it is installed already. 