### PR TITLE
Add derive debug, clone for FormData and File

### DIFF
--- a/worker/src/formdata.rs
+++ b/worker/src/formdata.rs
@@ -12,14 +12,14 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 
 /// Representing the options any FormData value can be, a field or a file.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FormEntry {
     Field(String),
     File(File),
 }
 /// A [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) representation of the
 /// request body, providing access to form encoded fields and files.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FormData(web_sys::FormData);
 
 impl FormData {
@@ -112,7 +112,7 @@ impl From<HashMap<&dyn AsRef<&str>, &dyn AsRef<&str>>> for FormData {
 
 /// A [File](https://developer.mozilla.org/en-US/docs/Web/API/File) representation used with
 /// `FormData`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct File(web_sys::File);
 
 impl File {

--- a/worker/src/formdata.rs
+++ b/worker/src/formdata.rs
@@ -12,11 +12,11 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 
 /// Representing the options any FormData value can be, a field or a file.
+#[derive(Debug, Clone)]
 pub enum FormEntry {
     Field(String),
     File(File),
 }
-
 /// A [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) representation of the
 /// request body, providing access to form encoded fields and files.
 #[derive(Debug)]
@@ -112,6 +112,7 @@ impl From<HashMap<&dyn AsRef<&str>, &dyn AsRef<&str>>> for FormData {
 
 /// A [File](https://developer.mozilla.org/en-US/docs/Web/API/File) representation used with
 /// `FormData`.
+#[derive(Debug, Clone)]
 pub struct File(web_sys::File);
 
 impl File {

--- a/worker/src/headers.rs
+++ b/worker/src/headers.rs
@@ -13,6 +13,7 @@ use worker_sys::ext::HeadersExt;
 
 /// A [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) representation used in
 /// Request and Response objects.
+#[derive(Clone, PartialEq, Eq)]
 pub struct Headers(pub web_sys::Headers);
 
 impl std::fmt::Debug for Headers {
@@ -180,12 +181,5 @@ impl From<&Headers> for HeaderMap {
 impl From<Headers> for HeaderMap {
     fn from(headers: Headers) -> Self {
         (&headers).into()
-    }
-}
-
-impl Clone for Headers {
-    fn clone(&self) -> Self {
-        // Headers constructor doesn't throw an error
-        Headers(web_sys::Headers::new_with_headers(&self.0).unwrap())
     }
 }

--- a/worker/src/http.rs
+++ b/worker/src/http.rs
@@ -1,6 +1,6 @@
 /// A [`Method`](https://developer.mozilla.org/en-US/docs/Web/API/Request/method) representation
 /// used on Request objects.
-#[derive(Default, Debug, Clone, PartialEq, Hash, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Hash, Eq)]
 pub enum Method {
     Head = 0,
     #[default]


### PR DESCRIPTION
This adds derive macros for a couple of types. There's no reason not to have them.
