### PR TITLE
Add semver checks and sanity-check build to create-release-pr

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -29,6 +29,25 @@ jobs:
           cargo update
           NEW_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -rc '.packages[] | select(.name=="worker") | .version')
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        continue-on-error: true
+        with:
+          package: worker
+          verbose: true
+          release-type: minor
+      - name: Check semver (http)
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        continue-on-error: true
+        with:
+          package: worker
+          feature-group: all-features
+          verbose: true
+          release-type: minor
+      - name: Build workspace
+        run: cargo build --workspace
+      - name: Build workspace (http)
+        run: cargo build --package worker-sandbox --all-features
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
Adds [cargo-semver-checks](https://crates.io/crates/cargo-semver-checks) when creating a new release. Since we are still on `0.x.y`, these checks do not detect anything by default. I have forced the checker to treat every release as a `minor` version so that it will highlight any breaking changes. 

Since we still want to be able to ship breaking changes occasionally, I have set these steps to not fail the build, and instead will review them manually. 

I've also added a sanity check build step to make sure there are no issues introduced by `cargo update`. Ideally the full test suite would still run on the PR, but I will have to figure out how to do that later. 