### PR TITLE
add a way of getting the Crypto object

### DIFF
--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -39,6 +39,7 @@ worker-sys = { path = "../worker-sys", version = "0.0.12" }
 [dependencies.web-sys]
 version = "0.3.63"
 features = [
+    "Crypto",
     "File",
     "WorkerGlobalScope",
     "ReadableStreamDefaultReader",

--- a/worker/src/crypto.rs
+++ b/worker/src/crypto.rs
@@ -1,0 +1,6 @@
+use wasm_bindgen::JsCast;
+
+pub fn crypto() -> web_sys::Crypto {
+    let global: web_sys::WorkerGlobalScope = js_sys::global().unchecked_into();
+    global.crypto().expect("failed to acquire Crypto")
+}

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -25,6 +25,7 @@ pub use crate::abort::*;
 pub use crate::cache::{Cache, CacheDeletionOutcome, CacheKey};
 pub use crate::context::Context;
 pub use crate::cors::Cors;
+pub use crate::crypto::*;
 #[cfg(feature = "d1")]
 pub use crate::d1::*;
 pub use crate::date::{Date, DateInit};
@@ -55,6 +56,7 @@ mod cache;
 mod cf;
 mod context;
 mod cors;
+mod crypto;
 // Require pub module for macro export
 #[cfg(feature = "d1")]
 pub mod d1;


### PR DESCRIPTION
`web_sys` understands how to acquire `Crypto` from a `Window` or from a `WorkerGlobalScope`, but neither of these work in a worker context.

It turns out to be possible, but it's not obvious how to do it, so it's convenient to have the worker crate provide this access.

I find this very useful when doing JWT validation; I prefer letting the runtime handle the details of low-level cryptography.