### PR TITLE
Fix `axum` feature

### DIFF
--- a/worker/src/http/response.rs
+++ b/worker/src/http/response.rs
@@ -59,7 +59,7 @@ pub fn from_wasm(res: web_sys::Response) -> Result<HttpResponse> {
     })
 }
 
-#[cfg(feature = "http")]
+#[cfg(feature = "axum")]
 impl From<crate::Response> for http::Response<axum::body::Body> {
     fn from(resp: crate::Response) -> http::Response<axum::body::Body> {
         let res: web_sys::Response = resp.into();


### PR DESCRIPTION
`worker` did not build with only `http` feature because `From<worker::Response>` for `http::Response<axum::Body>` was gated behind `http` feature instead of `axum` feature. 