### PR TITLE
Add Socket.opened implementation

### DIFF
--- a/worker-sys/src/types/socket.rs
+++ b/worker-sys/src/types/socket.rs
@@ -15,7 +15,7 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn close(this: &Socket) -> js_sys::Promise;
 
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, getter)]
     pub fn closed(this: &Socket) -> js_sys::Promise;
 
     #[wasm_bindgen(method)]

--- a/worker-sys/src/types/socket.rs
+++ b/worker-sys/src/types/socket.rs
@@ -15,7 +15,7 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn close(this: &Socket) -> js_sys::Promise;
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(method)]
     pub fn closed(this: &Socket) -> js_sys::Promise;
 
     #[wasm_bindgen(method)]

--- a/worker-sys/src/types/socket.rs
+++ b/worker-sys/src/types/socket.rs
@@ -18,6 +18,9 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn closed(this: &Socket) -> js_sys::Promise;
 
+    #[wasm_bindgen(method)]
+    pub fn opened(this: &Socket) -> js_sys::Promise;
+
     #[wasm_bindgen(method, js_name=startTls)]
     pub fn start_tls(this: &Socket) -> Socket;
 

--- a/worker/src/socket.rs
+++ b/worker/src/socket.rs
@@ -20,38 +20,33 @@ use web_sys::{
     ReadableStream, ReadableStreamDefaultReader, WritableStream, WritableStreamDefaultWriter,
 };
 
+#[derive(Default)]
 enum Reading {
+    #[default]
     None,
     Pending(JsFuture, ReadableStreamDefaultReader),
     Ready(Vec<u8>),
 }
 
-impl Default for Reading {
-    fn default() -> Self {
-        Self::None
-    }
-}
-
+#[derive(Default)]
 enum Writing {
     Pending(JsFuture, WritableStreamDefaultWriter, usize),
+    #[default]
     None,
 }
 
-impl Default for Writing {
-    fn default() -> Self {
-        Self::None
-    }
-}
-
+#[derive(Default)]
 enum Closing {
     Pending(JsFuture),
+    #[default]
     None,
 }
 
-impl Default for Closing {
-    fn default() -> Self {
-        Self::None
-    }
+#[derive(Default)]
+enum Opening {
+    Pending(JsFuture),
+    #[default]
+    None,
 }
 
 /// Represents an outbound TCP connection from your Worker.
@@ -62,6 +57,7 @@ pub struct Socket {
     write: Option<Writing>,
     read: Option<Reading>,
     close: Option<Closing>,
+    opened: Option<Opening>,
 }
 
 // This can only be done because workers are single threaded.
@@ -79,6 +75,7 @@ impl Socket {
             read: None,
             write: None,
             close: None,
+            opened: None,
         }
     }
 
@@ -92,6 +89,11 @@ impl Socket {
     /// and is rejected if the socket encounters an error.
     pub async fn closed(&self) -> Result<()> {
         JsFuture::from(self.inner.closed()).await?;
+        Ok(())
+    }
+
+    pub async fn opened(&self) -> Result<()> {
+        JsFuture::from(self.inner.opened()).await?;
         Ok(())
     }
 

--- a/worker/src/socket.rs
+++ b/worker/src/socket.rs
@@ -42,13 +42,6 @@ enum Closing {
     None,
 }
 
-#[derive(Default)]
-enum Opening {
-    Pending(JsFuture),
-    #[default]
-    None,
-}
-
 /// Represents an outbound TCP connection from your Worker.
 pub struct Socket {
     inner: worker_sys::Socket,
@@ -57,7 +50,6 @@ pub struct Socket {
     write: Option<Writing>,
     read: Option<Reading>,
     close: Option<Closing>,
-    opened: Option<Opening>,
 }
 
 // This can only be done because workers are single threaded.
@@ -75,7 +67,6 @@ impl Socket {
             read: None,
             write: None,
             close: None,
-            opened: None,
         }
     }
 


### PR DESCRIPTION
#441 
I'm a bit confused regarding the actual implementation of Socket.opened itself. I created all the necessary bindings, same as the ones [already implemented](https://developers.cloudflare.com/workers/runtime-apis/tcp-sockets/#Socket), but I'm not sure if I'm done. The `Socket` struct confuses me. I know the `inner` is the bound JS object itself, and the rest are mostly streams and options. What do Options such as `close` do? They are used in Tokio traits such as `AsyncWrite`. It looks like to me that particular one returns whether the Socket has closed yet, and the implementation also indicates that.  I tried to decipher what I think is the [original implementation](https://github.com/cloudflare/workerd/blob/main/src/workerd/api/sockets.h) of `opened` but have not been successful in understanding it. I added an `opened` Option to the `Socket` struct but am not sure of what to do with it.

Would it be incorrect to just implement it in `AsyncRead.poll_read()` ?

I _think_ I just have to use reflection to grab the `opened` value on `poll_read()`?