### PR TITLE
Make `cf()` return an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         "{} {}, located at: {:?}, within: {}",
         req.method().to_string(),
         req.path(),
-        req.cf().coordinates().unwrap_or_default(),
-        req.cf().region().unwrap_or("unknown region".into())
+        req.cf().unwrap().coordinates().unwrap_or_default(),
+        req.cf().unwrap().region().unwrap_or("unknown region".into())
     );
 
     if !matches!(req.method(), Method::Post) {
@@ -245,7 +245,7 @@ new_classes = ["Chatroom"] # Array of new classes
 ### Enabling queues
 As queues are in beta you need to enable the `queue` feature flag.
 
-Enable it by adding it to the worker dependency in your `Cargo.toml`: 
+Enable it by adding it to the worker dependency in your `Cargo.toml`:
 ```toml
 worker = {version = "...", features = ["queue"]}
 ```

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -59,8 +59,10 @@ fn handle_a_request<D>(req: Request, _ctx: RouteContext<D>) -> Result<Response> 
     Response::ok(format!(
         "req at: {}, located at: {:?}, within: {}",
         req.path(),
-        req.cf().coordinates().unwrap_or_default(),
-        req.cf().region().unwrap_or_else(|| "unknown region".into())
+        req.cf().map(|cf| cf.coordinates().unwrap_or_default()),
+        req.cf()
+            .map(|cf| cf.region().unwrap_or_else(|| "unknown region".into()))
+            .unwrap_or(String::from("No CF properties"))
     ))
 }
 
@@ -68,8 +70,10 @@ async fn handle_async_request<D>(req: Request, _ctx: RouteContext<D>) -> Result<
     Response::ok(format!(
         "[async] req at: {}, located at: {:?}, within: {}",
         req.path(),
-        req.cf().coordinates().unwrap_or_default(),
-        req.cf().region().unwrap_or_else(|| "unknown region".into())
+        req.cf().map(|cf| cf.coordinates().unwrap_or_default()),
+        req.cf()
+            .map(|cf| cf.region().unwrap_or_else(|| "unknown region".into()))
+            .unwrap_or(String::from("No CF properties"))
     ))
 }
 

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -204,8 +204,9 @@ impl Request {
     }
 
     /// Access this request's Cloudflare-specific properties.
-    pub fn cf(&self) -> &Cf {
-        self.cf.as_ref().unwrap()
+    /// **Note:** returns an Option because the assumption that the struct `Cf` will always exists can not be relied upon
+    pub fn cf(&self) -> Option<&Cf> {
+        self.cf.as_ref()
     }
 
     /// The HTTP Method associated with this `Request`.


### PR DESCRIPTION
This is in response to issue #353 

I understand that this change is technically a breaking change. Another option is to silently add the `cf` field to any requests constructed. There are situations, like for the mail events, where there is no request to copy from. 

Bearing this all in mind, the `cf` field _is_ wrapped in `Option` on the request struct, and therefore having the `cf()` method also return an `Option` would make sense. 

## small example

There're more details in the linked issue (in the workerd repo), but the issue can be seen for example in an upstream TS service calls a bound rust worker. Something like:

```typescript
let new_request = new Request("https://foo.com", { method: "POST", body: request.body })
```

Here a new request is being made, but the `cf` property is not being copied over.  On the other hand something like

```typescript
env.B.fetch(new Request("https://foo.com", request))
```

copies over the `cf` properties from the initial request from the client. 