### PR TITLE
Supply token so that cargo-binstall does not encounter rate limits

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: chainguard-dev/actions/setup-gitsign@main
       - name: Install cargo-release
         uses: taiki-e/install-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tool: cargo-release
       - name: Update versions

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -59,3 +59,8 @@ jobs:
           title: Release v${{ steps.update_versions.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Trigger Pull Request Workflow
+        env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run .github/workflows/pullrequest.yml --ref releases/v${{ steps.update_versions.outputs.version }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,6 +1,8 @@
 name: Pull Request
 
-on: pull_request
+on:
+- pull_request
+- workflow_dispatch
 
 jobs:
   rustfmt:


### PR DESCRIPTION
Not very well documented, but looks like `binstall` will automatically detect `GITHUB_TOKEN` environment variable which allows fetching GitHub release artifacts without encountering rate limits. 

https://github.com/cargo-bins/cargo-binstall/blob/8de3ec8fb72df0f5052768e750a70ebceafbbe3e/crates/bin/src/args.rs#L302