### PR TITLE
Fix absence of worker::secret documentation

### DIFF
--- a/worker/src/env.rs
+++ b/worker/src/env.rs
@@ -148,6 +148,7 @@ impl ToString for StringBinding {
 }
 
 /// A string value representing a binding to a secret in a Worker.
-pub type Secret = StringBinding;
+#[doc(inline)]
+pub use StringBinding as Secret;
 /// A string value representing a binding to an environment variable in a Worker.
 pub type Var = StringBinding;


### PR DESCRIPTION
#482
Inlined the documentation so it is copied over from the private module.