### PR TITLE
fix: Use method of http crate instead of the original method

### DIFF
--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
 
 use blake2::{Blake2b512, Digest};
 use futures_util::{future::Either, StreamExt, TryStreamExt};
+use http::Method;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -331,7 +332,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
             Response::ok(req.text().await?)
         })
         .get_async("/fetch", |_req, _ctx| async move {
-            let req = Request::new("https://example.com", Method::Post)?;
+            let req = Request::new("https://example.com", Method::POST)?;
             let resp = Fetch::Request(req).send().await?;
             let resp2 = Fetch::Url("https://example.com".parse()?).send().await?;
             Response::ok(format!(
@@ -453,7 +454,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         })
         .get_async("/request-init-fetch-post", |_, _| async move {
             let mut init = RequestInit::new();
-            init.method = Method::Post;
+            init.method = Method::POST;
             Fetch::Request(Request::new_with_init("https://httpbin.org/post", &init)?)
                 .send()
                 .await
@@ -676,7 +677,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         .get_async("/remote-by-path", |req, ctx| async move {
             let fetcher = ctx.service("remote")?;
             let mut init = RequestInit::new();
-            init.with_method(Method::Post);
+            init.with_method(Method::POST);
 
             fetcher.fetch(req.url()?.to_string(), Some(init)).await
         })
@@ -738,7 +739,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
 }
 
 fn respond<D>(req: Request, _ctx: RouteContext<D>) -> Result<Response> {
-    Response::ok(format!("Ok: {}", String::from(req.method()))).map(|resp| {
+    Response::ok(format!("Ok: {}", req.method())).map(|resp| {
         let mut headers = Headers::new();
         headers.set("x-testing", "123").unwrap();
         resp.with_headers(headers)
@@ -746,7 +747,7 @@ fn respond<D>(req: Request, _ctx: RouteContext<D>) -> Result<Response> {
 }
 
 async fn respond_async<D>(req: Request, _ctx: RouteContext<D>) -> Result<Response> {
-    Response::ok(format!("Ok (async): {}", String::from(req.method()))).map(|resp| {
+    Response::ok(format!("Ok (async): {}", req.method())).map(|resp| {
         let mut headers = Headers::new();
         headers.set("x-testing", "123").unwrap();
         resp.with_headers(headers)

--- a/worker-sandbox/src/test/durable.rs
+++ b/worker-sandbox/src/test/durable.rs
@@ -1,4 +1,5 @@
 use crate::ensure;
+use http::Method;
 use worker::*;
 
 #[allow(dead_code)]
@@ -15,7 +16,7 @@ pub async fn basic_test(env: &Env) -> Result<()> {
             "hello",
             RequestInit::new()
                 .with_body(Some("lol".into()))
-                .with_method(Method::Post),
+                .with_method(Method::POST),
         )?)
         .await?
         .text()

--- a/worker/src/cors.rs
+++ b/worker/src/cors.rs
@@ -1,4 +1,5 @@
-use crate::{Error, Headers, Method, Result};
+use crate::{Error, Headers, Result};
+use http::Method;
 
 /// Cors struct, holding cors configuration
 #[derive(Debug, Clone)]

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -37,7 +37,6 @@ pub use crate::fetcher::Fetcher;
 pub use crate::formdata::*;
 pub use crate::global::Fetch;
 pub use crate::headers::Headers;
-pub use crate::http::Method;
 #[cfg(feature = "queue")]
 pub use crate::queue::*;
 pub use crate::r2::*;
@@ -68,7 +67,6 @@ mod fetcher;
 mod formdata;
 mod global;
 mod headers;
-mod http;
 #[cfg(feature = "queue")]
 mod queue;
 mod r2;

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -1,8 +1,8 @@
 use std::convert::TryFrom;
 
-use crate::{
-    cf::Cf, error::Error, headers::Headers, http::Method, ByteStream, FormData, RequestInit, Result,
-};
+use crate::{cf::Cf, error::Error, headers::Headers, ByteStream, FormData, RequestInit, Result};
+
+use http::Method;
 
 use serde::de::DeserializeOwned;
 use std::borrow::Cow;
@@ -27,7 +27,7 @@ pub struct Request {
 impl From<web_sys::Request> for Request {
     fn from(req: web_sys::Request) -> Self {
         Self {
-            method: req.method().into(),
+            method: Method::try_from(req.method().as_str()).unwrap_or(Method::GET),
             path: Url::parse(&req.url())
                 .map(|u| u.path().into())
                 .unwrap_or_else(|_| {
@@ -321,7 +321,7 @@ fn url_param_works() {
 fn clone_mut_works() {
     let req = Request::new(
         "https://example.com/foo.html?a=foo&b=bar&a=baz",
-        crate::Method::Get,
+        Method::GET,
     )
     .unwrap();
     assert!(!req.immutable);

--- a/worker/src/request_init.rs
+++ b/worker/src/request_init.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::headers::Headers;
-use crate::http::Method;
+use http::Method;
 
 use js_sys::{self, Object};
 use wasm_bindgen::{prelude::*, JsValue};
@@ -84,7 +84,7 @@ impl Default for RequestInit {
             body: None,
             headers: Headers::new(),
             cf: CfProperties::default(),
-            method: Method::Get,
+            method: Method::GET,
             redirect: RequestRedirect::default(),
         }
     }

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -1,6 +1,7 @@
-use crate::{Error, Fetch, Method, Request, Result};
+use crate::{Error, Fetch, Request, Result};
 use futures_channel::mpsc::UnboundedReceiver;
 use futures_util::Stream;
+use http::Method;
 use serde::Serialize;
 use url::Url;
 use worker_sys::ext::WebSocketExt;
@@ -74,7 +75,7 @@ impl WebSocket {
         // those connections into websockets if we use the `Upgrade` header.
         url.set_scheme(&scheme).unwrap();
 
-        let mut req = Request::new(url.as_str(), Method::Get)?;
+        let mut req = Request::new(url.as_str(), Method::GET)?;
         req.headers_mut()?.set("upgrade", "websocket")?;
 
         let res = Fetch::Request(req).send().await?;


### PR DESCRIPTION
close: #426

In the original `worker-rs`, the `Method` was limited to only 8 standard methods. However, in reality, there are more than 8 methods defined on top of HTTP, and custom methods cannot be created. But, using JavaScript, the custom methods are possible.

I believe this is a bug, using `http` crate from Rust is a better choice, because `reqwest` and `hyper` are based on it. So I hope the offical team can address and fix this bug.
