### PR TITLE
Fix DO example to use full URL instead of relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         .on_async("/durable", |_req, ctx| async move {
             let namespace = ctx.durable_object("CHATROOM")?;
             let stub = namespace.id_from_name("A")?.get_stub()?;
-            stub.fetch_with_str("/messages").await
+            stub.fetch_with_str("https://durable-object/messages").await
         })
         .get("/secret", |_req, ctx| {
             Response::ok(ctx.secret("CF_API_TOKEN")?.to_string())


### PR DESCRIPTION
After following this example I got an error saying:

```
Fetch API cannot load: /new
```

Talking to Skye and James on Discord, they pointed out that the API used to accept relative paths but that these days it requires a full URL.