### PR TITLE
d1 js array optimization

### DIFF
--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -321,8 +321,9 @@ impl D1PreparedStatement {
     pub async fn raw_js_value(&self) -> Result<Vec<JsValue>> {
         let result = JsFuture::from(self.0.raw()).await;
         let result = cast_to_d1_error(result)?;
-        let result = result.dyn_into::<Array>()?;
-        Ok(result.iter().collect())
+        let array = result.dyn_into::<Array>()?;
+
+        Ok(array.to_vec())
     }
 
     /// Returns the inner JsValue bindings object.


### PR DESCRIPTION
very small improvement...

on the JS side it already knows the capacity of the Vec 
so `to_vec()` may be slightly more efficient than iterating/collecting