### PR TITLE
:memo: caveat when upgrading to worker 0.0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,19 @@ please [take a look](https://www.cloudflare.com/careers/).
   your code depends on, or strip as much from the `.wasm` binary as possible. Here are some extra
   steps you can try: https://rustwasm.github.io/book/reference/code-size.html#optimizing-builds-for-code-size
 
+### ⚠️ Caveats
+
+1. Upgrading worker package to version `0.0.18` and higher
+
+- While upgrading your worker to version `0.0.18` an error `error[E0432]: unresolved import `crate::sys::IoSourceState` can appear.
+  In this case, upgrade `package.edition` to `edition = "2021"` in `wrangler.toml`
+
+```toml
+[package]
+edition = "2021"
+```
+
+
 # Contributing
 
 Your feedback is welcome and appreciated! Please use the issue tracker to talk about potential


### PR DESCRIPTION
### Context

We (@kodadot) are huge fans of Cloudflare and Workers and we have a ton of workers in the prod (Rust / TS).

As anyone would upgrade to latest version they would meet this very scary error 

```
[INFO]: 🌀  Compiling to Wasm...
   Compiling proc-macro2 v1.0.67
   Compiling phf_shared v0.11.1
   Compiling serde v1.0.164
   Compiling syn v1.0.109
   Compiling unicode-normalization v0.1.22
   Compiling mio v0.8.8
   Compiling matchit v0.4.6
error[E0432]: unresolved import `crate::sys::IoSourceState`
```

The only mention I found was in Cloudlfare's discord


<img width="893" alt="Screenshot 2023-10-03 at 17 34 25" src="https://github.com/cloudflare/workers-rs/assets/22471030/a71dfd24-6017-4910-bca8-86620f6bb588">



