### PR TITLE
Make Response::from_html use `text/html; charset=utf-8`

### DIFF
--- a/examples/hyper/src/lib.rs
+++ b/examples/hyper/src/lib.rs
@@ -20,7 +20,9 @@ async fn make_request(
         .map_err(map_hyper_error)?;
     let text = std::str::from_utf8(&buf).map_err(map_utf8_error)?;
     let mut response = Response::ok(text)?;
-    response.headers_mut().append("Content-Type", "text/html; charset=utf-8")?;
+    response
+        .headers_mut()
+        .append("Content-Type", "text/html; charset=utf-8")?;
     Ok(response)
 }
 #[event(fetch)]

--- a/examples/hyper/src/lib.rs
+++ b/examples/hyper/src/lib.rs
@@ -20,7 +20,7 @@ async fn make_request(
         .map_err(map_hyper_error)?;
     let text = std::str::from_utf8(&buf).map_err(map_utf8_error)?;
     let mut response = Response::ok(text)?;
-    response.headers_mut().append("Content-Type", "text/html")?;
+    response.headers_mut().append("Content-Type", "text/html; charset=utf-8")?;
     Ok(response)
 }
 #[event(fetch)]

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -52,10 +52,10 @@ impl Response {
     }
 
     /// Create a `Response` using the body encoded as HTML. Sets the associated `Content-Type`
-    /// header for the `Response` as `text/html`.
+    /// header for the `Response` as `text/html; charset=utf-8`.
     pub fn from_html(html: impl AsRef<str>) -> Result<Self> {
         let mut headers = Headers::new();
-        headers.set(CONTENT_TYPE, "text/html")?;
+        headers.set(CONTENT_TYPE, "text/html; charset=utf-8")?;
 
         let data = html.as_ref().as_bytes().to_vec();
         Ok(Self {

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -130,10 +130,10 @@ impl Response {
     }
 
     /// Create a `Response` using unprocessed text provided. Sets the associated `Content-Type`
-    /// header for the `Response` as `text/plain`.
+    /// header for the `Response` as `text/plain; charset=utf-8`.
     pub fn ok(body: impl Into<String>) -> Result<Self> {
         let mut headers = Headers::new();
-        headers.set(CONTENT_TYPE, "text/plain")?;
+        headers.set(CONTENT_TYPE, "text/plain; charset=utf-8")?;
 
         Ok(Self {
             body: ResponseBody::Body(body.into().into_bytes()),


### PR DESCRIPTION
```rust
Response::from_html("<h1>Hello, World! 🐱</h1>")
```

## Before

![image](https://github.com/cloudflare/workers-rs/assets/7763184/eb3fc81a-d685-499f-bb84-9e0e96274b45)

## After

![image](https://github.com/cloudflare/workers-rs/assets/7763184/36aa088b-ee13-459e-bc1b-42c51013b245)
