### PR TITLE
more flexible non-http fetch request

### DIFF
--- a/worker-macros/src/event.rs
+++ b/worker-macros/src/event.rs
@@ -73,7 +73,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream, http: bool) -> TokenSt
                     }
                 )
             } else {
-                quote!(#input_fn_ident(::worker::Request::from(req), env, ctx).await.map(::worker::worker_sys::web_sys::Response::from))
+                quote!(#input_fn_ident(req.into(), env, ctx).await.map(::worker::worker_sys::web_sys::Response::from))
             };
 
             // create a new "main" function that takes the worker_sys::Request, and calls the


### PR DESCRIPTION
Follows the same pattern for the current return type (which is implemented as `From<web_sys::Response>`, but for the input request type - instead of hardcoding that it _must_ be worker::Request, allow any `From<web_sys::Request>` (by way of calling .into())

For example, this now works out of the box:

```
#[event(fetch, respond_with_errors)]
async fn main(req: web_sys::Request, env: Env, ctx: Context) -> Result<web_sys::Response> {
    Ok(web_sys::Response::new_with_opt_str(Some("Hello World (native type)".into())).unwrap())
}
```

This is _not_ a breaking change afaict, e.g. this still works as expected:

```
#[event(fetch, respond_with_errors)]
async fn main(req: worker::Request, env: Env, ctx: Context) -> Result<worker::Response> {
    worker::Response::ok("Hello World (worker type)")
}
```

I didn't touch the `http` path, so it shouldn't break anything there at all