### PR TITLE
Use serde to more easily get query parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,6 +2361,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen 0.6.1",
  "serde_json",
+ "serde_urlencoded",
  "tokio",
  "tokio-postgres",
  "url",

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -30,6 +30,7 @@ url = "2.4.0"
 wasm-bindgen = "=0.2.87"
 wasm-bindgen-futures = "0.4.36"
 serde-wasm-bindgen = "0.6.1"
+serde_urlencoded = "0.7"
 wasm-streams = "0.3.0"
 worker-kv = "0.6.0"
 worker-macros = { path = "../worker-macros", version = "0.0.10" }

--- a/worker/src/error.rs
+++ b/worker/src/error.rs
@@ -34,6 +34,12 @@ impl From<url::ParseError> for Error {
     }
 }
 
+impl From<serde_urlencoded::de::Error> for Error {
+    fn from(e: serde_urlencoded::de::Error) -> Self {
+        Self::RustError(e.to_string())
+    }
+}
+
 impl From<serde_wasm_bindgen::Error> for Error {
     fn from(e: serde_wasm_bindgen::Error) -> Self {
         let val: JsValue = e.into();

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -242,6 +242,15 @@ impl Request {
             .map_err(|e| Error::RustError(format!("failed to parse Url from {e}: {url}")))
     }
 
+    /// Deserialize the url query
+    pub fn query<Q: DeserializeOwned>(&self) -> Result<Q> {
+        let url = self.url()?;
+        let pairs = url.query_pairs();
+        let deserializer = serde_urlencoded::Deserializer::new(pairs);
+
+        Q::deserialize(deserializer).map_err(Error::from)
+    }
+
     #[allow(clippy::should_implement_trait)]
     pub fn clone(&self) -> Result<Self> {
         self.edge_request


### PR DESCRIPTION
Allows the user to do something like this:

```rust
#[derive(Deserialize)]
struct MyQueryParams {
    a: i32,
    b: bool,
    c: String,
}

router.get("/route", |req, _ctx| {
    let query: MyQueryParams = req.query()?;

    // ?a=2&b=true&c=Hello
    assert_eq!(
        query,
        MyQueryParams {
            a: 2,
            b: true,
            c: "Hello".into(),
        }
    );
})
```

This is the inverse implementation of what [`reqwest` does](https://docs.rs/reqwest/latest/src/reqwest/async_impl/request.rs.html#349-369) for building queries using serde.