### PR TITLE
💡 Expose `uploadId` for multipart uploads

### DIFF
--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -367,6 +367,11 @@ impl MultipartUpload {
         })
     }
 
+    /// Request the upload id.
+    pub async fn upload_id(&self) -> String {
+        self.inner.upload_id()
+    }
+
     /// Aborts the multipart upload.
     pub async fn abort(&self) -> Result<()> {
         JsFuture::from(self.inner.abort()).await?;


### PR DESCRIPTION
While trying to implement https://developers.cloudflare.com/r2/api/workers/workers-multipart-usage/ in Rust it appears that `uploadId` isn't exposed in the existing APIs. This PR rectifies that.