### PR TITLE
Introduce D1PreparedStatement.bind_refs which does not take ownership

### DIFF
--- a/worker-sandbox/src/d1.rs
+++ b/worker-sandbox/src/d1.rs
@@ -18,7 +18,7 @@ pub async fn prepared_statement(
     let db = env.d1("DB")?;
     let unbound_stmt = worker::query!(&db, "SELECT * FROM people WHERE name = ?");
 
-    let stmt = unbound_stmt.bind_refs(&[&D1Type::Text("Ryan Upton")])?;
+    let stmt = unbound_stmt.bind_refs(&[&D1Type::text("Ryan Upton")])?;
 
     // All rows
     let results = stmt.all().await?;
@@ -49,7 +49,7 @@ pub async fn prepared_statement(
     assert_eq!(columns[1].as_str(), Some("Ryan Upton"));
     assert_eq!(columns[2].as_u64(), Some(21));
 
-    let stmt_2 = unbound_stmt.bind_refs(&[&D1Type::Text("John Smith")])?;
+    let stmt_2 = unbound_stmt.bind_refs(&[&D1Type::text("John Smith")])?;
     let person = stmt_2.first::<Person>(None).await?.unwrap();
     assert_eq!(person.name, "John Smith");
     assert_eq!(person.age, 92);

--- a/worker-sandbox/src/d1.rs
+++ b/worker-sandbox/src/d1.rs
@@ -18,7 +18,7 @@ pub async fn prepared_statement(
     let db = env.d1("DB")?;
     let unbound_stmt = worker::query!(&db, "SELECT * FROM people WHERE name = ?");
 
-    let stmt = unbound_stmt.bind_refs(&[&D1Type::text("Ryan Upton")])?;
+    let stmt = unbound_stmt.bind_refs(&D1Type::Text("Ryan Upton"))?;
 
     // All rows
     let results = stmt.all().await?;
@@ -49,10 +49,16 @@ pub async fn prepared_statement(
     assert_eq!(columns[1].as_str(), Some("Ryan Upton"));
     assert_eq!(columns[2].as_u64(), Some(21));
 
-    let stmt_2 = unbound_stmt.bind_refs(&[&D1Type::text("John Smith")])?;
+    let stmt_2 = unbound_stmt.bind_refs([&D1Type::Text("John Smith")])?;
     let person = stmt_2.first::<Person>(None).await?.unwrap();
     assert_eq!(person.name, "John Smith");
     assert_eq!(person.age, 92);
+
+    let prepared_argument = PreparedArgument::new(&D1Type::Text("Dorian Fischer"));
+    let stmt_3 = unbound_stmt.bind_refs(&prepared_argument)?;
+    let person = stmt_3.first::<Person>(None).await?.unwrap();
+    assert_eq!(person.name, "Dorian Fischer");
+    assert_eq!(person.age, 19);
 
     Response::ok("ok")
 }

--- a/worker-sandbox/src/d1.rs
+++ b/worker-sandbox/src/d1.rs
@@ -112,7 +112,7 @@ pub async fn error(_req: Request, env: Env, _data: SomeSharedData) -> Result<Res
     if let Error::D1(error) = error {
         assert_eq!(
             error.cause(),
-            "Error in line 1: THIS IS NOT VALID SQL: SqliteError: near \"THIS\": syntax error"
+            "Error in line 1: THIS IS NOT VALID SQL: near \"THIS\": syntax error"
         )
     } else {
         panic!("expected D1 error");

--- a/worker-sandbox/src/d1.rs
+++ b/worker-sandbox/src/d1.rs
@@ -54,7 +54,7 @@ pub async fn prepared_statement(
     assert_eq!(person.name, "John Smith");
     assert_eq!(person.age, 92);
 
-    let prepared_argument = PreparedArgument::new(&D1Type::Text("Dorian Fischer"));
+    let prepared_argument = D1PreparedArgument::new(&D1Type::Text("Dorian Fischer"));
     let stmt_3 = unbound_stmt.bind_refs(&prepared_argument)?;
     let person = stmt_3.first::<Person>(None).await?.unwrap();
     assert_eq!(person.name, "Dorian Fischer");

--- a/worker-sandbox/src/d1.rs
+++ b/worker-sandbox/src/d1.rs
@@ -1,6 +1,5 @@
 use crate::SomeSharedData;
 use serde::Deserialize;
-use wasm_bindgen::JsValue;
 use worker::*;
 
 #[derive(Deserialize)]
@@ -19,7 +18,7 @@ pub async fn prepared_statement(
     let db = env.d1("DB")?;
     let unbound_stmt = worker::query!(&db, "SELECT * FROM people WHERE name = ?");
 
-    let stmt = unbound_stmt.bind_refs(&[&JsValue::from_str("Ryan Upton")])?;
+    let stmt = unbound_stmt.bind_refs(&[&D1Type::Text("Ryan Upton")])?;
 
     // All rows
     let results = stmt.all().await?;
@@ -50,7 +49,7 @@ pub async fn prepared_statement(
     assert_eq!(columns[1].as_str(), Some("Ryan Upton"));
     assert_eq!(columns[2].as_u64(), Some(21));
 
-    let stmt_2 = unbound_stmt.bind_refs(&[&JsValue::from_str("John Smith")])?;
+    let stmt_2 = unbound_stmt.bind_refs(&[&D1Type::Text("John Smith")])?;
     let person = stmt_2.first::<Person>(None).await?.unwrap();
     assert_eq!(person.name, "John Smith");
     assert_eq!(person.age, 92);

--- a/worker-sandbox/tests/d1.spec.ts
+++ b/worker-sandbox/tests/d1.spec.ts
@@ -1,11 +1,8 @@
 import { describe, test, expect } from "vitest";
-
-const hasLocalDevServer = await fetch("http://localhost:8787/request")
-  .then((resp) => resp.ok)
-  .catch(() => false);
+import { mf } from "./mf";
 
 async function exec(query: string): Promise<number> {
-  const resp = await fetch("http://127.0.0.1:8787/d1/exec", {
+  const resp = await mf.dispatchFetch("http://fake.host/d1/exec", {
     method: "POST",
     body: query.split("\n").join(""),
   });
@@ -15,7 +12,7 @@ async function exec(query: string): Promise<number> {
   return Number(body);
 }
 
-describe.skipIf(!hasLocalDevServer)("d1", () => {
+describe("d1", () => {
   test("create table", async () => {
     const query = `CREATE TABLE IF NOT EXISTS uniqueTable (
       id INTEGER PRIMARY KEY,
@@ -49,22 +46,17 @@ describe.skipIf(!hasLocalDevServer)("d1", () => {
   });
 
   test("prepared statement", async () => {
-    const resp = await fetch("http://127.0.0.1:8787/d1/prepared");
+    const resp = await mf.dispatchFetch("http://fake.host/d1/prepared");
     expect(resp.status).toBe(200);
   });
 
   test("batch", async () => {
-    const resp = await fetch("http://127.0.0.1:8787/d1/batch");
-    expect(resp.status).toBe(200);
-  });
-
-  test("dump", async () => {
-    const resp = await fetch("http://127.0.0.1:8787/d1/dump");
+    const resp = await mf.dispatchFetch("http://fake.host/d1/batch");
     expect(resp.status).toBe(200);
   });
 
   test("error", async () => {
-    const resp = await fetch("http://127.0.0.1:8787/d1/error");
+    const resp = await mf.dispatchFetch("http://fake.host/d1/error");
     expect(resp.status).toBe(200);
   });
 });

--- a/worker-sandbox/tests/mf.ts
+++ b/worker-sandbox/tests/mf.ts
@@ -37,6 +37,7 @@ export const mf = new Miniflare({
   compatibilityDate: "2023-05-18",
   cache: true,
   cachePersist: false,
+  d1Databases: ["DB"],
   d1Persist: false,
   kvPersist: false,
   r2Persist: false,

--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -150,6 +150,24 @@ impl D1PreparedStatement {
         }
     }
 
+    /// Bind one or more parameters to the statement.
+    /// Consumes the old statement and returns a new statement with the bound parameters.
+    ///
+    /// D1 follows the SQLite convention for prepared statements parameter binding.
+    ///
+    /// # Considerations
+    ///
+    /// Supports Ordered (?NNNN) and Anonymous (?) parameters - named parameters are currently not supported.
+    ///
+    pub fn bind_refs(self, values: &[&JsValue]) -> Result<Self> {
+        let array: Array = values.iter().collect::<Array>();
+
+        match self.0.bind(array) {
+            Ok(stmt) => Ok(D1PreparedStatement(stmt)),
+            Err(err) => Err(Error::from(err)),
+        }
+    }
+
     /// Return the first row of results.
     ///
     /// If `col_name` is `Some`, returns that single value, otherwise returns the entire object.

--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -261,13 +261,13 @@ impl D1PreparedStatement {
     /// Result can be passed to [`D1Database::batch`] to execute the statements.
     pub fn batch_bind<'a, U: 'a, T: 'a, V: 'a>(&self, values: T) -> Result<Vec<Self>>
     where
-        T: IntoIterator<Item = &'a &'a U>,
-        &'a U: IntoIterator<Item = &'a V>,
+        T: IntoIterator<Item = U>,
+        U: IntoIterator<Item = &'a V>,
         V: D1Argument,
     {
         values
             .into_iter()
-            .map(|&batch| self.bind_refs(batch))
+            .map(|batch| self.bind_refs(batch))
             .collect()
     }
 


### PR DESCRIPTION

`bind` does not actually need owned values 