### PR TITLE
Exposes wait_until method on Durable Object state

### DIFF
--- a/worker-sys/src/types/durable_object/state.rs
+++ b/worker-sys/src/types/durable_object/state.rs
@@ -12,4 +12,7 @@ extern "C" {
 
     #[wasm_bindgen(method, getter)]
     pub fn storage(this: &DurableObjectState) -> DurableObjectStorage;
+
+    #[wasm_bindgen(method, js_name=waitUntil)]
+    pub fn wait_until(this: &DurableObjectState, promise: &js_sys::Promise);
 }


### PR DESCRIPTION
This is needed to get the usual `waitUntil` behaviour for DO.

In JS you can just "fire and forget" the promise and DO will take care of ensuring it runs: https://developers.cloudflare.com/workers/runtime-apis/durable-objects/#durable-object-class-definition

But as futures are lazy in Rust, this is the only way.

Related: https://github.com/cloudflare/workers-rs/issues/151