### PR TITLE
impl Send/Sync for Queue

### DIFF
--- a/worker/src/queue.rs
+++ b/worker/src/queue.rs
@@ -145,6 +145,9 @@ impl<'a, T> std::iter::ExactSizeIterator for MessageIter<'a, T> where T: Deseria
 
 pub struct Queue(EdgeQueue);
 
+unsafe impl Send for Queue {}
+unsafe impl Sync for Queue {}
+
 impl EnvBinding for Queue {
     const TYPE_NAME: &'static str = "WorkerQueue";
 }


### PR DESCRIPTION
I'm in the process of migrating a worker to use `axum` and this missing impl prevents using `Queue` in a state that can be attached to a router. Another issue is a missing `Send`/`Sync` impl on `KvStore` but that lives in the `worker-kv` repo, outside of the cloudflare org. Should I make a PR there as well?