### PR TITLE
Expose D1 Statements JsValue API

### DIFF
--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -316,6 +316,19 @@ impl D1PreparedStatement {
         }
         Ok(vec)
     }
+
+    /// Executes a query against the database and returns a `Vec` of JsValues.
+    pub async fn raw_js_value(&self) -> Result<Vec<JsValue>> {
+        let result = JsFuture::from(self.0.raw()).await;
+        let result = cast_to_d1_error(result)?;
+        let result = result.dyn_into::<Array>()?;
+        Ok(result.iter().collect())
+    }
+
+    /// Returns the inner JsValue bindings object.
+    pub fn inner(&self) -> &D1PreparedStatementSys {
+        &self.0
+    }
 }
 
 impl From<D1PreparedStatementSys> for D1PreparedStatement {


### PR DESCRIPTION
Example usages to debug in application code:

```rust
let res = get_d1(env)?
    .prepare("SELECT count(*) FROM accounts WHERE email = ?1")
    .bind(&[email.into()])?
    .raw_js_value()
    .await?;

console_log!("debugging via raw_js_value: {:?}", res);

let promise = get_d1(env)?
    .prepare("SELECT count(*) FROM accounts WHERE email = ?1")
    .bind(&[email.into()])?
    .inner()
    .first(None);

let res = JsFuture::from(promise).await?;

console_log!("debugging via inner: {:?}", res);
```