### PR TITLE
[WIP] Convert global fetcher to use `http` crate

### DIFF
--- a/worker/src/global.rs
+++ b/worker/src/global.rs
@@ -3,9 +3,17 @@ use std::ops::Deref;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 
-use crate::{
-    request::Request as WorkerRequest, response::Response as WorkerResponse, AbortSignal, Result,
-};
+use crate::{AbortSignal, Result};
+
+#[cfg(feature = "http")]
+type WorkerRequest = http::Request<crate::Body>;
+#[cfg(not(feature = "http"))]
+type WorkerRequest = crate::request::Request;
+
+#[cfg(feature = "http")]
+type WorkerResponse = http::Response<crate::Body>;
+#[cfg(not(feature = "http"))]
+type WorkerResponse = crate::response::Response;
 
 /// Construct a Fetch call from a URL string or a Request object. Call its `send` method to execute
 /// the request.
@@ -14,6 +22,7 @@ pub enum Fetch {
     Request(WorkerRequest),
 }
 
+#[cfg(not(feature = "http"))]
 impl Fetch {
     /// Execute a Fetch call and receive a Response.
     pub async fn send(&self) -> Result<WorkerResponse> {
@@ -32,6 +41,25 @@ impl Fetch {
     }
 }
 
+#[cfg(feature = "http")]
+impl Fetch {
+    /// Execute a Fetch call and receive a Response.
+    pub async fn send(self) -> Result<WorkerResponse> {
+        match self {
+            Fetch::Url(url) => fetch_with_str(url.as_ref(), None).await,
+            Fetch::Request(req) => fetch_with_request(req, None).await,
+        }
+    }
+
+    /// Execute a Fetch call and receive a Response.
+    pub async fn send_with_signal(self, signal: &AbortSignal) -> Result<WorkerResponse> {
+        match self {
+            Fetch::Url(url) => fetch_with_str(url.as_ref(), Some(signal)).await,
+            Fetch::Request(req) => fetch_with_request(req, Some(signal)).await,
+        }
+    }
+}
+
 async fn fetch_with_str(url: &str, signal: Option<&AbortSignal>) -> Result<WorkerResponse> {
     let mut init = web_sys::RequestInit::new();
     init.signal(signal.map(|x| x.deref()));
@@ -40,20 +68,34 @@ async fn fetch_with_str(url: &str, signal: Option<&AbortSignal>) -> Result<Worke
     let promise = worker.fetch_with_str_and_init(url, &init);
     let resp = JsFuture::from(promise).await?;
     let resp: web_sys::Response = resp.dyn_into()?;
-    Ok(resp.into())
+    #[cfg(feature = "http")]
+    let result = crate::response_from_wasm(resp);
+    #[cfg(not(feature = "http"))]
+    let result = Ok(resp.into());
+    result
 }
 
 async fn fetch_with_request(
-    request: &WorkerRequest,
+    #[cfg(feature = "http")] request: WorkerRequest,
+    #[cfg(not(feature = "http"))] request: &WorkerRequest,
     signal: Option<&AbortSignal>,
 ) -> Result<WorkerResponse> {
     let mut init = web_sys::RequestInit::new();
     init.signal(signal.map(|x| x.deref()));
 
     let worker: web_sys::WorkerGlobalScope = js_sys::global().unchecked_into();
+
+    #[cfg(feature = "http")]
+    let req = &crate::request_to_wasm(request)?;
+    #[cfg(not(feature = "http"))]
     let req = request.inner();
+
     let promise = worker.fetch_with_request_and_init(req, &init);
-    let resp = JsFuture::from(promise).await?;
-    let edge_response: web_sys::Response = resp.dyn_into()?;
-    Ok(edge_response.into())
+    let js_resp = JsFuture::from(promise).await?;
+    let resp: web_sys::Response = js_resp.dyn_into()?;
+    #[cfg(feature = "http")]
+    let result = crate::response_from_wasm(resp);
+    #[cfg(not(feature = "http"))]
+    let result = Ok(resp.into());
+    result
 }

--- a/worker/src/request_init.rs
+++ b/worker/src/request_init.rs
@@ -198,6 +198,12 @@ impl From<&CfProperties> for JsValue {
 
         set_prop(
             &obj,
+            &JsValue::from("httpProtocol"),
+            &JsValue::from("HTTP/1.1"),
+        );
+
+        set_prop(
+            &obj,
             &JsValue::from("minify"),
             &JsValue::from(props.minify.unwrap_or(defaults.minify.unwrap_or_default())),
         );


### PR DESCRIPTION
This was identified as an inconsistency in the original PR (#477). This is one option for fixing it (converting the existing API), but another that I will try is to improve interoperability so that we can just recommend that people use `reqwest` directly and remove this API entirely. Will open another PR with that option. 

Note that there is one breaking change: the request object supplied to `fetch_with_request` is no longer a reference. 