### PR TITLE
Don't increment KV version when creating release PR

### DIFF
--- a/examples/kv/Cargo.toml
+++ b/examples/kv/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Zeb Piasecki <zeb@zebulon.dev>"]
 edition = "2018"
 
+[package.metadata.release]
+release = false
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/worker-kv/Cargo.toml
+++ b/worker-kv/Cargo.toml
@@ -7,6 +7,9 @@ description = "Rust bindings to Cloudflare Worker KV Stores."
 repository = "https://github.com/zebp/worker-kv"
 license = "MIT OR Apache-2.0"
 
+[package.metadata.release]
+release = false
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
In most cases `worker-kv` will not change so we shouldn't release it on every release PR.