### PR TITLE
add the ability to set the protocol(s) when creating a websocket client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# RustRover
+.idea

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -64,7 +64,7 @@ impl WebSocket {
     /// Response::error("never got a message echoed back :(", 500)
     /// ```
     pub async fn connect(url: Url) -> Result<WebSocket> {
-        return WebSocket::connect_with_protocols(url, None).await;
+        WebSocket::connect_with_protocols(url, None).await
     }
 
     /// Attempts to establish a [`WebSocket`] connection to the provided [`Url`] and protocol.
@@ -74,7 +74,10 @@ impl WebSocket {
     /// let ws = WebSocket::connect_with_protocols("wss://echo.zeb.workers.dev/".parse()?, Some(vec!["GiggleBytes"])).await?;
     ///
     /// ```
-    pub async fn connect_with_protocols(mut url: Url, protocols: Option<Vec<&str>>) -> Result<WebSocket> {
+    pub async fn connect_with_protocols(
+        mut url: Url,
+        protocols: Option<Vec<&str>>,
+    ) -> Result<WebSocket> {
         let scheme: String = match url.scheme() {
             "ws" => "http".into(),
             "wss" => "https".into(),
@@ -91,7 +94,8 @@ impl WebSocket {
         match protocols {
             None => {}
             Some(v) => {
-                req.headers_mut()?.set("Sec-WebSocket-Protocol", v.join(",").as_str())?;
+                req.headers_mut()?
+                    .set("Sec-WebSocket-Protocol", v.join(",").as_str())?;
             }
         }
 

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -63,7 +63,18 @@ impl WebSocket {
     ///
     /// Response::error("never got a message echoed back :(", 500)
     /// ```
-    pub async fn connect(mut url: Url) -> Result<WebSocket> {
+    pub async fn connect(url: Url) -> Result<WebSocket> {
+        return WebSocket::connect_with_protocols(url, None).await;
+    }
+
+    /// Attempts to establish a [`WebSocket`] connection to the provided [`Url`] and protocol.
+    ///
+    /// # Example:
+    /// ```rust,ignore
+    /// let ws = WebSocket::connect_with_protocols("wss://echo.zeb.workers.dev/".parse()?, Some(vec!["GiggleBytes"])).await?;
+    ///
+    /// ```
+    pub async fn connect_with_protocols(mut url: Url, protocols: Option<Vec<&str>>) -> Result<WebSocket> {
         let scheme: String = match url.scheme() {
             "ws" => "http".into(),
             "wss" => "https".into(),
@@ -76,6 +87,13 @@ impl WebSocket {
 
         let mut req = Request::new(url.as_str(), Method::Get)?;
         req.headers_mut()?.set("upgrade", "websocket")?;
+
+        match protocols {
+            None => {}
+            Some(v) => {
+                req.headers_mut()?.set("Sec-WebSocket-Protocol", v.join(",").as_str())?;
+            }
+        }
 
         let res = Fetch::Request(req).send().await?;
 


### PR DESCRIPTION
I found myself needing to set the protocol when creating a websocket client. This exposes a new function that allows the caller to the protocol.

Pretty straightforward, happy to adjust as needed!

