### PR TITLE
Allow returning any error that implements `std::error::Error`

### DIFF
--- a/examples/custom-req/src/lib.rs
+++ b/examples/custom-req/src/lib.rs
@@ -8,9 +8,11 @@ async fn main(_req: MyRequest, _env: Env, _ctx: Context) -> Result<MyResponse> {
 struct MyRequest {}
 
 impl FromRequest for MyRequest {
-    fn from_raw(_req: crate::worker_sys::web_sys::Request) -> Self {
+    fn from_raw(
+        _req: crate::worker_sys::web_sys::Request,
+    ) -> std::result::Result<Self, impl Into<Box<dyn std::error::Error>>> {
         // we don't care about the request, so we just return a new instance
-        Self {}
+        Ok::<Self, Error>(Self {})
     }
 }
 
@@ -25,7 +27,13 @@ impl MyResponse {
 }
 
 impl IntoResponse for MyResponse {
-    fn into_raw(self) -> crate::worker_sys::web_sys::Response {
-        crate::worker_sys::web_sys::Response::new_with_opt_str(Some(self.data)).unwrap()
+    fn into_raw(
+        self,
+    ) -> std::result::Result<
+        crate::worker_sys::web_sys::Response,
+        impl Into<Box<dyn std::error::Error>>,
+    > {
+        crate::worker_sys::web_sys::Response::new_with_opt_str(Some(self.data))
+            .map_err(|e| Error::JsError(format!("{:?}", e)))
     }
 }

--- a/worker-macros/src/event.rs
+++ b/worker-macros/src/event.rs
@@ -65,12 +65,28 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ctx: ::worker::worker_sys::Context
                 ) -> ::worker::worker_sys::web_sys::Response {
                     let ctx = worker::Context::new(ctx);
-                    let result = #input_fn_ident(::worker::FromRequest::from_raw(req), env, ctx).await.map(::worker::IntoResponse::into_raw);
-                    // get the worker::Result<worker::Response> by calling the original fn
-                    match result {
-                        Ok(res) => res,
+                    match ::worker::FromRequest::from_raw(req) {
+                        Ok(req) => {
+                            let result = #input_fn_ident(req, env, ctx).await;
+                            // get the worker::Result<worker::Response> by calling the original fn
+                            match result {
+                                Ok(raw_res) => {
+                                    match ::worker::IntoResponse::into_raw(raw_res) {
+                                        Ok(res) => res,
+                                        Err(e) => {
+                                            ::worker::console_error!("Error converting response: {}", &e);
+                                            #error_handling
+                                        }
+                                    }
+                                },
+                                Err(e) => {
+                                    ::worker::console_error!("{}", &e);
+                                    #error_handling
+                                }
+                            }
+                        },
                         Err(e) => {
-                            ::worker::console_error!("{}", &e);
+                            ::worker::console_error!("Error converting request: {}", &e);
                             #error_handling
                         }
                     }

--- a/worker-macros/src/event.rs
+++ b/worker-macros/src/event.rs
@@ -73,19 +73,22 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 Ok(raw_res) => {
                                     match ::worker::IntoResponse::into_raw(raw_res) {
                                         Ok(res) => res,
-                                        Err(e) => {
+                                        Err(err) => {
+                                            let e: Box<dyn std::error::Error> = err.into();
                                             ::worker::console_error!("Error converting response: {}", &e);
                                             #error_handling
                                         }
                                     }
                                 },
-                                Err(e) => {
+                                Err(err) => {
+                                    let e: Box<dyn std::error::Error> = err.into();
                                     ::worker::console_error!("{}", &e);
                                     #error_handling
                                 }
                             }
                         },
-                        Err(e) => {
+                        Err(err) => {
+                            let e: Box<dyn std::error::Error> = err.into();
                             ::worker::console_error!("Error converting request: {}", &e);
                             #error_handling
                         }

--- a/worker-macros/src/lib.rs
+++ b/worker-macros/src/lib.rs
@@ -29,11 +29,12 @@ pub fn durable_object(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// At a high-level, the `fetch` handler is used to handle incoming HTTP requests. The function signature for a `fetch` handler is conceptually something like:
 ///  
 /// ```rust
-/// async fn fetch(req: impl From<web_sys::Request>, env: Env, ctx: Context) -> Result<impl Into<web_sys::Response>, worker::Error>
+/// async fn fetch(req: impl From<web_sys::Request>, env: Env, ctx: Context) -> Result<impl Into<web_sys::Response>, impl Into<Box<dyn Error>>>
 /// ```
 ///
-/// In other words, it takes a some "request" object that can be derived *from* a `web_sys::Request` (into whatever concrete Request type you like), and returns some "response" object that can be converted *into* a `web_sys::Response` (from whatever concrete Response type you like).
-/// It also receives the worker `Env` and `Context` objects.
+/// In other words, it takes some "request" object that can be derived *from* a `web_sys::Request` (into whatever concrete Request type you like),
+/// and returns some "response" object that can be converted *into* a `web_sys::Response` (from whatever concrete Response type you like).
+/// Error types can be any type that implements [`std::error::Error`].
 ///
 /// In practice, the "request" and "response" objects are usually one of these concrete types, supported out of the box:
 ///

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -349,25 +349,27 @@ fn clone_mut_works() {
     assert!(mut_req.immutable);
 }
 
-/// A trait used to represent any viable Request struct that can be used in the Worker.
-/// The only requirement is that it be convertable from a web_sys::Request.
-pub trait FromRequest {
-    fn from_raw(request: web_sys::Request) -> Self;
+/// A trait used to represent any viable Request type that can be used in the Worker.
+/// The only requirement is that it be convertible from a web_sys::Request.
+pub trait FromRequest: std::marker::Sized {
+    fn from_raw(request: web_sys::Request) -> Result<Self>;
 }
 
 impl FromRequest for web_sys::Request {
-    fn from_raw(request: web_sys::Request) -> Self {
-        request
+    fn from_raw(request: web_sys::Request) -> Result<Self> {
+        Ok(request)
     }
 }
+
 impl FromRequest for Request {
-    fn from_raw(request: web_sys::Request) -> Self {
-        request.into()
+    fn from_raw(request: web_sys::Request) -> Result<Self> {
+        Ok(request.into())
     }
 }
+
 #[cfg(feature = "http")]
 impl FromRequest for crate::HttpRequest {
-    fn from_raw(request: web_sys::Request) -> Self {
-        crate::http::request::from_wasm(request).unwrap()
+    fn from_raw(request: web_sys::Request) -> Result<Self> {
+        crate::http::request::from_wasm(request)
     }
 }

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -352,24 +352,32 @@ fn clone_mut_works() {
 /// A trait used to represent any viable Request type that can be used in the Worker.
 /// The only requirement is that it be convertible from a web_sys::Request.
 pub trait FromRequest: std::marker::Sized {
-    fn from_raw(request: web_sys::Request) -> Result<Self>;
+    fn from_raw(
+        request: web_sys::Request,
+    ) -> std::result::Result<Self, impl Into<Box<dyn std::error::Error>>>;
 }
 
 impl FromRequest for web_sys::Request {
-    fn from_raw(request: web_sys::Request) -> Result<Self> {
-        Ok(request)
+    fn from_raw(
+        request: web_sys::Request,
+    ) -> std::result::Result<Self, impl Into<Box<dyn std::error::Error>>> {
+        Ok::<web_sys::Request, Error>(request)
     }
 }
 
 impl FromRequest for Request {
-    fn from_raw(request: web_sys::Request) -> Result<Self> {
-        Ok(request.into())
+    fn from_raw(
+        request: web_sys::Request,
+    ) -> std::result::Result<Self, impl Into<Box<dyn std::error::Error>>> {
+        Ok::<Request, Error>(request.into())
     }
 }
 
 #[cfg(feature = "http")]
 impl FromRequest for crate::HttpRequest {
-    fn from_raw(request: web_sys::Request) -> Result<Self> {
+    fn from_raw(
+        request: web_sys::Request,
+    ) -> std::result::Result<Self, impl Into<Box<dyn std::error::Error>>> {
         crate::http::request::from_wasm(request)
     }
 }

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -476,18 +476,24 @@ impl From<web_sys::Response> for Response {
 /// A trait used to represent any viable Response type that can be used in the Worker.
 /// The only requirement is that it be convertible to a web_sys::Response.
 pub trait IntoResponse {
-    fn into_raw(self) -> Result<web_sys::Response>;
+    fn into_raw(
+        self,
+    ) -> std::result::Result<web_sys::Response, impl Into<Box<dyn std::error::Error>>>;
 }
 
 impl IntoResponse for web_sys::Response {
-    fn into_raw(self) -> Result<web_sys::Response> {
-        Ok(self)
+    fn into_raw(
+        self,
+    ) -> std::result::Result<web_sys::Response, impl Into<Box<dyn std::error::Error>>> {
+        Ok::<web_sys::Response, Error>(self)
     }
 }
 
 impl IntoResponse for Response {
-    fn into_raw(self) -> Result<web_sys::Response> {
-        Ok(self.into())
+    fn into_raw(
+        self,
+    ) -> std::result::Result<web_sys::Response, impl Into<Box<dyn std::error::Error>>> {
+        Ok::<web_sys::Response, Error>(self.into())
     }
 }
 
@@ -496,7 +502,9 @@ impl<B> IntoResponse for http::Response<B>
 where
     B: http_body::Body<Data = Bytes> + 'static,
 {
-    fn into_raw(self) -> Result<web_sys::Response> {
+    fn into_raw(
+        self,
+    ) -> std::result::Result<web_sys::Response, impl Into<Box<dyn std::error::Error>>> {
         crate::http::response::to_wasm(self)
     }
 }

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -473,21 +473,21 @@ impl From<web_sys::Response> for Response {
     }
 }
 
-/// A trait used to represent any viable Response struct that can be used in the Worker.
-/// The only requirement is that it be convertable to a web_sys::Response.
+/// A trait used to represent any viable Response type that can be used in the Worker.
+/// The only requirement is that it be convertible to a web_sys::Response.
 pub trait IntoResponse {
-    fn into_raw(self) -> web_sys::Response;
+    fn into_raw(self) -> Result<web_sys::Response>;
 }
 
 impl IntoResponse for web_sys::Response {
-    fn into_raw(self) -> web_sys::Response {
-        self
+    fn into_raw(self) -> Result<web_sys::Response> {
+        Ok(self)
     }
 }
 
 impl IntoResponse for Response {
-    fn into_raw(self) -> web_sys::Response {
-        self.into()
+    fn into_raw(self) -> Result<web_sys::Response> {
+        Ok(self.into())
     }
 }
 
@@ -496,7 +496,7 @@ impl<B> IntoResponse for http::Response<B>
 where
     B: http_body::Body<Data = Bytes> + 'static,
 {
-    fn into_raw(self) -> web_sys::Response {
-        crate::http::response::to_wasm(self).unwrap()
+    fn into_raw(self) -> Result<web_sys::Response> {
+        crate::http::response::to_wasm(self)
     }
 }


### PR DESCRIPTION
This allows the `fetch` handler to return any error type that implements `std::error::Error`. This will allow the user to choose how they want to handle errors (use `worker::Error`, `anyhow`, `thiserror`, etc.). 

This also changes some behavior slightly:
1. If `respond_with_error` is enabled, this now uses `Display` to stringify the error instead of `to_string`. 
2. The error logged is now stringified with `Debug` and with `console_error` instead of `console_log`. 

cc @avsaase 