### PR TITLE
Fix error display for Json variant & add Custom variant

### DIFF
--- a/worker/src/error.rs
+++ b/worker/src/error.rs
@@ -54,7 +54,7 @@ impl std::fmt::Display for Error {
         match self {
             Error::BadEncoding => write!(f, "content-type mismatch"),
             Error::BodyUsed => write!(f, "body has already been read"),
-            Error::Custom(e) => write!(f, "{}", e),
+            Error::Custom(e) => write!(f, "{e}"),
             Error::Json((msg, _)) => write!(f, "{msg}"),
             Error::JsError(s) | Error::RustError(s) => {
                 write!(f, "{s}")

--- a/worker/src/error.rs
+++ b/worker/src/error.rs
@@ -6,6 +6,7 @@ use wasm_bindgen::{JsCast, JsValue};
 pub enum Error {
     BadEncoding,
     BodyUsed,
+    Custom(String),
     Json((String, u16)),
     JsError(String),
     Internal(JsValue),
@@ -53,7 +54,8 @@ impl std::fmt::Display for Error {
         match self {
             Error::BadEncoding => write!(f, "content-type mismatch"),
             Error::BodyUsed => write!(f, "body has already been read"),
-            Error::Json((msg, status)) => write!(f, "{msg} (status: {status})"),
+            Error::Custom(e) => write!(f, "{}", e),
+            Error::Json((msg, _)) => write!(f, "{msg}"),
             Error::JsError(s) | Error::RustError(s) => {
                 write!(f, "{s}")
             }


### PR DESCRIPTION
This PR fixes the `Display` trait implemented for `Error` and introduces a new variant `Custom` on the enum.


When implementing custom error handlers, the `Display` trait implemented for `Error` on `Json` variant

```rust
Error::Json((msg, status)) => write!(f, "{msg} (status: {status})")
```
makes it difficult for custom error implementation as the output of the above would look weird.

Here's an example:

```rust
let json_string = r#"{ "message": "test", "success": false }"#;
let err = worker::Error::Json((json_string.to_owned(), 500u16));
Response::error(err.to_string(), 500u16)
```

Outputs:
```json
{ "message": "test", "success": false } (status: 500)
```
The above doesn't quite serve its purpose for the implemented `Display` trait.

It looks perfect when the Json variant is written so:
```rust
Error::Json((msg, _)) => write!(f, "{msg}")
```

Outputs:
```json
{
	"message": "test",
	"success": false
}
```
