### PR TITLE
implement get_tags for hibernatable websockets

### DIFF
--- a/worker-sys/src/types/durable_object/state.rs
+++ b/worker-sys/src/types/durable_object/state.rs
@@ -32,4 +32,7 @@ extern "C" {
     #[wasm_bindgen(method, js_name=getWebSockets)]
     pub fn get_websockets_with_tag(this: &DurableObjectState, tag: &str)
         -> Vec<web_sys::WebSocket>;
+
+    #[wasm_bindgen(method, js_name=getTags)]
+    pub fn get_tags(this: &DurableObjectState, ws: &web_sys::WebSocket) -> Vec<String>;
 }

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -220,6 +220,11 @@ impl State {
             .map(Into::into)
             .collect()
     }
+
+    /// Retrieve tags from a hibernatable websocket
+    pub fn get_tags(&self, websocket: &WebSocket) -> Vec<String> {
+        self.inner.get_tags(websocket.as_ref())
+    }
 }
 
 impl From<DurableObjectState> for State {


### PR DESCRIPTION
get_tags allows a durable object to read metadata describing the websocket.

It's useful when a durable object is managing multiple websockets and needs to discover which one sent a message that caused a hibernating websocket to wake.