### PR TITLE
Expose DurableObject Storage's transaction function

### DIFF
--- a/worker-sys/src/types/durable_object/storage.rs
+++ b/worker-sys/src/types/durable_object/storage.rs
@@ -53,7 +53,7 @@ extern "C" {
     #[wasm_bindgen(method, catch)]
     pub fn transaction(
         this: &DurableObjectStorage,
-        closure: &Closure<dyn FnMut(DurableObjectTransaction)>,
+        closure: &Closure<dyn FnMut(DurableObjectTransaction) -> js_sys::Promise>,
     ) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=getAlarm)]

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -437,36 +437,34 @@ impl Storage {
         fut.await.map(|_| ()).map_err(Error::from)
     }
 
-    // TODO(nilslice): follow up with runtime team on transaction API in general
-    // This function doesn't work on stable yet because the wasm_bindgen `Closure` type is still nightly-gated
-    // #[allow(dead_code)]
-    // async fn transaction<F>(&mut self, closure: fn(Transaction) -> F) -> Result<()>
-    // where
-    //     F: Future<Output = Result<()>> + 'static,
-    // {
-    //     let mut clos = |t: Transaction| {
-    //         future_to_promise(async move {
-    //             closure(t)
-    //                 .await
-    //                 .map_err(JsValue::from)
-    //                 .map(|_| JsValue::NULL)
-    //         })
-    //     };
-    //     JsFuture::from(self.inner.transaction_internal(&mut clos)?)
-    //         .await
-    //         .map_err(Error::from)
-    //         .map(|_| ())
-    // }
+    pub async fn transaction<F, Fut>(&mut self, mut closure: F) -> Result<()>
+    where
+        F: FnMut(Transaction) -> Fut + Copy + 'static,
+        Fut: Future<Output = Result<()>> + 'static,
+    {
+        let inner: Box<dyn FnMut(DurableObjectTransaction) -> js_sys::Promise> =
+            Box::new(move |t: DurableObjectTransaction| -> js_sys::Promise {
+                future_to_promise(async move {
+                    closure(Transaction { inner: t })
+                        .await
+                        .map_err(JsValue::from)
+                        .map(|_| JsValue::NULL)
+                })
+            });
+        let clos = wasm_bindgen::closure::Closure::wrap(inner);
+        JsFuture::from(self.inner.transaction(&clos)?)
+            .await
+            .map_err(Error::from)
+            .map(|_| ())
+    }
 }
 
-#[allow(dead_code)]
-struct Transaction {
+pub struct Transaction {
     inner: DurableObjectTransaction,
 }
 
-#[allow(dead_code)]
 impl Transaction {
-    async fn get<T: DeserializeOwned>(&self, key: &str) -> Result<T> {
+    pub async fn get<T: DeserializeOwned>(&self, key: &str) -> Result<T> {
         JsFuture::from(self.inner.get(key)?)
             .await
             .and_then(|val| {
@@ -479,7 +477,7 @@ impl Transaction {
             .map_err(Error::from)
     }
 
-    async fn get_multiple(&self, keys: Vec<impl Deref<Target = str>>) -> Result<Map> {
+    pub async fn get_multiple(&self, keys: Vec<impl Deref<Target = str>>) -> Result<Map> {
         let keys = self.inner.get_multiple(
             keys.into_iter()
                 .map(|key| JsValue::from(key.deref()))
@@ -489,7 +487,7 @@ impl Transaction {
         keys.dyn_into::<Map>().map_err(Error::from)
     }
 
-    async fn put<T: Serialize>(&mut self, key: &str, value: T) -> Result<()> {
+    pub async fn put<T: Serialize>(&mut self, key: &str, value: T) -> Result<()> {
         JsFuture::from(self.inner.put(key, serde_wasm_bindgen::to_value(&value)?)?)
             .await
             .map_err(Error::from)
@@ -497,7 +495,7 @@ impl Transaction {
     }
 
     // Each key-value pair in the serialized object will be added to the storage
-    async fn put_multiple<T: Serialize>(&mut self, values: T) -> Result<()> {
+    pub async fn put_multiple<T: Serialize>(&mut self, values: T) -> Result<()> {
         let values = serde_wasm_bindgen::to_value(&values)?;
         if !values.is_object() {
             return Err("Must pass in a struct type".to_string().into());
@@ -508,7 +506,7 @@ impl Transaction {
             .map(|_| ())
     }
 
-    async fn delete(&mut self, key: &str) -> Result<bool> {
+    pub async fn delete(&mut self, key: &str) -> Result<bool> {
         let fut: JsFuture = self.inner.delete(key)?.into();
         fut.await
             .and_then(|jsv| {
@@ -518,7 +516,7 @@ impl Transaction {
             .map_err(Error::from)
     }
 
-    async fn delete_multiple(&mut self, keys: Vec<impl Deref<Target = str>>) -> Result<usize> {
+    pub async fn delete_multiple(&mut self, keys: Vec<impl Deref<Target = str>>) -> Result<usize> {
         let fut: JsFuture = self
             .inner
             .delete_multiple(
@@ -536,19 +534,19 @@ impl Transaction {
             .map_err(Error::from)
     }
 
-    async fn delete_all(&mut self) -> Result<()> {
+    pub async fn delete_all(&mut self) -> Result<()> {
         let fut: JsFuture = self.inner.delete_all()?.into();
         fut.await.map(|_| ()).map_err(Error::from)
     }
 
-    async fn list(&self) -> Result<Map> {
+    pub async fn list(&self) -> Result<Map> {
         let fut: JsFuture = self.inner.list()?.into();
         fut.await
             .and_then(|jsv| jsv.dyn_into())
             .map_err(Error::from)
     }
 
-    async fn list_with_options(&self, opts: ListOptions<'_>) -> Result<Map> {
+    pub async fn list_with_options(&self, opts: ListOptions<'_>) -> Result<Map> {
         let fut: JsFuture = self
             .inner
             .list_with_options(serde_wasm_bindgen::to_value(&opts)?.into())?
@@ -558,7 +556,7 @@ impl Transaction {
             .map_err(Error::from)
     }
 
-    fn rollback(&mut self) -> Result<()> {
+    pub fn rollback(&mut self) -> Result<()> {
         self.inner.rollback().map_err(Error::from)
     }
 }


### PR DESCRIPTION
Associated issue: #486 

The comment about nightly features is no longer relevant and I have a local changeset that enables this functionality with the existing dependency versions.

The documentation on this API indicates that it shouldn't generally be necessary to invoke this but there are still some cases where it is useful: https://developers.cloudflare.com/durable-objects/api/transactional-storage-api/#supported-options-2