### PR TITLE
Add cf.as_organization function

### DIFF
--- a/worker-sys/src/types/incoming_request_cf_properties.rs
+++ b/worker-sys/src/types/incoming_request_cf_properties.rs
@@ -14,6 +14,9 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn asn(this: &IncomingRequestCfProperties) -> u32;
 
+    #[wasm_bindgen(method, getter, js_name=asOrganization)]
+    pub fn as_organization(this: &IncomingRequestCfProperties) -> String;
+
     #[wasm_bindgen(method, getter)]
     pub fn country(this: &IncomingRequestCfProperties) -> Option<String>;
 

--- a/worker/src/cf.rs
+++ b/worker/src/cf.rs
@@ -18,6 +18,11 @@ impl Cf {
         self.inner.asn()
     }
 
+    /// The Autonomous System organization name of the request, e.g. `Cloudflare, Inc.`
+    pub fn as_organization(&self) -> String {
+        self.inner.as_organization()
+    }
+
     /// The two-letter country code of origin for the request.
     /// This is the same value as that provided in the CF-IPCountry header, e.g.  `"US"`
     pub fn country(&self) -> Option<String> {


### PR DESCRIPTION
I noticed there's no getter for this field. It's analogous to `asn`, but I'm not sure if `String` is correct or if this should be `Option<String>`.