### PR TITLE
Serialize cache_ttl_by_status as object in cf properties

### DIFF
--- a/worker/src/request_init.rs
+++ b/worker/src/request_init.rs
@@ -4,6 +4,7 @@ use crate::headers::Headers;
 use crate::http::Method;
 
 use js_sys::{self, Object};
+use serde::Serialize;
 use wasm_bindgen::{prelude::*, JsValue};
 
 /// Optional options struct that contains settings to apply to the `Request`.
@@ -146,6 +147,7 @@ impl From<&CfProperties> for JsValue {
     fn from(props: &CfProperties) -> Self {
         let obj = js_sys::Object::new();
         let defaults = CfProperties::default();
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
 
         set_prop(
             &obj,
@@ -191,7 +193,7 @@ impl From<&CfProperties> for JsValue {
         set_prop(
             &obj,
             &JsValue::from("cacheTtlByStatus"),
-            &serde_wasm_bindgen::to_value(&ttl_status_map).unwrap_or_default(),
+            &ttl_status_map.serialize(&serializer).unwrap_or_default(),
         );
 
         set_prop(


### PR DESCRIPTION
Fixes #442

Serializes `ttl_status_map` as an object instead of a JavaScript Map using a serde_wasm_bindgen serializer.

Inspecting cf properties, TTL attributes are now present.

Before:
```Rust
request cf properties: Cf { inner: IncomingRequestCfProperties { obj: Object { obj: JsValue(Object({"apps":true,"cacheEverything":true,"cacheKey":"","cacheTtl":0,"cacheTtlByStatus":{},"minify":{"__wbg_ptr":1455240},"mirage":true,"polish":"off","resolveOverride":"","scrapeShield":true})) } } }

```

After
```Rust
request cf properties: Cf { inner: IncomingRequestCfProperties { obj: Object { obj: JsValue(Object({"apps":true,"cacheEverything":true,"cacheKey":"","cacheTtl":0,"cacheTtlByStatus":{"200-299":5,"300-399":10},"minify":{"__wbg_ptr":1311768},"mirage":true,"polish":"off","resolveOverride":"","scrapeShield":true})) } } }
```

Repeating the test from the reported issue:

```Rust
const originResponse = await fetch(url, {
  cf: {
    cacheEverything: true,
    cacheTtlByStatus: {
      '200-299': 5,
      '300-399': 10,
    },
  }
});
```

The behavior now matches that of the JavaScript implementation:
```
172.69.64.52 - - [14/Feb/2024:04:55:56 +0000] "GET / HTTP/1.1" 304"
172.69.64.52 - - [14/Feb/2024:04:56:07 +0000] "GET / HTTP/1.1" 304"
172.69.64.52 - - [14/Feb/2024:04:56:18 +0000] "GET / HTTP/1.1" 304"
172.69.64.52 - - [14/Feb/2024:04:56:29 +0000] "GET / HTTP/1.1" 304"
172.69.64.52 - - [14/Feb/2024:04:56:40 +0000] "GET / HTTP/1.1" 304"
```