### PR TITLE
Updated matchit dependency to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,9 +713,9 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "matchit"
-version = "0.4.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9376a4f0340565ad675d11fc1419227faf5f60cd7ac9cb2e7185a471f30af833"
+checksum = "3dfc802da7b1cf80aefffa0c7b2f77247c8b32206cc83c270b61264f5b360a80"
 
 [[package]]
 name = "md-5"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -19,7 +19,7 @@ futures-channel = "0.3.28"
 futures-util = { version = "0.3.28", default-features = false }
 http = "0.2.9"
 js-sys = "0.3.63"
-matchit = "0.4.6"
+matchit = "0.6.0"
 pin-project = "1.1.0"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.96"

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, future::Future, rc::Rc};
 
 use futures_util::future::LocalBoxFuture;
-use matchit::{Match, Node};
+use matchit::{Match, Router as Node};
 use worker_kv::KvStore;
 
 use crate::{


### PR DESCRIPTION
[matchit 0.6.0](https://github.com/ibraheemdev/matchit/releases/tag/v0.6.0) allows catch all routes to overlap with normal routes. So routes like `/*foo` and `/bar` can both exist with `/bar` getting priority.

The closest behavior that currently exists allows only for routes like `/:foo` and `/bar` to overlap. This is less usable due to `/:foo` only matching till the next slash and not matching a full path.

The new behavior should be preferred to allow for path like the following:
`/`
`/api/:function`
`/*filepath`
