### PR TITLE
Update `chrono-tz` to v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.6.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
+checksum = "cf9cc2b23599e6d7479755f3594285efb3f74a1bdca7a7374948bc831e23a552"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
+checksum = "d9998fb9f7e9b2111641485bf8beb32f92945f97f92a3d061f744cfef335f751"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -896,7 +896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
 dependencies = [
  "siphasher",
- "uncased",
 ]
 
 [[package]]
@@ -1476,15 +1475,6 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
-name = "uncased"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicase"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 [dependencies]
 async-trait = "0.1.56"
 chrono = { version = "0.4.22", default-features = false, features = ["wasmbind"] }
-chrono-tz = { version = "0.6.3", default-features = false }
+chrono-tz = { version = "0.8.2", default-features = false }
 futures-channel = "0.3.21"
 futures-util = { version = "0.3.21", default-features = false }
 http = "0.2.8"


### PR DESCRIPTION
`chrono-tz` v0.7 and v0.8 didn't really introduce breaking changes (at least not for `workers-rs`), but just updated it's database: https://github.com/chronotope/chrono-tz/blob/main/CHANGELOG.md.

This PR updates `chrono-tz` to v0.8.2.