### PR TITLE
Return 500 instead of panicking when returning error to fetch handler

### DIFF
--- a/worker-macros/src/event.rs
+++ b/worker-macros/src/event.rs
@@ -57,7 +57,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream, http: bool) -> TokenSt
                     }
                 }
                 false => {
-                    quote! { panic!("{}", e) }
+                    quote! { ::worker::Response::error("INTERNAL SERVER ERROR", 500).unwrap().into() }
                 }
             };
 

--- a/worker-macros/src/event.rs
+++ b/worker-macros/src/event.rs
@@ -50,15 +50,10 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream, http: bool) -> TokenSt
             // rename the original attributed fn
             input_fn.sig.ident = input_fn_ident.clone();
 
-            let error_handling = match respond_with_errors {
-                true => {
-                    quote! {
-                        ::worker::Response::error(e.to_string(), 500).unwrap().into()
-                    }
-                }
-                false => {
-                    quote! { ::worker::Response::error("INTERNAL SERVER ERROR", 500).unwrap().into() }
-                }
+            let error_handling = if respond_with_errors {
+                quote! { ::worker::Response::error(e.to_string(), 500).unwrap().into() }
+            } else {
+                quote! { ::worker::Response::error("INTERNAL SERVER ERROR", 500).unwrap().into() }
             };
 
             let fetch_invoke = if http {


### PR DESCRIPTION
This PR returns a generic 500 response to the client, instead of panicking, when an error is returned to the fetch handler. IMO panicking defeats the purpose of Rust's error handling model and propagating errors.

The `respond_with_errors` option avoids a panic but blindly returns the error to the client which is not good practice.

I can also add a new option if you want to keep the existing behavior. Or add a new panic option in case some people really want to do a panic.