### PR TITLE
Implement Send, Sync and Clone for Fetcher

### DIFF
--- a/worker-sys/src/types/fetcher.rs
+++ b/worker-sys/src/types/fetcher.rs
@@ -26,3 +26,6 @@ extern "C" {
         init: &web_sys::RequestInit,
     ) -> js_sys::Promise;
 }
+
+unsafe impl Send for Fetcher {}
+unsafe impl Sync for Fetcher {}

--- a/worker/src/fetcher.rs
+++ b/worker/src/fetcher.rs
@@ -8,6 +8,7 @@ use wasm_bindgen_futures::JsFuture;
 use crate::{HttpRequest, HttpResponse};
 use crate::{Request, Response};
 /// A struct for invoking fetch events to other Workers.
+#[derive(Clone)]
 pub struct Fetcher(worker_sys::Fetcher);
 
 #[cfg(not(feature = "http"))]


### PR DESCRIPTION
Continuing the game of whack-a-type...

I implemented `Send` and `Sync` for the `worker-sys` type. I can change that to the wrapper in `worker` if you think that makes more sense.