### PR TITLE
fix docs typos in `DurableObject`

### DIFF
--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -713,10 +713,9 @@ use worker::*;
 #[durable_object]
 pub struct Chatroom {
     users: Vec<User>,
-    messages: Vec<Message>
+    messages: Vec<Message>,
     state: State,
     env: Env, // access `Env` across requests, use inside `fetch`
-
 }
 
 #[durable_object]

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -724,7 +724,7 @@ impl DurableObject for Chatroom {
         Self {
             users: vec![],
             messages: vec![],
-            state: state,
+            state,
             env,
         }
     }


### PR DESCRIPTION
Fix a syntax error (missing comma) and a lint warning, and remove a blank line.

This is part of the [public documentation](https://docs.rs/worker/0.0.18/worker/durable/trait.DurableObject.html#example); might as well have it be correct and idiomatic.