### PR TITLE
add get_field helper method

### DIFF
--- a/worker/src/formdata.rs
+++ b/worker/src/formdata.rs
@@ -45,6 +45,25 @@ impl FormData {
         None
     }
 
+    /// Returns the first Field value associated with a given key from within a `FormData` object.
+    pub fn get_field(&self, name: &str) -> Option<String> {
+        let val = self.0.get(name);
+        if val.is_undefined() {
+            return None;
+        }
+
+        if val.is_instance_of::<web_sys::File>() {
+            return None;
+        }
+
+        if let Some(field) = val.as_string() {
+            return Some(field);
+        }
+
+        None
+
+    }
+
     /// Returns a vec of all the values associated with a given key from within a `FormData` object.
     pub fn get_all(&self, name: &str) -> Option<Vec<FormEntry>> {
         let val = self.0.get_all(name);

--- a/worker/src/formdata.rs
+++ b/worker/src/formdata.rs
@@ -61,7 +61,6 @@ impl FormData {
         }
 
         None
-
     }
 
     /// Returns a vec of all the values associated with a given key from within a `FormData` object.


### PR DESCRIPTION
This PR creates a helper method for `FormData` so that users don't have to pattern match for `FormEntry::Field` every time they want to use this. 99% of the time the passed arguments aren't files.
