### PR TITLE
Export worker::cache::CacheKey and worker::env::EnvBinding

### DIFF
--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -22,14 +22,14 @@ pub use worker_sys;
 pub use worker_sys::{console_debug, console_error, console_log, console_warn};
 
 pub use crate::abort::*;
-pub use crate::cache::{Cache, CacheDeletionOutcome};
+pub use crate::cache::{Cache, CacheDeletionOutcome, CacheKey};
 pub use crate::context::Context;
 pub use crate::cors::Cors;
 pub use crate::date::{Date, DateInit};
 pub use crate::delay::Delay;
 pub use crate::durable::*;
 pub use crate::dynamic_dispatch::*;
-pub use crate::env::{Env, Secret, Var};
+pub use crate::env::{Env, EnvBinding, Secret, Var};
 pub use crate::error::Error;
 pub use crate::fetcher::Fetcher;
 pub use crate::formdata::*;


### PR DESCRIPTION
### 🔖 Summary

The `worker::cache::CacheKey` is useful when the user wants to wrap the cache methods by accepting the same bounds for the generic key type.

The `worker::env::EnvBinding` export is a follow-up to https://github.com/cloudflare/workers-rs/pull/318. Without that export, the user cannot implement the `EnvBinding` trait which is required by the the `worker::env::Env::get_binding()` method.