### PR TITLE
Add Headers len and is_empty method

### DIFF
--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -37,7 +37,7 @@ impl From<web_sys::Request> for Request {
                     }
                     u
                 }),
-            headers: Headers(req.headers()),
+            headers: req.headers().into(),
             cf: req.cf().map(Into::into),
             edge_request: req,
             body_used: false,

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -440,7 +440,7 @@ impl From<&Response> for web_sys::Response {
 impl From<web_sys::Response> for Response {
     fn from(res: web_sys::Response) -> Self {
         Self {
-            headers: Headers(res.headers()),
+            headers: res.headers().into(),
             status_code: res.status(),
             websocket: res.websocket().map(|ws| ws.into()),
             body: match res.body() {


### PR DESCRIPTION
## Features
- Headers::len method
- Headers::is_empty method
- New addition of macro that's used to set or append to headers to avoid duplicated code

This PR introduces the above to let caller get the number of elements that are in the headers.

Currently the only way to get the number of elements is by iterating the headers and call the iterator's method `.count()`, the above allows caller to do so without iterating the elements.