### PR TITLE
Derive Clone for Queue

### DIFF
--- a/worker/src/queue.rs
+++ b/worker/src/queue.rs
@@ -143,6 +143,7 @@ impl<'a, T> std::iter::FusedIterator for MessageIter<'a, T> where T: Deserialize
 
 impl<'a, T> std::iter::ExactSizeIterator for MessageIter<'a, T> where T: DeserializeOwned {}
 
+#[derive(Clone)]
 pub struct Queue(EdgeQueue);
 
 impl EnvBinding for Queue {


### PR DESCRIPTION
I think there is no reason not to have this. It will come in handy when the https://github.com/cloudflare/workers-rs/pull/477 lands because `axum` requires state to implement `Clone`.