### PR TITLE
🤽 `worker-sys` Make all methods `catch`

### DIFF
--- a/worker-sandbox/src/d1.rs
+++ b/worker-sandbox/src/d1.rs
@@ -96,7 +96,7 @@ pub async fn exec(mut req: Request, env: Env, _data: SomeSharedData) -> Result<R
         .await
         .expect("doesn't exist");
 
-    Response::ok(result.count().unwrap_or_default().to_string())
+    Response::ok(result.count()?.unwrap_or_default().to_string())
 }
 
 #[worker::send]

--- a/worker-sys/src/ext/abort_controller.rs
+++ b/worker-sys/src/ext/abort_controller.rs
@@ -8,7 +8,7 @@ mod glue {
         #[wasm_bindgen]
         pub type AbortController;
 
-        #[wasm_bindgen(method, js_name=abort)]
+        #[wasm_bindgen(method, catch, js_name=abort)]
         pub fn abort_with_reason(this: &AbortController, reason: &JsValue);
     }
 }

--- a/worker-sys/src/ext/abort_controller.rs
+++ b/worker-sys/src/ext/abort_controller.rs
@@ -9,7 +9,7 @@ mod glue {
         pub type AbortController;
 
         #[wasm_bindgen(method, catch, js_name=abort)]
-        pub fn abort_with_reason(this: &AbortController, reason: &JsValue);
+        pub fn abort_with_reason(this: &AbortController, reason: &JsValue) -> Result<(), JsValue>;
     }
 }
 
@@ -21,5 +21,6 @@ impl AbortControllerExt for web_sys::AbortController {
     fn abort_with_reason(&self, reason: &JsValue) {
         self.unchecked_ref::<glue::AbortController>()
             .abort_with_reason(reason)
+            .unwrap()
     }
 }

--- a/worker-sys/src/ext/abort_signal.rs
+++ b/worker-sys/src/ext/abort_signal.rs
@@ -8,14 +8,14 @@ mod glue {
         #[wasm_bindgen]
         pub type AbortSignal;
 
-        #[wasm_bindgen(method, getter)]
-        pub fn reason(this: &AbortSignal) -> JsValue;
+        #[wasm_bindgen(method, catch, getter)]
+        pub fn reason(this: &AbortSignal) -> Result<JsValue, JsValue>
 
-        #[wasm_bindgen(static_method_of=AbortSignal)]
-        pub fn abort() -> web_sys::AbortSignal;
+        #[wasm_bindgen(static_method, catch_of=AbortSignal)]
+        pub fn abort() -> Result<web_sys::AbortSignal, JsValue>
 
-        #[wasm_bindgen(static_method_of=AbortSignal, js_name=abort)]
-        pub fn abort_with_reason(reason: &JsValue) -> web_sys::AbortSignal;
+        #[wasm_bindgen(static_method, catch_of=AbortSignal, js_name=abort)]
+        pub fn abort_with_reason(reason: &JsValue) -> Result<web_sys::AbortSignal, JsValue>
     }
 }
 

--- a/worker-sys/src/ext/abort_signal.rs
+++ b/worker-sys/src/ext/abort_signal.rs
@@ -9,13 +9,13 @@ mod glue {
         pub type AbortSignal;
 
         #[wasm_bindgen(method, catch, getter)]
-        pub fn reason(this: &AbortSignal) -> Result<JsValue, JsValue>
+        pub fn reason(this: &AbortSignal) -> Result<JsValue, JsValue>;
 
-        #[wasm_bindgen(static_method, catch_of=AbortSignal)]
-        pub fn abort() -> Result<web_sys::AbortSignal, JsValue>
+        #[wasm_bindgen(static_method_of=AbortSignal, catch)]
+        pub fn abort() -> Result<web_sys::AbortSignal, JsValue>;
 
-        #[wasm_bindgen(static_method, catch_of=AbortSignal, js_name=abort)]
-        pub fn abort_with_reason(reason: &JsValue) -> Result<web_sys::AbortSignal, JsValue>
+        #[wasm_bindgen(static_method_of=AbortSignal, js_name=abort, catch)]
+        pub fn abort_with_reason(reason: &JsValue) -> Result<web_sys::AbortSignal, JsValue>;
     }
 }
 
@@ -29,14 +29,14 @@ pub trait AbortSignalExt {
 
 impl AbortSignalExt for web_sys::AbortSignal {
     fn reason(&self) -> JsValue {
-        self.unchecked_ref::<glue::AbortSignal>().reason()
+        self.unchecked_ref::<glue::AbortSignal>().reason().unwrap()
     }
 
     fn abort() -> web_sys::AbortSignal {
-        glue::AbortSignal::abort()
+        glue::AbortSignal::abort().unwrap()
     }
 
     fn abort_with_reason(reason: &JsValue) -> web_sys::AbortSignal {
-        glue::AbortSignal::abort_with_reason(reason)
+        glue::AbortSignal::abort_with_reason(reason).unwrap()
     }
 }

--- a/worker-sys/src/ext/cache_storage.rs
+++ b/worker-sys/src/ext/cache_storage.rs
@@ -8,8 +8,8 @@ mod glue {
         #[wasm_bindgen]
         pub type CacheStorage;
 
-        #[wasm_bindgen(method, getter)]
-        pub fn default(this: &CacheStorage) -> web_sys::Cache;
+        #[wasm_bindgen(method, catch, getter)]
+        pub fn default(this: &CacheStorage) -> Result<web_sys::Cache, JsValue>
     }
 }
 

--- a/worker-sys/src/ext/cache_storage.rs
+++ b/worker-sys/src/ext/cache_storage.rs
@@ -9,7 +9,7 @@ mod glue {
         pub type CacheStorage;
 
         #[wasm_bindgen(method, catch, getter)]
-        pub fn default(this: &CacheStorage) -> Result<web_sys::Cache, JsValue>
+        pub fn default(this: &CacheStorage) -> Result<web_sys::Cache, JsValue>;
     }
 }
 
@@ -19,6 +19,8 @@ pub trait CacheStorageExt {
 
 impl CacheStorageExt for web_sys::CacheStorage {
     fn default(&self) -> web_sys::Cache {
-        self.unchecked_ref::<glue::CacheStorage>().default()
+        self.unchecked_ref::<glue::CacheStorage>()
+            .default()
+            .unwrap()
     }
 }

--- a/worker-sys/src/ext/request.rs
+++ b/worker-sys/src/ext/request.rs
@@ -10,8 +10,8 @@ mod glue {
         #[wasm_bindgen]
         pub type Request;
 
-        #[wasm_bindgen(method, getter)]
-        pub fn cf(this: &Request) -> Option<IncomingRequestCfProperties>;
+        #[wasm_bindgen(method, catch, getter)]
+        pub fn cf(this: &Request) -> Result<Option<IncomingRequestCfProperties>, JsValue>
     }
 }
 

--- a/worker-sys/src/ext/request.rs
+++ b/worker-sys/src/ext/request.rs
@@ -11,7 +11,7 @@ mod glue {
         pub type Request;
 
         #[wasm_bindgen(method, catch, getter)]
-        pub fn cf(this: &Request) -> Result<Option<IncomingRequestCfProperties>, JsValue>
+        pub fn cf(this: &Request) -> Result<Option<IncomingRequestCfProperties>, JsValue>;
     }
 }
 
@@ -22,6 +22,6 @@ pub trait RequestExt {
 
 impl RequestExt for web_sys::Request {
     fn cf(&self) -> Option<IncomingRequestCfProperties> {
-        self.unchecked_ref::<glue::Request>().cf()
+        self.unchecked_ref::<glue::Request>().cf().unwrap()
     }
 }

--- a/worker-sys/src/ext/response.rs
+++ b/worker-sys/src/ext/response.rs
@@ -8,8 +8,8 @@ mod glue {
         #[wasm_bindgen]
         pub type Response;
 
-        #[wasm_bindgen(method, getter)]
-        pub fn webSocket(this: &Response) -> Option<web_sys::WebSocket>;
+        #[wasm_bindgen(method, catch, getter)]
+        pub fn webSocket(this: &Response) -> Result<Option<web_sys::WebSocket>, JsValue>
     }
 }
 

--- a/worker-sys/src/ext/response.rs
+++ b/worker-sys/src/ext/response.rs
@@ -9,7 +9,7 @@ mod glue {
         pub type Response;
 
         #[wasm_bindgen(method, catch, getter)]
-        pub fn webSocket(this: &Response) -> Result<Option<web_sys::WebSocket>, JsValue>
+        pub fn webSocket(this: &Response) -> Result<Option<web_sys::WebSocket>, JsValue>;
     }
 }
 
@@ -20,6 +20,6 @@ pub trait ResponseExt {
 
 impl ResponseExt for web_sys::Response {
     fn websocket(&self) -> Option<web_sys::WebSocket> {
-        self.unchecked_ref::<glue::Response>().webSocket()
+        self.unchecked_ref::<glue::Response>().webSocket().unwrap()
     }
 }

--- a/worker-sys/src/types/context.rs
+++ b/worker-sys/src/types/context.rs
@@ -6,9 +6,9 @@ extern "C" {
     #[derive(Debug, PartialEq, Eq)]
     pub type Context;
 
-    #[wasm_bindgen(method, js_name=waitUntil)]
+    #[wasm_bindgen(method, catch, js_name=waitUntil)]
     pub fn wait_until(this: &Context, promise: &js_sys::Promise);
 
-    #[wasm_bindgen(method, js_name=passThroughOnException)]
+    #[wasm_bindgen(method, catch, js_name=passThroughOnException)]
     pub fn pass_through_on_exception(this: &Context);
 }

--- a/worker-sys/src/types/context.rs
+++ b/worker-sys/src/types/context.rs
@@ -7,8 +7,8 @@ extern "C" {
     pub type Context;
 
     #[wasm_bindgen(method, catch, js_name=waitUntil)]
-    pub fn wait_until(this: &Context, promise: &js_sys::Promise);
+    pub fn wait_until(this: &Context, promise: &js_sys::Promise) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=passThroughOnException)]
-    pub fn pass_through_on_exception(this: &Context);
+    pub fn pass_through_on_exception(this: &Context) -> Result<(), JsValue>;
 }

--- a/worker-sys/src/types/d1.rs
+++ b/worker-sys/src/types/d1.rs
@@ -8,17 +8,17 @@ extern "C" {
     #[derive(Debug, Clone)]
     pub type D1Result;
 
-    #[wasm_bindgen(structural, method, getter, js_name=results)]
-    pub fn results(this: &D1Result) -> Option<Array>;
+    #[wasm_bindgen(structural, method, catch, getter, js_name=results)]
+    pub fn results(this: &D1Result) -> Result<Option<Array>, JsValue>
 
-    #[wasm_bindgen(structural, method, getter, js_name=success)]
-    pub fn success(this: &D1Result) -> bool;
+    #[wasm_bindgen(structural, method, catch, getter, js_name=success)]
+    pub fn success(this: &D1Result) -> Result<bool, JsValue>
 
-    #[wasm_bindgen(structural, method, getter, js_name=error)]
-    pub fn error(this: &D1Result) -> Option<String>;
+    #[wasm_bindgen(structural, method, catch, getter, js_name=error)]
+    pub fn error(this: &D1Result) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(structural, method, getter, js_name=meta)]
-    pub fn meta(this: &D1Result) -> Object;
+    #[wasm_bindgen(structural, method, catch, getter, js_name=meta)]
+    pub fn meta(this: &D1Result) -> Result<Object, JsValue>
 }
 
 #[wasm_bindgen]
@@ -26,11 +26,11 @@ extern "C" {
     #[derive(Debug, Clone)]
     pub type D1ExecResult;
 
-    #[wasm_bindgen(structural, method, getter, js_name=count)]
-    pub fn count(this: &D1ExecResult) -> Option<u32>;
+    #[wasm_bindgen(structural, method, catch, getter, js_name=count)]
+    pub fn count(this: &D1ExecResult) -> Result<Option<u32>, JsValue>
 
-    #[wasm_bindgen(structural, method, getter, js_name=duration)]
-    pub fn duration(this: &D1ExecResult) -> Option<f64>;
+    #[wasm_bindgen(structural, method, catch, getter, js_name=duration)]
+    pub fn duration(this: &D1ExecResult) -> Result<Option<f64>, JsValue>
 }
 
 #[wasm_bindgen]
@@ -39,17 +39,17 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type D1Database;
 
-    #[wasm_bindgen(structural, method, js_class=D1Database, js_name=prepare)]
-    pub fn prepare(this: &D1Database, query: &str) -> D1PreparedStatement;
+    #[wasm_bindgen(structural, method, catch, js_class=D1Database, js_name=prepare)]
+    pub fn prepare(this: &D1Database, query: &str) -> Result<D1PreparedStatement, JsValue>
 
-    #[wasm_bindgen(structural, method, js_class=D1Database, js_name=dump)]
-    pub fn dump(this: &D1Database) -> Promise;
+    #[wasm_bindgen(structural, method, catch, js_class=D1Database, js_name=dump)]
+    pub fn dump(this: &D1Database) -> Result<Promise, JsValue>
 
-    #[wasm_bindgen(structural, method, js_class=D1Database, js_name=batch)]
-    pub fn batch(this: &D1Database, statements: Array) -> Promise;
+    #[wasm_bindgen(structural, method, catch, js_class=D1Database, js_name=batch)]
+    pub fn batch(this: &D1Database, statements: Array) -> Result<Promise, JsValue>
 
-    #[wasm_bindgen(structural, method, js_class=D1Database, js_name=exec)]
-    pub fn exec(this: &D1Database, query: &str) -> Promise;
+    #[wasm_bindgen(structural, method, catch, js_class=D1Database, js_name=exec)]
+    pub fn exec(this: &D1Database, query: &str) -> Result<Promise, JsValue>
 }
 
 #[wasm_bindgen]
@@ -61,15 +61,15 @@ extern "C" {
     #[wasm_bindgen(structural, method, catch, variadic, js_class=D1PreparedStatement, js_name=bind)]
     pub fn bind(this: &D1PreparedStatement, values: Array) -> Result<D1PreparedStatement, JsValue>;
 
-    #[wasm_bindgen(structural, method, js_class=D1PreparedStatement, js_name=first)]
-    pub fn first(this: &D1PreparedStatement, col_name: Option<&str>) -> Promise;
+    #[wasm_bindgen(structural, method, catch, js_class=D1PreparedStatement, js_name=first)]
+    pub fn first(this: &D1PreparedStatement, col_name: Option<&str>) -> Result<Promise, JsValue>
 
-    #[wasm_bindgen(structural, method, js_class=D1PreparedStatement, js_name=run)]
-    pub fn run(this: &D1PreparedStatement) -> Promise;
+    #[wasm_bindgen(structural, method, catch, js_class=D1PreparedStatement, js_name=run)]
+    pub fn run(this: &D1PreparedStatement) -> Result<Promise, JsValue>
 
-    #[wasm_bindgen(structural, method, js_class=D1PreparedStatement, js_name=all)]
-    pub fn all(this: &D1PreparedStatement) -> Promise;
+    #[wasm_bindgen(structural, method, catch, js_class=D1PreparedStatement, js_name=all)]
+    pub fn all(this: &D1PreparedStatement) -> Result<Promise, JsValue>
 
-    #[wasm_bindgen(structural, method, js_class=D1PreparedStatement, js_name=raw)]
-    pub fn raw(this: &D1PreparedStatement) -> Promise;
+    #[wasm_bindgen(structural, method, catch, js_class=D1PreparedStatement, js_name=raw)]
+    pub fn raw(this: &D1PreparedStatement) -> Result<Promise, JsValue>
 }

--- a/worker-sys/src/types/d1.rs
+++ b/worker-sys/src/types/d1.rs
@@ -9,16 +9,16 @@ extern "C" {
     pub type D1Result;
 
     #[wasm_bindgen(structural, method, catch, getter, js_name=results)]
-    pub fn results(this: &D1Result) -> Result<Option<Array>, JsValue>
+    pub fn results(this: &D1Result) -> Result<Option<Array>, JsValue>;
 
     #[wasm_bindgen(structural, method, catch, getter, js_name=success)]
-    pub fn success(this: &D1Result) -> Result<bool, JsValue>
+    pub fn success(this: &D1Result) -> Result<bool, JsValue>;
 
     #[wasm_bindgen(structural, method, catch, getter, js_name=error)]
-    pub fn error(this: &D1Result) -> Result<Option<String>, JsValue>
+    pub fn error(this: &D1Result) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(structural, method, catch, getter, js_name=meta)]
-    pub fn meta(this: &D1Result) -> Result<Object, JsValue>
+    pub fn meta(this: &D1Result) -> Result<Object, JsValue>;
 }
 
 #[wasm_bindgen]
@@ -27,10 +27,10 @@ extern "C" {
     pub type D1ExecResult;
 
     #[wasm_bindgen(structural, method, catch, getter, js_name=count)]
-    pub fn count(this: &D1ExecResult) -> Result<Option<u32>, JsValue>
+    pub fn count(this: &D1ExecResult) -> Result<Option<u32>, JsValue>;
 
     #[wasm_bindgen(structural, method, catch, getter, js_name=duration)]
-    pub fn duration(this: &D1ExecResult) -> Result<Option<f64>, JsValue>
+    pub fn duration(this: &D1ExecResult) -> Result<Option<f64>, JsValue>;
 }
 
 #[wasm_bindgen]
@@ -40,16 +40,16 @@ extern "C" {
     pub type D1Database;
 
     #[wasm_bindgen(structural, method, catch, js_class=D1Database, js_name=prepare)]
-    pub fn prepare(this: &D1Database, query: &str) -> Result<D1PreparedStatement, JsValue>
+    pub fn prepare(this: &D1Database, query: &str) -> Result<D1PreparedStatement, JsValue>;
 
     #[wasm_bindgen(structural, method, catch, js_class=D1Database, js_name=dump)]
-    pub fn dump(this: &D1Database) -> Result<Promise, JsValue>
+    pub fn dump(this: &D1Database) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, catch, js_class=D1Database, js_name=batch)]
-    pub fn batch(this: &D1Database, statements: Array) -> Result<Promise, JsValue>
+    pub fn batch(this: &D1Database, statements: Array) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, catch, js_class=D1Database, js_name=exec)]
-    pub fn exec(this: &D1Database, query: &str) -> Result<Promise, JsValue>
+    pub fn exec(this: &D1Database, query: &str) -> Result<Promise, JsValue>;
 }
 
 #[wasm_bindgen]
@@ -62,14 +62,14 @@ extern "C" {
     pub fn bind(this: &D1PreparedStatement, values: Array) -> Result<D1PreparedStatement, JsValue>;
 
     #[wasm_bindgen(structural, method, catch, js_class=D1PreparedStatement, js_name=first)]
-    pub fn first(this: &D1PreparedStatement, col_name: Option<&str>) -> Result<Promise, JsValue>
+    pub fn first(this: &D1PreparedStatement, col_name: Option<&str>) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, catch, js_class=D1PreparedStatement, js_name=run)]
-    pub fn run(this: &D1PreparedStatement) -> Result<Promise, JsValue>
+    pub fn run(this: &D1PreparedStatement) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, catch, js_class=D1PreparedStatement, js_name=all)]
-    pub fn all(this: &D1PreparedStatement) -> Result<Promise, JsValue>
+    pub fn all(this: &D1PreparedStatement) -> Result<Promise, JsValue>;
 
     #[wasm_bindgen(structural, method, catch, js_class=D1PreparedStatement, js_name=raw)]
-    pub fn raw(this: &D1PreparedStatement) -> Result<Promise, JsValue>
+    pub fn raw(this: &D1PreparedStatement) -> Result<Promise, JsValue>;
 }

--- a/worker-sys/src/types/durable_object.rs
+++ b/worker-sys/src/types/durable_object.rs
@@ -17,9 +17,9 @@ extern "C" {
     #[wasm_bindgen(extends=js_sys::Object)]
     pub type DurableObject;
 
-    #[wasm_bindgen(method, js_name=fetch)]
-    pub fn fetch_with_request(this: &DurableObject, req: &web_sys::Request) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch, js_name=fetch)]
+    pub fn fetch_with_request(this: &DurableObject, req: &web_sys::Request) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method, js_name=fetch)]
-    pub fn fetch_with_str(this: &DurableObject, url: &str) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch, js_name=fetch)]
+    pub fn fetch_with_str(this: &DurableObject, url: &str) -> Result<js_sys::Promise, JsValue>
 }

--- a/worker-sys/src/types/durable_object.rs
+++ b/worker-sys/src/types/durable_object.rs
@@ -18,8 +18,11 @@ extern "C" {
     pub type DurableObject;
 
     #[wasm_bindgen(method, catch, js_name=fetch)]
-    pub fn fetch_with_request(this: &DurableObject, req: &web_sys::Request) -> Result<js_sys::Promise, JsValue>
+    pub fn fetch_with_request(
+        this: &DurableObject,
+        req: &web_sys::Request,
+    ) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=fetch)]
-    pub fn fetch_with_str(this: &DurableObject, url: &str) -> Result<js_sys::Promise, JsValue>
+    pub fn fetch_with_str(this: &DurableObject, url: &str) -> Result<js_sys::Promise, JsValue>;
 }

--- a/worker-sys/src/types/durable_object/id.rs
+++ b/worker-sys/src/types/durable_object/id.rs
@@ -5,6 +5,6 @@ extern "C" {
     #[wasm_bindgen(extends=js_sys::Object)]
     pub type DurableObjectId;
 
-    #[wasm_bindgen(method, js_name=toString)]
-    pub fn to_string(this: &DurableObjectId) -> String;
+    #[wasm_bindgen(method, catch, js_name=toString)]
+    pub fn to_string(this: &DurableObjectId) -> Result<String, JsValue>
 }

--- a/worker-sys/src/types/durable_object/id.rs
+++ b/worker-sys/src/types/durable_object/id.rs
@@ -6,5 +6,5 @@ extern "C" {
     pub type DurableObjectId;
 
     #[wasm_bindgen(method, catch, js_name=toString)]
-    pub fn to_string(this: &DurableObjectId) -> Result<String, JsValue>
+    pub fn to_string(this: &DurableObjectId) -> Result<String, JsValue>;
 }

--- a/worker-sys/src/types/durable_object/state.rs
+++ b/worker-sys/src/types/durable_object/state.rs
@@ -8,31 +8,39 @@ extern "C" {
     pub type DurableObjectState;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn id(this: &DurableObjectState) -> Result<DurableObjectId, JsValue>
+    pub fn id(this: &DurableObjectState) -> Result<DurableObjectId, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn storage(this: &DurableObjectState) -> Result<DurableObjectStorage, JsValue>
+    pub fn storage(this: &DurableObjectState) -> Result<DurableObjectStorage, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=waitUntil)]
-    pub fn wait_until(this: &DurableObjectState, promise: &js_sys::Promise);
+    pub fn wait_until(this: &DurableObjectState, promise: &js_sys::Promise) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=acceptWebSocket)]
-    pub fn accept_websocket(this: &DurableObjectState, ws: &web_sys::WebSocket);
+    pub fn accept_websocket(
+        this: &DurableObjectState,
+        ws: &web_sys::WebSocket,
+    ) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=acceptWebSocket)]
     pub fn accept_websocket_with_tags(
         this: &DurableObjectState,
         ws: &web_sys::WebSocket,
         tags: Vec<JsValue>,
-    );
+    ) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=getWebSockets)]
-    pub fn get_websockets(this: &DurableObjectState) -> Result<Vec<web_sys::WebSocket>, JsValue>
+    pub fn get_websockets(this: &DurableObjectState) -> Result<Vec<web_sys::WebSocket>, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=getWebSockets)]
-    pub fn get_websockets_with_tag(this: &DurableObjectState, tag: &str)
-        -> Vec<web_sys::WebSocket>;
+    pub fn get_websockets_with_tag(
+        this: &DurableObjectState,
+        tag: &str,
+    ) -> Result<Vec<web_sys::WebSocket>, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=getTags)]
-    pub fn get_tags(this: &DurableObjectState, ws: &web_sys::WebSocket) -> Result<Vec<String>, JsValue>
+    pub fn get_tags(
+        this: &DurableObjectState,
+        ws: &web_sys::WebSocket,
+    ) -> Result<Vec<String>, JsValue>;
 }

--- a/worker-sys/src/types/durable_object/state.rs
+++ b/worker-sys/src/types/durable_object/state.rs
@@ -7,32 +7,32 @@ extern "C" {
     #[wasm_bindgen(extends=js_sys::Object)]
     pub type DurableObjectState;
 
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &DurableObjectState) -> DurableObjectId;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn id(this: &DurableObjectState) -> Result<DurableObjectId, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn storage(this: &DurableObjectState) -> DurableObjectStorage;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn storage(this: &DurableObjectState) -> Result<DurableObjectStorage, JsValue>
 
-    #[wasm_bindgen(method, js_name=waitUntil)]
+    #[wasm_bindgen(method, catch, js_name=waitUntil)]
     pub fn wait_until(this: &DurableObjectState, promise: &js_sys::Promise);
 
-    #[wasm_bindgen(method, js_name=acceptWebSocket)]
+    #[wasm_bindgen(method, catch, js_name=acceptWebSocket)]
     pub fn accept_websocket(this: &DurableObjectState, ws: &web_sys::WebSocket);
 
-    #[wasm_bindgen(method, js_name=acceptWebSocket)]
+    #[wasm_bindgen(method, catch, js_name=acceptWebSocket)]
     pub fn accept_websocket_with_tags(
         this: &DurableObjectState,
         ws: &web_sys::WebSocket,
         tags: Vec<JsValue>,
     );
 
-    #[wasm_bindgen(method, js_name=getWebSockets)]
-    pub fn get_websockets(this: &DurableObjectState) -> Vec<web_sys::WebSocket>;
+    #[wasm_bindgen(method, catch, js_name=getWebSockets)]
+    pub fn get_websockets(this: &DurableObjectState) -> Result<Vec<web_sys::WebSocket>, JsValue>
 
-    #[wasm_bindgen(method, js_name=getWebSockets)]
+    #[wasm_bindgen(method, catch, js_name=getWebSockets)]
     pub fn get_websockets_with_tag(this: &DurableObjectState, tag: &str)
         -> Vec<web_sys::WebSocket>;
 
-    #[wasm_bindgen(method, js_name=getTags)]
-    pub fn get_tags(this: &DurableObjectState, ws: &web_sys::WebSocket) -> Vec<String>;
+    #[wasm_bindgen(method, catch, js_name=getTags)]
+    pub fn get_tags(this: &DurableObjectState, ws: &web_sys::WebSocket) -> Result<Vec<String>, JsValue>
 }

--- a/worker-sys/src/types/fetcher.rs
+++ b/worker-sys/src/types/fetcher.rs
@@ -6,20 +6,20 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Fetcher;
 
-    #[wasm_bindgen(method)]
-    pub fn fetch(this: &Fetcher, input: &web_sys::Request) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch)]
+    pub fn fetch(this: &Fetcher, input: &web_sys::Request) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method, js_name=fetch)]
-    pub fn fetch_with_str(this: &Fetcher, input: &str) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch, js_name=fetch)]
+    pub fn fetch_with_str(this: &Fetcher, input: &str) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method, js_name=fetch)]
+    #[wasm_bindgen(method, catch, js_name=fetch)]
     pub fn fetch_with_init(
         this: &Fetcher,
         input: &web_sys::Request,
         init: &web_sys::RequestInit,
     ) -> js_sys::Promise;
 
-    #[wasm_bindgen(method, js_name=fetch)]
+    #[wasm_bindgen(method, catch, js_name=fetch)]
     pub fn fetch_with_str_and_init(
         this: &Fetcher,
         input: &str,

--- a/worker-sys/src/types/fetcher.rs
+++ b/worker-sys/src/types/fetcher.rs
@@ -7,24 +7,24 @@ extern "C" {
     pub type Fetcher;
 
     #[wasm_bindgen(method, catch)]
-    pub fn fetch(this: &Fetcher, input: &web_sys::Request) -> Result<js_sys::Promise, JsValue>
+    pub fn fetch(this: &Fetcher, input: &web_sys::Request) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=fetch)]
-    pub fn fetch_with_str(this: &Fetcher, input: &str) -> Result<js_sys::Promise, JsValue>
+    pub fn fetch_with_str(this: &Fetcher, input: &str) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=fetch)]
     pub fn fetch_with_init(
         this: &Fetcher,
         input: &web_sys::Request,
         init: &web_sys::RequestInit,
-    ) -> js_sys::Promise;
+    ) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=fetch)]
     pub fn fetch_with_str_and_init(
         this: &Fetcher,
         input: &str,
         init: &web_sys::RequestInit,
-    ) -> js_sys::Promise;
+    ) -> Result<js_sys::Promise, JsValue>;
 }
 
 unsafe impl Send for Fetcher {}

--- a/worker-sys/src/types/fixed_length_stream.rs
+++ b/worker-sys/src/types/fixed_length_stream.rs
@@ -7,11 +7,11 @@ extern "C" {
     pub type FixedLengthStream;
 
     #[wasm_bindgen(constructor)]
-    pub fn new(length: u32) -> FixedLengthStream;
+    pub fn new(length: u32) -> Result<FixedLengthStream, JsValue>
 
     #[wasm_bindgen(constructor)]
-    pub fn new_big_int(length: js_sys::BigInt) -> FixedLengthStream;
+    pub fn new_big_int(length: js_sys::BigInt) -> Result<FixedLengthStream, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn cron(this: &FixedLengthStream) -> String;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn cron(this: &FixedLengthStream) -> Result<String, JsValue>
 }

--- a/worker-sys/src/types/fixed_length_stream.rs
+++ b/worker-sys/src/types/fixed_length_stream.rs
@@ -6,12 +6,12 @@ extern "C" {
     #[derive(Debug, Clone)]
     pub type FixedLengthStream;
 
-    #[wasm_bindgen(constructor)]
-    pub fn new(length: u32) -> Result<FixedLengthStream, JsValue>
+    #[wasm_bindgen(constructor, catch)]
+    pub fn new(length: u32) -> Result<FixedLengthStream, JsValue>;
 
-    #[wasm_bindgen(constructor)]
-    pub fn new_big_int(length: js_sys::BigInt) -> Result<FixedLengthStream, JsValue>
+    #[wasm_bindgen(constructor, catch)]
+    pub fn new_big_int(length: js_sys::BigInt) -> Result<FixedLengthStream, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn cron(this: &FixedLengthStream) -> Result<String, JsValue>
+    pub fn cron(this: &FixedLengthStream) -> Result<String, JsValue>;
 }

--- a/worker-sys/src/types/incoming_request_cf_properties.rs
+++ b/worker-sys/src/types/incoming_request_cf_properties.rs
@@ -9,59 +9,61 @@ extern "C" {
     pub type IncomingRequestCfProperties;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn colo(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
+    pub fn colo(this: &IncomingRequestCfProperties) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn asn(this: &IncomingRequestCfProperties) -> Result<u32, JsValue>
+    pub fn asn(this: &IncomingRequestCfProperties) -> Result<u32, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=asOrganization)]
-    pub fn as_organization(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
+    pub fn as_organization(this: &IncomingRequestCfProperties) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn country(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
+    pub fn country(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=httpProtocol)]
-    pub fn http_protocol(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
+    pub fn http_protocol(this: &IncomingRequestCfProperties) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=requestPriority)]
-    pub fn request_priority(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
+    pub fn request_priority(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=tlsClientAuth)]
-    pub fn tls_client_auth(this: &IncomingRequestCfProperties) -> Result<Option<TlsClientAuth>, JsValue>
+    pub fn tls_client_auth(
+        this: &IncomingRequestCfProperties,
+    ) -> Result<Option<TlsClientAuth>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=tlsCipher)]
-    pub fn tls_cipher(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
+    pub fn tls_cipher(this: &IncomingRequestCfProperties) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=tlsVersion)]
-    pub fn tls_version(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
+    pub fn tls_version(this: &IncomingRequestCfProperties) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn city(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
+    pub fn city(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn continent(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
+    pub fn continent(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn latitude(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
+    pub fn latitude(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn longitude(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
+    pub fn longitude(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=postalCode)]
-    pub fn postal_code(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
+    pub fn postal_code(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=metroCode)]
-    pub fn metro_code(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
+    pub fn metro_code(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn region(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
+    pub fn region(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=regionCode)]
-    pub fn region_code(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
+    pub fn region_code(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn timezone(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
+    pub fn timezone(this: &IncomingRequestCfProperties) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=isEUCountry)]
-    pub fn is_eu_country(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
+    pub fn is_eu_country(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 }

--- a/worker-sys/src/types/incoming_request_cf_properties.rs
+++ b/worker-sys/src/types/incoming_request_cf_properties.rs
@@ -8,60 +8,60 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type IncomingRequestCfProperties;
 
-    #[wasm_bindgen(method, getter)]
-    pub fn colo(this: &IncomingRequestCfProperties) -> String;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn colo(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn asn(this: &IncomingRequestCfProperties) -> u32;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn asn(this: &IncomingRequestCfProperties) -> Result<u32, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=asOrganization)]
-    pub fn as_organization(this: &IncomingRequestCfProperties) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=asOrganization)]
+    pub fn as_organization(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn country(this: &IncomingRequestCfProperties) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn country(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=httpProtocol)]
-    pub fn http_protocol(this: &IncomingRequestCfProperties) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=httpProtocol)]
+    pub fn http_protocol(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=requestPriority)]
-    pub fn request_priority(this: &IncomingRequestCfProperties) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter, js_name=requestPriority)]
+    pub fn request_priority(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=tlsClientAuth)]
-    pub fn tls_client_auth(this: &IncomingRequestCfProperties) -> Option<TlsClientAuth>;
+    #[wasm_bindgen(method, catch, getter, js_name=tlsClientAuth)]
+    pub fn tls_client_auth(this: &IncomingRequestCfProperties) -> Result<Option<TlsClientAuth>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=tlsCipher)]
-    pub fn tls_cipher(this: &IncomingRequestCfProperties) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=tlsCipher)]
+    pub fn tls_cipher(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=tlsVersion)]
-    pub fn tls_version(this: &IncomingRequestCfProperties) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=tlsVersion)]
+    pub fn tls_version(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn city(this: &IncomingRequestCfProperties) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn city(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn continent(this: &IncomingRequestCfProperties) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn continent(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn latitude(this: &IncomingRequestCfProperties) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn latitude(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn longitude(this: &IncomingRequestCfProperties) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn longitude(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=postalCode)]
-    pub fn postal_code(this: &IncomingRequestCfProperties) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter, js_name=postalCode)]
+    pub fn postal_code(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=metroCode)]
-    pub fn metro_code(this: &IncomingRequestCfProperties) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter, js_name=metroCode)]
+    pub fn metro_code(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn region(this: &IncomingRequestCfProperties) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn region(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=regionCode)]
-    pub fn region_code(this: &IncomingRequestCfProperties) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter, js_name=regionCode)]
+    pub fn region_code(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn timezone(this: &IncomingRequestCfProperties) -> String;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn timezone(this: &IncomingRequestCfProperties) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=isEUCountry)]
-    pub fn is_eu_country(this: &IncomingRequestCfProperties) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter, js_name=isEUCountry)]
+    pub fn is_eu_country(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>
 }

--- a/worker-sys/src/types/queue.rs
+++ b/worker-sys/src/types/queue.rs
@@ -6,16 +6,16 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type MessageBatch;
 
-    #[wasm_bindgen(method, getter)]
-    pub fn queue(this: &MessageBatch) -> js_sys::JsString;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn queue(this: &MessageBatch) -> Result<js_sys::JsString, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn messages(this: &MessageBatch) -> js_sys::Array;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn messages(this: &MessageBatch) -> Result<js_sys::Array, JsValue>
 
-    #[wasm_bindgen(method, js_name=retryAll)]
+    #[wasm_bindgen(method, catch, js_name=retryAll)]
     pub fn retry_all(this: &MessageBatch, options: JsValue);
 
-    #[wasm_bindgen(method, js_name=ackAll)]
+    #[wasm_bindgen(method, catch, js_name=ackAll)]
     pub fn ack_all(this: &MessageBatch);
 }
 
@@ -25,19 +25,19 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Message;
 
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &Message) -> js_sys::JsString;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn id(this: &Message) -> Result<js_sys::JsString, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn timestamp(this: &Message) -> js_sys::Date;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn timestamp(this: &Message) -> Result<js_sys::Date, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn body(this: &Message) -> JsValue;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn body(this: &Message) -> Result<JsValue, JsValue>
 
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, catch)]
     pub fn retry(this: &Message, options: JsValue);
 
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, catch)]
     pub fn ack(this: &Message);
 }
 
@@ -47,9 +47,9 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Queue;
 
-    #[wasm_bindgen(method)]
-    pub fn send(this: &Queue, message: JsValue, options: JsValue) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch)]
+    pub fn send(this: &Queue, message: JsValue, options: JsValue) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method, js_name=sendBatch)]
-    pub fn send_batch(this: &Queue, messages: js_sys::Array, options: JsValue) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch, js_name=sendBatch)]
+    pub fn send_batch(this: &Queue, messages: js_sys::Array, options: JsValue) -> Result<js_sys::Promise, JsValue>
 }

--- a/worker-sys/src/types/queue.rs
+++ b/worker-sys/src/types/queue.rs
@@ -7,10 +7,10 @@ extern "C" {
     pub type MessageBatch;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn queue(this: &MessageBatch) -> Result<js_sys::JsString, JsValue>
+    pub fn queue(this: &MessageBatch) -> Result<js_sys::JsString, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn messages(this: &MessageBatch) -> Result<js_sys::Array, JsValue>
+    pub fn messages(this: &MessageBatch) -> Result<js_sys::Array, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=retryAll)]
     pub fn retry_all(this: &MessageBatch, options: JsValue);
@@ -26,13 +26,13 @@ extern "C" {
     pub type Message;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn id(this: &Message) -> Result<js_sys::JsString, JsValue>
+    pub fn id(this: &Message) -> Result<js_sys::JsString, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn timestamp(this: &Message) -> Result<js_sys::Date, JsValue>
+    pub fn timestamp(this: &Message) -> Result<js_sys::Date, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn body(this: &Message) -> Result<JsValue, JsValue>
+    pub fn body(this: &Message) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(method, catch)]
     pub fn retry(this: &Message, options: JsValue);
@@ -48,8 +48,16 @@ extern "C" {
     pub type Queue;
 
     #[wasm_bindgen(method, catch)]
-    pub fn send(this: &Queue, message: JsValue, options: JsValue) -> Result<js_sys::Promise, JsValue>
+    pub fn send(
+        this: &Queue,
+        message: JsValue,
+        options: JsValue,
+    ) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=sendBatch)]
-    pub fn send_batch(this: &Queue, messages: js_sys::Array, options: JsValue) -> Result<js_sys::Promise, JsValue>
+    pub fn send_batch(
+        this: &Queue,
+        messages: js_sys::Array,
+        options: JsValue,
+    ) -> Result<js_sys::Promise, JsValue>;
 }

--- a/worker-sys/src/types/queue.rs
+++ b/worker-sys/src/types/queue.rs
@@ -13,10 +13,10 @@ extern "C" {
     pub fn messages(this: &MessageBatch) -> Result<js_sys::Array, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=retryAll)]
-    pub fn retry_all(this: &MessageBatch, options: JsValue);
+    pub fn retry_all(this: &MessageBatch, options: JsValue) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=ackAll)]
-    pub fn ack_all(this: &MessageBatch);
+    pub fn ack_all(this: &MessageBatch) -> Result<(), JsValue>;
 }
 
 #[wasm_bindgen]
@@ -35,10 +35,10 @@ extern "C" {
     pub fn body(this: &Message) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(method, catch)]
-    pub fn retry(this: &Message, options: JsValue);
+    pub fn retry(this: &Message, options: JsValue) -> Result<(), JsValue>;
 
     #[wasm_bindgen(method, catch)]
-    pub fn ack(this: &Message);
+    pub fn ack(this: &Message) -> Result<(), JsValue>;
 }
 
 #[wasm_bindgen]

--- a/worker-sys/src/types/r2/bucket.rs
+++ b/worker-sys/src/types/r2/bucket.rs
@@ -7,27 +7,36 @@ extern "C" {
     pub type R2Bucket;
 
     #[wasm_bindgen(method, catch)]
-    pub fn head(this: &R2Bucket, key: String) -> Result<js_sys::Promise, JsValue>
+    pub fn head(this: &R2Bucket, key: String) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch)]
-    pub fn get(this: &R2Bucket, key: String, options: JsValue) -> Result<js_sys::Promise, JsValue>
+    pub fn get(this: &R2Bucket, key: String, options: JsValue) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch)]
-    pub fn put(this: &R2Bucket, key: String, value: JsValue, options: JsValue) -> Result<js_sys::Promise, JsValue>
+    pub fn put(
+        this: &R2Bucket,
+        key: String,
+        value: JsValue,
+        options: JsValue,
+    ) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch)]
-    pub fn delete(this: &R2Bucket, key: String) -> Result<js_sys::Promise, JsValue>
+    pub fn delete(this: &R2Bucket, key: String) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch)]
-    pub fn list(this: &R2Bucket, options: JsValue) -> Result<js_sys::Promise, JsValue>
+    pub fn list(this: &R2Bucket, options: JsValue) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=createMultipartUpload)]
     pub fn create_multipart_upload(
         this: &R2Bucket,
         key: String,
         options: JsValue,
-    ) -> js_sys::Promise;
+    ) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=resumeMultipartUpload)]
-    pub fn resume_multipart_upload(this: &R2Bucket, key: String, upload_id: String) -> Result<JsValue, JsValue>
+    pub fn resume_multipart_upload(
+        this: &R2Bucket,
+        key: String,
+        upload_id: String,
+    ) -> Result<JsValue, JsValue>;
 }

--- a/worker-sys/src/types/r2/bucket.rs
+++ b/worker-sys/src/types/r2/bucket.rs
@@ -6,28 +6,28 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2Bucket;
 
-    #[wasm_bindgen(method)]
-    pub fn head(this: &R2Bucket, key: String) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch)]
+    pub fn head(this: &R2Bucket, key: String) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method)]
-    pub fn get(this: &R2Bucket, key: String, options: JsValue) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch)]
+    pub fn get(this: &R2Bucket, key: String, options: JsValue) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method)]
-    pub fn put(this: &R2Bucket, key: String, value: JsValue, options: JsValue) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch)]
+    pub fn put(this: &R2Bucket, key: String, value: JsValue, options: JsValue) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method)]
-    pub fn delete(this: &R2Bucket, key: String) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch)]
+    pub fn delete(this: &R2Bucket, key: String) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method)]
-    pub fn list(this: &R2Bucket, options: JsValue) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch)]
+    pub fn list(this: &R2Bucket, options: JsValue) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method, js_name=createMultipartUpload)]
+    #[wasm_bindgen(method, catch, js_name=createMultipartUpload)]
     pub fn create_multipart_upload(
         this: &R2Bucket,
         key: String,
         options: JsValue,
     ) -> js_sys::Promise;
 
-    #[wasm_bindgen(method, js_name=resumeMultipartUpload)]
-    pub fn resume_multipart_upload(this: &R2Bucket, key: String, upload_id: String) -> JsValue;
+    #[wasm_bindgen(method, catch, js_name=resumeMultipartUpload)]
+    pub fn resume_multipart_upload(this: &R2Bucket, key: String, upload_id: String) -> Result<JsValue, JsValue>
 }

--- a/worker-sys/src/types/r2/http_metadata.rs
+++ b/worker-sys/src/types/r2/http_metadata.rs
@@ -6,21 +6,21 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2HttpMetadata;
 
-    #[wasm_bindgen(method, getter, js_name=contentType)]
-    pub fn content_type(this: &R2HttpMetadata) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter, js_name=contentType)]
+    pub fn content_type(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=contentLanguage)]
-    pub fn content_language(this: &R2HttpMetadata) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter, js_name=contentLanguage)]
+    pub fn content_language(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=contentDisposition)]
-    pub fn content_disposition(this: &R2HttpMetadata) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter, js_name=contentDisposition)]
+    pub fn content_disposition(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=contentEncoding)]
-    pub fn content_encoding(this: &R2HttpMetadata) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter, js_name=contentEncoding)]
+    pub fn content_encoding(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=cacheControl)]
-    pub fn cache_control(this: &R2HttpMetadata) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter, js_name=cacheControl)]
+    pub fn cache_control(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=cacheExpiry)]
-    pub fn cache_expiry(this: &R2HttpMetadata) -> Option<js_sys::Date>;
+    #[wasm_bindgen(method, catch, getter, js_name=cacheExpiry)]
+    pub fn cache_expiry(this: &R2HttpMetadata) -> Result<Option<js_sys::Date>, JsValue>
 }

--- a/worker-sys/src/types/r2/http_metadata.rs
+++ b/worker-sys/src/types/r2/http_metadata.rs
@@ -7,20 +7,20 @@ extern "C" {
     pub type R2HttpMetadata;
 
     #[wasm_bindgen(method, catch, getter, js_name=contentType)]
-    pub fn content_type(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>
+    pub fn content_type(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=contentLanguage)]
-    pub fn content_language(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>
+    pub fn content_language(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=contentDisposition)]
-    pub fn content_disposition(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>
+    pub fn content_disposition(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=contentEncoding)]
-    pub fn content_encoding(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>
+    pub fn content_encoding(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=cacheControl)]
-    pub fn cache_control(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>
+    pub fn cache_control(this: &R2HttpMetadata) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=cacheExpiry)]
-    pub fn cache_expiry(this: &R2HttpMetadata) -> Result<Option<js_sys::Date>, JsValue>
+    pub fn cache_expiry(this: &R2HttpMetadata) -> Result<Option<js_sys::Date>, JsValue>;
 }

--- a/worker-sys/src/types/r2/multipart_upload.rs
+++ b/worker-sys/src/types/r2/multipart_upload.rs
@@ -7,21 +7,24 @@ extern "C" {
     pub type R2MultipartUpload;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn key(this: &R2MultipartUpload) -> Result<String, JsValue>
+    pub fn key(this: &R2MultipartUpload) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=uploadId)]
-    pub fn upload_id(this: &R2MultipartUpload) -> Result<String, JsValue>
+    pub fn upload_id(this: &R2MultipartUpload) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=uploadPart)]
     pub fn upload_part(
         this: &R2MultipartUpload,
         part_number: u16,
         value: JsValue,
-    ) -> js_sys::Promise;
+    ) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch)]
-    pub fn abort(this: &R2MultipartUpload) -> Result<js_sys::Promise, JsValue>
+    pub fn abort(this: &R2MultipartUpload) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch)]
-    pub fn complete(this: &R2MultipartUpload, uploaded_parts: Vec<JsValue>) -> Result<js_sys::Promise, JsValue>
+    pub fn complete(
+        this: &R2MultipartUpload,
+        uploaded_parts: Vec<JsValue>,
+    ) -> Result<js_sys::Promise, JsValue>;
 }

--- a/worker-sys/src/types/r2/multipart_upload.rs
+++ b/worker-sys/src/types/r2/multipart_upload.rs
@@ -6,22 +6,22 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2MultipartUpload;
 
-    #[wasm_bindgen(method, getter)]
-    pub fn key(this: &R2MultipartUpload) -> String;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn key(this: &R2MultipartUpload) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=uploadId)]
-    pub fn upload_id(this: &R2MultipartUpload) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=uploadId)]
+    pub fn upload_id(this: &R2MultipartUpload) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, js_name=uploadPart)]
+    #[wasm_bindgen(method, catch, js_name=uploadPart)]
     pub fn upload_part(
         this: &R2MultipartUpload,
         part_number: u16,
         value: JsValue,
     ) -> js_sys::Promise;
 
-    #[wasm_bindgen(method)]
-    pub fn abort(this: &R2MultipartUpload) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch)]
+    pub fn abort(this: &R2MultipartUpload) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method)]
-    pub fn complete(this: &R2MultipartUpload, uploaded_parts: Vec<JsValue>) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch)]
+    pub fn complete(this: &R2MultipartUpload, uploaded_parts: Vec<JsValue>) -> Result<js_sys::Promise, JsValue>
 }

--- a/worker-sys/src/types/r2/object.rs
+++ b/worker-sys/src/types/r2/object.rs
@@ -9,34 +9,34 @@ extern "C" {
     pub type R2Object;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn key(this: &R2Object) -> Result<String, JsValue>
+    pub fn key(this: &R2Object) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn version(this: &R2Object) -> Result<String, JsValue>
+    pub fn version(this: &R2Object) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn size(this: &R2Object) -> Result<u32, JsValue>
+    pub fn size(this: &R2Object) -> Result<u32, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn etag(this: &R2Object) -> Result<String, JsValue>
+    pub fn etag(this: &R2Object) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=httpEtag)]
-    pub fn http_etag(this: &R2Object) -> Result<String, JsValue>
+    pub fn http_etag(this: &R2Object) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn uploaded(this: &R2Object) -> Result<js_sys::Date, JsValue>
+    pub fn uploaded(this: &R2Object) -> Result<js_sys::Date, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=httpMetadata)]
-    pub fn http_metadata(this: &R2Object) -> Result<R2HttpMetadata, JsValue>
+    pub fn http_metadata(this: &R2Object) -> Result<R2HttpMetadata, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn checksums(this: &R2Object) -> Result<js_sys::Object, JsValue>
+    pub fn checksums(this: &R2Object) -> Result<js_sys::Object, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=customMetadata)]
-    pub fn custom_metadata(this: &R2Object) -> Result<js_sys::Object, JsValue>
+    pub fn custom_metadata(this: &R2Object) -> Result<js_sys::Object, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn range(this: &R2Object) -> Result<R2Range, JsValue>
+    pub fn range(this: &R2Object) -> Result<R2Range, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=writeHttpMetadata)]
     pub fn write_http_metadata(

--- a/worker-sys/src/types/r2/object.rs
+++ b/worker-sys/src/types/r2/object.rs
@@ -8,35 +8,35 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2Object;
 
-    #[wasm_bindgen(method, getter)]
-    pub fn key(this: &R2Object) -> String;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn key(this: &R2Object) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn version(this: &R2Object) -> String;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn version(this: &R2Object) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn size(this: &R2Object) -> u32;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn size(this: &R2Object) -> Result<u32, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn etag(this: &R2Object) -> String;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn etag(this: &R2Object) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=httpEtag)]
-    pub fn http_etag(this: &R2Object) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=httpEtag)]
+    pub fn http_etag(this: &R2Object) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn uploaded(this: &R2Object) -> js_sys::Date;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn uploaded(this: &R2Object) -> Result<js_sys::Date, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=httpMetadata)]
-    pub fn http_metadata(this: &R2Object) -> R2HttpMetadata;
+    #[wasm_bindgen(method, catch, getter, js_name=httpMetadata)]
+    pub fn http_metadata(this: &R2Object) -> Result<R2HttpMetadata, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn checksums(this: &R2Object) -> js_sys::Object;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn checksums(this: &R2Object) -> Result<js_sys::Object, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=customMetadata)]
-    pub fn custom_metadata(this: &R2Object) -> js_sys::Object;
+    #[wasm_bindgen(method, catch, getter, js_name=customMetadata)]
+    pub fn custom_metadata(this: &R2Object) -> Result<js_sys::Object, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn range(this: &R2Object) -> R2Range;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn range(this: &R2Object) -> Result<R2Range, JsValue>
 
     #[wasm_bindgen(method, catch, js_name=writeHttpMetadata)]
     pub fn write_http_metadata(

--- a/worker-sys/src/types/r2/object_body.rs
+++ b/worker-sys/src/types/r2/object_body.rs
@@ -8,12 +8,12 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2ObjectBody;
 
-    #[wasm_bindgen(method, getter)]
-    pub fn body(this: &R2ObjectBody) -> web_sys::ReadableStream;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn body(this: &R2ObjectBody) -> Result<web_sys::ReadableStream, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=bodyUsed)]
-    pub fn body_used(this: &R2ObjectBody) -> bool;
+    #[wasm_bindgen(method, catch, getter, js_name=bodyUsed)]
+    pub fn body_used(this: &R2ObjectBody) -> Result<bool, JsValue>
 
-    #[wasm_bindgen(method, js_name=arrayBuffer)]
-    pub fn array_buffer(this: &R2ObjectBody) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch, js_name=arrayBuffer)]
+    pub fn array_buffer(this: &R2ObjectBody) -> Result<js_sys::Promise, JsValue>
 }

--- a/worker-sys/src/types/r2/object_body.rs
+++ b/worker-sys/src/types/r2/object_body.rs
@@ -9,11 +9,11 @@ extern "C" {
     pub type R2ObjectBody;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn body(this: &R2ObjectBody) -> Result<web_sys::ReadableStream, JsValue>
+    pub fn body(this: &R2ObjectBody) -> Result<web_sys::ReadableStream, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=bodyUsed)]
-    pub fn body_used(this: &R2ObjectBody) -> Result<bool, JsValue>
+    pub fn body_used(this: &R2ObjectBody) -> Result<bool, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=arrayBuffer)]
-    pub fn array_buffer(this: &R2ObjectBody) -> Result<js_sys::Promise, JsValue>
+    pub fn array_buffer(this: &R2ObjectBody) -> Result<js_sys::Promise, JsValue>;
 }

--- a/worker-sys/src/types/r2/objects.rs
+++ b/worker-sys/src/types/r2/objects.rs
@@ -8,15 +8,15 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2Objects;
 
-    #[wasm_bindgen(method, getter)]
-    pub fn objects(this: &R2Objects) -> Vec<R2Object>;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn objects(this: &R2Objects) -> Result<Vec<R2Object>, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn truncated(this: &R2Objects) -> bool;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn truncated(this: &R2Objects) -> Result<bool, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn cursor(this: &R2Objects) -> Option<String>;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn cursor(this: &R2Objects) -> Result<Option<String>, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=delimitedPrefixes)]
-    pub fn delimited_prefixes(this: &R2Objects) -> Vec<js_sys::JsString>;
+    #[wasm_bindgen(method, catch, getter, js_name=delimitedPrefixes)]
+    pub fn delimited_prefixes(this: &R2Objects) -> Result<Vec<js_sys::JsString>, JsValue>
 }

--- a/worker-sys/src/types/r2/objects.rs
+++ b/worker-sys/src/types/r2/objects.rs
@@ -9,14 +9,14 @@ extern "C" {
     pub type R2Objects;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn objects(this: &R2Objects) -> Result<Vec<R2Object>, JsValue>
+    pub fn objects(this: &R2Objects) -> Result<Vec<R2Object>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn truncated(this: &R2Objects) -> Result<bool, JsValue>
+    pub fn truncated(this: &R2Objects) -> Result<bool, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn cursor(this: &R2Objects) -> Result<Option<String>, JsValue>
+    pub fn cursor(this: &R2Objects) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=delimitedPrefixes)]
-    pub fn delimited_prefixes(this: &R2Objects) -> Result<Vec<js_sys::JsString>, JsValue>
+    pub fn delimited_prefixes(this: &R2Objects) -> Result<Vec<js_sys::JsString>, JsValue>;
 }

--- a/worker-sys/src/types/r2/uploaded_part.rs
+++ b/worker-sys/src/types/r2/uploaded_part.rs
@@ -7,8 +7,8 @@ extern "C" {
     pub type R2UploadedPart;
 
     #[wasm_bindgen(method, catch, getter, js_name=partNumber)]
-    pub fn part_number(this: &R2UploadedPart) -> Result<u16, JsValue>
+    pub fn part_number(this: &R2UploadedPart) -> Result<u16, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn etag(this: &R2UploadedPart) -> Result<String, JsValue>
+    pub fn etag(this: &R2UploadedPart) -> Result<String, JsValue>;
 }

--- a/worker-sys/src/types/r2/uploaded_part.rs
+++ b/worker-sys/src/types/r2/uploaded_part.rs
@@ -6,9 +6,9 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type R2UploadedPart;
 
-    #[wasm_bindgen(method, getter, js_name=partNumber)]
-    pub fn part_number(this: &R2UploadedPart) -> u16;
+    #[wasm_bindgen(method, catch, getter, js_name=partNumber)]
+    pub fn part_number(this: &R2UploadedPart) -> Result<u16, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn etag(this: &R2UploadedPart) -> String;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn etag(this: &R2UploadedPart) -> Result<String, JsValue>
 }

--- a/worker-sys/src/types/schedule.rs
+++ b/worker-sys/src/types/schedule.rs
@@ -6,11 +6,11 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type ScheduledEvent;
 
-    #[wasm_bindgen(method, getter, js_name=scheduledTime)]
-    pub fn scheduled_time(this: &ScheduledEvent) -> f64;
+    #[wasm_bindgen(method, catch, getter, js_name=scheduledTime)]
+    pub fn scheduled_time(this: &ScheduledEvent) -> Result<f64, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn cron(this: &ScheduledEvent) -> String;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn cron(this: &ScheduledEvent) -> Result<String, JsValue>
 }
 
 /// [Context](https://developers.cloudflare.com/workers/runtime-apis/scheduled-event#syntax-module-worker)
@@ -20,6 +20,6 @@ extern "C" {
     #[derive(Debug, Clone)]
     pub type ScheduleContext;
 
-    #[wasm_bindgen(method, js_name=waitUntil)]
+    #[wasm_bindgen(method, catch, js_name=waitUntil)]
     pub fn wait_until(this: &ScheduleContext, promise: js_sys::Promise);
 }

--- a/worker-sys/src/types/schedule.rs
+++ b/worker-sys/src/types/schedule.rs
@@ -7,10 +7,10 @@ extern "C" {
     pub type ScheduledEvent;
 
     #[wasm_bindgen(method, catch, getter, js_name=scheduledTime)]
-    pub fn scheduled_time(this: &ScheduledEvent) -> Result<f64, JsValue>
+    pub fn scheduled_time(this: &ScheduledEvent) -> Result<f64, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn cron(this: &ScheduledEvent) -> Result<String, JsValue>
+    pub fn cron(this: &ScheduledEvent) -> Result<String, JsValue>;
 }
 
 /// [Context](https://developers.cloudflare.com/workers/runtime-apis/scheduled-event#syntax-module-worker)
@@ -21,5 +21,5 @@ extern "C" {
     pub type ScheduleContext;
 
     #[wasm_bindgen(method, catch, js_name=waitUntil)]
-    pub fn wait_until(this: &ScheduleContext, promise: js_sys::Promise);
+    pub fn wait_until(this: &ScheduleContext, promise: js_sys::Promise) -> Result<(), JsValue>;
 }

--- a/worker-sys/src/types/socket.rs
+++ b/worker-sys/src/types/socket.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen(module = "cloudflare:sockets")]
 extern "C" {
     #[wasm_bindgen]
-    pub fn connect(address: JsValue, options: JsValue) -> Socket;
+    pub fn connect(address: JsValue, options: JsValue) -> Result<Socket, JsValue>
 }
 
 #[wasm_bindgen]
@@ -12,21 +12,21 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Socket;
 
-    #[wasm_bindgen(method)]
-    pub fn close(this: &Socket) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch)]
+    pub fn close(this: &Socket) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn closed(this: &Socket) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn closed(this: &Socket) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn opened(this: &Socket) -> js_sys::Promise;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn opened(this: &Socket) -> Result<js_sys::Promise, JsValue>
 
-    #[wasm_bindgen(method, js_name=startTls)]
-    pub fn start_tls(this: &Socket) -> Socket;
+    #[wasm_bindgen(method, catch, js_name=startTls)]
+    pub fn start_tls(this: &Socket) -> Result<Socket, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn readable(this: &Socket) -> web_sys::ReadableStream;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn readable(this: &Socket) -> Result<web_sys::ReadableStream, JsValue>
 
-    #[wasm_bindgen(method, getter)]
-    pub fn writable(this: &Socket) -> web_sys::WritableStream;
+    #[wasm_bindgen(method, catch, getter)]
+    pub fn writable(this: &Socket) -> Result<web_sys::WritableStream, JsValue>
 }

--- a/worker-sys/src/types/socket.rs
+++ b/worker-sys/src/types/socket.rs
@@ -2,8 +2,8 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(module = "cloudflare:sockets")]
 extern "C" {
-    #[wasm_bindgen]
-    pub fn connect(address: JsValue, options: JsValue) -> Result<Socket, JsValue>
+    #[wasm_bindgen(catch)]
+    pub fn connect(address: JsValue, options: JsValue) -> Result<Socket, JsValue>;
 }
 
 #[wasm_bindgen]
@@ -13,20 +13,20 @@ extern "C" {
     pub type Socket;
 
     #[wasm_bindgen(method, catch)]
-    pub fn close(this: &Socket) -> Result<js_sys::Promise, JsValue>
+    pub fn close(this: &Socket) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn closed(this: &Socket) -> Result<js_sys::Promise, JsValue>
+    pub fn closed(this: &Socket) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn opened(this: &Socket) -> Result<js_sys::Promise, JsValue>
+    pub fn opened(this: &Socket) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=startTls)]
-    pub fn start_tls(this: &Socket) -> Result<Socket, JsValue>
+    pub fn start_tls(this: &Socket) -> Result<Socket, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn readable(this: &Socket) -> Result<web_sys::ReadableStream, JsValue>
+    pub fn readable(this: &Socket) -> Result<web_sys::ReadableStream, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn writable(this: &Socket) -> Result<web_sys::WritableStream, JsValue>
+    pub fn writable(this: &Socket) -> Result<web_sys::WritableStream, JsValue>;
 }

--- a/worker-sys/src/types/tls_client_auth.rs
+++ b/worker-sys/src/types/tls_client_auth.rs
@@ -5,39 +5,39 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq)]
     pub type TlsClientAuth;
 
-    #[wasm_bindgen(method, getter, js_name=certIssuerDNLegacy)]
-    pub fn cert_issuer_dn_legacy(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certIssuerDNLegacy)]
+    pub fn cert_issuer_dn_legacy(this: &TlsClientAuth) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=certIssuerDN)]
-    pub fn cert_issuer_dn(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certIssuerDN)]
+    pub fn cert_issuer_dn(this: &TlsClientAuth) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=certIssuerDNRFC2253)]
-    pub fn cert_issuer_dn_rfc2253(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certIssuerDNRFC2253)]
+    pub fn cert_issuer_dn_rfc2253(this: &TlsClientAuth) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=certSubjectDNLegacy)]
-    pub fn cert_subject_dn_legacy(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certSubjectDNLegacy)]
+    pub fn cert_subject_dn_legacy(this: &TlsClientAuth) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=certVerified)]
-    pub fn cert_verified(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certVerified)]
+    pub fn cert_verified(this: &TlsClientAuth) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=certNotAfter)]
-    pub fn cert_not_after(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certNotAfter)]
+    pub fn cert_not_after(this: &TlsClientAuth) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=certSubjectDN)]
-    pub fn cert_subject_dn(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certSubjectDN)]
+    pub fn cert_subject_dn(this: &TlsClientAuth) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=certFingerprintSHA1)]
-    pub fn cert_fingerprint_sha1(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certFingerprintSHA1)]
+    pub fn cert_fingerprint_sha1(this: &TlsClientAuth) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=certNotBefore)]
-    pub fn cert_not_before(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certNotBefore)]
+    pub fn cert_not_before(this: &TlsClientAuth) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=certSerial)]
-    pub fn cert_serial(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certSerial)]
+    pub fn cert_serial(this: &TlsClientAuth) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=certPresented)]
-    pub fn cert_presented(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certPresented)]
+    pub fn cert_presented(this: &TlsClientAuth) -> Result<String, JsValue>
 
-    #[wasm_bindgen(method, getter, js_name=certSubjectDNRFC2253)]
-    pub fn cert_subject_dn_rfc2253(this: &TlsClientAuth) -> String;
+    #[wasm_bindgen(method, catch, getter, js_name=certSubjectDNRFC2253)]
+    pub fn cert_subject_dn_rfc2253(this: &TlsClientAuth) -> Result<String, JsValue>
 }

--- a/worker-sys/src/types/tls_client_auth.rs
+++ b/worker-sys/src/types/tls_client_auth.rs
@@ -6,38 +6,38 @@ extern "C" {
     pub type TlsClientAuth;
 
     #[wasm_bindgen(method, catch, getter, js_name=certIssuerDNLegacy)]
-    pub fn cert_issuer_dn_legacy(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_issuer_dn_legacy(this: &TlsClientAuth) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=certIssuerDN)]
-    pub fn cert_issuer_dn(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_issuer_dn(this: &TlsClientAuth) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=certIssuerDNRFC2253)]
-    pub fn cert_issuer_dn_rfc2253(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_issuer_dn_rfc2253(this: &TlsClientAuth) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=certSubjectDNLegacy)]
-    pub fn cert_subject_dn_legacy(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_subject_dn_legacy(this: &TlsClientAuth) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=certVerified)]
-    pub fn cert_verified(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_verified(this: &TlsClientAuth) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=certNotAfter)]
-    pub fn cert_not_after(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_not_after(this: &TlsClientAuth) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=certSubjectDN)]
-    pub fn cert_subject_dn(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_subject_dn(this: &TlsClientAuth) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=certFingerprintSHA1)]
-    pub fn cert_fingerprint_sha1(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_fingerprint_sha1(this: &TlsClientAuth) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=certNotBefore)]
-    pub fn cert_not_before(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_not_before(this: &TlsClientAuth) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=certSerial)]
-    pub fn cert_serial(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_serial(this: &TlsClientAuth) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=certPresented)]
-    pub fn cert_presented(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_presented(this: &TlsClientAuth) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=certSubjectDNRFC2253)]
-    pub fn cert_subject_dn_rfc2253(this: &TlsClientAuth) -> Result<String, JsValue>
+    pub fn cert_subject_dn_rfc2253(this: &TlsClientAuth) -> Result<String, JsValue>;
 }

--- a/worker-sys/src/types/websocket_pair.rs
+++ b/worker-sys/src/types/websocket_pair.rs
@@ -7,8 +7,8 @@ extern "C" {
     /// The `WebSocketPair` dictionary.
     pub type WebSocketPair;
 
-    #[wasm_bindgen(constructor)]
-    pub fn new() -> Result<WebSocketPair, JsValue>
+    #[wasm_bindgen(constructor, catch)]
+    pub fn new() -> Result<WebSocketPair, JsValue>;
 }
 
 impl WebSocketPair {

--- a/worker-sys/src/types/websocket_pair.rs
+++ b/worker-sys/src/types/websocket_pair.rs
@@ -8,7 +8,7 @@ extern "C" {
     pub type WebSocketPair;
 
     #[wasm_bindgen(constructor)]
-    pub fn new() -> WebSocketPair;
+    pub fn new() -> Result<WebSocketPair, JsValue>
 }
 
 impl WebSocketPair {

--- a/worker/src/cf.rs
+++ b/worker/src/cf.rs
@@ -26,35 +26,35 @@ impl Cf {
     /// The three-letter airport code (e.g. `ATX`, `LUX`) representing
     /// the colocation which processed the request
     pub fn colo(&self) -> String {
-        self.inner.colo()
+        self.inner.colo().unwrap()
     }
 
     /// The Autonomous System Number (ASN) of the request, e.g. `395747`
     pub fn asn(&self) -> u32 {
-        self.inner.asn()
+        self.inner.asn().unwrap()
     }
 
     /// The Autonomous System organization name of the request, e.g. `Cloudflare, Inc.`
     pub fn as_organization(&self) -> String {
-        self.inner.as_organization()
+        self.inner.as_organization().unwrap()
     }
 
     /// The two-letter country code of origin for the request.
     /// This is the same value as that provided in the CF-IPCountry header, e.g.  `"US"`
     pub fn country(&self) -> Option<String> {
-        self.inner.country()
+        self.inner.country().unwrap()
     }
 
     /// The HTTP Protocol (e.g. "HTTP/2") used by the request
     pub fn http_protocol(&self) -> String {
-        self.inner.http_protocol()
+        self.inner.http_protocol().unwrap()
     }
 
     /// The browser-requested prioritization information in the request object,
     ///
     /// See [this blog post](https://blog.cloudflare.com/better-http-2-prioritization-for-a-faster-web/#customizingprioritizationwithworkers) for details.
     pub fn request_priority(&self) -> Option<RequestPriority> {
-        if let Some(priority) = self.inner.request_priority() {
+        if let Some(priority) = self.inner.request_priority().unwrap() {
             let mut weight = 1;
             let mut exclusive = false;
             let mut group = 0;
@@ -93,35 +93,35 @@ impl Cf {
 
     /// The cipher for the connection to Cloudflare, e.g. "AEAD-AES128-GCM-SHA256".
     pub fn tls_cipher(&self) -> String {
-        self.inner.tls_cipher()
+        self.inner.tls_cipher().unwrap()
     }
 
     /// Information about the client's authorization.
     /// Only set when using Cloudflare Access or API Shield.
     pub fn tls_client_auth(&self) -> Option<TlsClientAuth> {
-        self.inner.tls_client_auth().map(Into::into)
+        self.inner.tls_client_auth().unwrap().map(Into::into)
     }
 
     /// The TLS version of the connection to Cloudflare, e.g. TLSv1.3.
     pub fn tls_version(&self) -> String {
         // TODO: should this be strongly typed? with ordering, etc.?
-        self.inner.tls_version()
+        self.inner.tls_version().unwrap()
     }
 
     /// City of the incoming request, e.g. "Austin".
     pub fn city(&self) -> Option<String> {
-        self.inner.city()
+        self.inner.city().unwrap()
     }
 
     /// Continent of the incoming request, e.g. "NA"
     pub fn continent(&self) -> Option<String> {
-        self.inner.continent()
+        self.inner.continent().unwrap()
     }
 
     /// Latitude and longitude of the incoming request, e.g. (30.27130, -97.74260)
     pub fn coordinates(&self) -> Option<(f32, f32)> {
-        let lat_opt = self.inner.latitude();
-        let lon_opt = self.inner.longitude();
+        let lat_opt = self.inner.latitude().unwrap();
+        let lon_opt = self.inner.longitude().unwrap();
         match (lat_opt, lon_opt) {
             (Some(lat_str), Some(lon_str)) => {
                 // SAFETY: i think this is fine..?
@@ -135,39 +135,39 @@ impl Cf {
 
     /// Postal code of the incoming request, e.g. "78701"
     pub fn postal_code(&self) -> Option<String> {
-        self.inner.postal_code()
+        self.inner.postal_code().unwrap()
     }
 
     /// Metro code (DMA) of the incoming request, e.g. "635"
     pub fn metro_code(&self) -> Option<String> {
-        self.inner.metro_code()
+        self.inner.metro_code().unwrap()
     }
 
     /// If known, the [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) name for the first level region associated with the IP address of the incoming request, e.g. "Texas".
     pub fn region(&self) -> Option<String> {
-        self.inner.region()
+        self.inner.region().unwrap()
     }
 
     /// If known, the [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code for the first level region associated with the IP address of the incoming request, e.g. "TX".
     pub fn region_code(&self) -> Option<String> {
-        self.inner.region_code()
+        self.inner.region_code().unwrap()
     }
 
     /// **Requires** `timezone` feature. Timezone of the incoming request
     #[cfg(feature = "timezone")]
     pub fn timezone(&self) -> Result<impl chrono::TimeZone> {
-        let tz = self.inner.timezone();
+        let tz = self.inner.timezone()?;
         Ok(tz.parse::<chrono_tz::Tz>()?)
     }
 
     /// Timezone name of the incoming request
     pub fn timezone_name(&self) -> String {
-        self.inner.timezone()
+        self.inner.timezone().unwrap()
     }
 
     /// Whether the country of the incoming request is in the EU
     pub fn is_eu_country(&self) -> bool {
-        self.inner.is_eu_country() == Some("1".to_string())
+        self.inner.is_eu_country().unwrap() == Some("1".to_string())
     }
 }
 
@@ -201,51 +201,51 @@ pub struct TlsClientAuth {
 
 impl TlsClientAuth {
     pub fn cert_issuer_dn_legacy(&self) -> String {
-        self.inner.cert_issuer_dn_legacy()
+        self.inner.cert_issuer_dn_legacy().unwrap()
     }
 
     pub fn cert_issuer_dn(&self) -> String {
-        self.inner.cert_issuer_dn()
+        self.inner.cert_issuer_dn().unwrap()
     }
 
     pub fn cert_issuer_dn_rfc2253(&self) -> String {
-        self.inner.cert_issuer_dn_rfc2253()
+        self.inner.cert_issuer_dn_rfc2253().unwrap()
     }
 
     pub fn cert_subject_dn_legacy(&self) -> String {
-        self.inner.cert_subject_dn_legacy()
+        self.inner.cert_subject_dn_legacy().unwrap()
     }
 
     pub fn cert_verified(&self) -> String {
-        self.inner.cert_verified()
+        self.inner.cert_verified().unwrap()
     }
 
     pub fn cert_not_after(&self) -> String {
-        self.inner.cert_not_after()
+        self.inner.cert_not_after().unwrap()
     }
 
     pub fn cert_subject_dn(&self) -> String {
-        self.inner.cert_subject_dn()
+        self.inner.cert_subject_dn().unwrap()
     }
 
     pub fn cert_fingerprint_sha1(&self) -> String {
-        self.inner.cert_fingerprint_sha1()
+        self.inner.cert_fingerprint_sha1().unwrap()
     }
 
     pub fn cert_not_before(&self) -> String {
-        self.inner.cert_not_before()
+        self.inner.cert_not_before().unwrap()
     }
 
     pub fn cert_serial(&self) -> String {
-        self.inner.cert_serial()
+        self.inner.cert_serial().unwrap()
     }
 
     pub fn cert_presented(&self) -> String {
-        self.inner.cert_presented()
+        self.inner.cert_presented().unwrap()
     }
 
     pub fn cert_subject_dn_rfc2253(&self) -> String {
-        self.inner.cert_subject_dn_rfc2253()
+        self.inner.cert_subject_dn_rfc2253().unwrap()
     }
 }
 

--- a/worker/src/context.rs
+++ b/worker/src/context.rs
@@ -33,17 +33,19 @@ impl Context {
     where
         F: Future<Output = ()> + 'static,
     {
-        self.inner.wait_until(&future_to_promise(async {
-            future.await;
-            Ok(JsValue::UNDEFINED)
-        }))
+        self.inner
+            .wait_until(&future_to_promise(async {
+                future.await;
+                Ok(JsValue::UNDEFINED)
+            }))
+            .unwrap()
     }
 
     /// Prevents a runtime error response when the Worker script throws an unhandled exception.
     /// Instead, the script will "fail open", which will proxy the request to the origin server
     /// as though the Worker was never invoked.
     pub fn pass_through_on_exception(&self) {
-        self.inner.pass_through_on_exception()
+        self.inner.pass_through_on_exception().unwrap()
     }
 }
 

--- a/worker/src/fetcher.rs
+++ b/worker/src/fetcher.rs
@@ -35,7 +35,7 @@ impl Fetcher {
         let promise = match init {
             Some(ref init) => self.0.fetch_with_str_and_init(&path, &init.into()),
             None => self.0.fetch_with_str(&path),
-        };
+        }?;
 
         let resp_sys: web_sys::Response = JsFuture::from(promise).await?.dyn_into()?;
         #[cfg(not(feature = "http"))]
@@ -57,7 +57,7 @@ impl Fetcher {
         let req = TryInto::<Request>::try_into(request)?;
         #[cfg(not(feature = "http"))]
         let req = request;
-        let promise = self.0.fetch(req.inner());
+        let promise = self.0.fetch(req.inner())?;
         let resp_sys: web_sys::Response = JsFuture::from(promise).await?.dyn_into()?;
         let response = Response::from(resp_sys);
         #[cfg(feature = "http")]

--- a/worker/src/http/request.rs
+++ b/worker/src/http/request.rs
@@ -34,7 +34,7 @@ pub fn from_wasm(req: web_sys::Request) -> Result<http::Request<Body>> {
 
     if let Some(cf) = req.cf() {
         builder = builder
-            .version(version_from_string(&cf.http_protocol()))
+            .version(version_from_string(&cf.http_protocol()?))
             .extension(Cf::new(cf));
     }
 

--- a/worker/src/r2/builder.rs
+++ b/worker/src/r2/builder.rs
@@ -45,7 +45,7 @@ impl<'bucket> GetOptionsBuilder<'bucket> {
                 "range" => self.range.map(JsObject::from),
             }
             .into(),
-        );
+        )?;
 
         let value = JsFuture::from(get_promise).await?;
 
@@ -228,7 +228,7 @@ impl<'bucket> PutOptionsBuilder<'bucket> {
                 }),
             }
             .into(),
-        );
+        )?;
         let res: EdgeR2Object = JsFuture::from(put_promise).await?.into();
         let inner = if JsString::from("bodyUsed").js_in(&res) {
             ObjectInner::Body(res.unchecked_into())
@@ -281,7 +281,7 @@ impl<'bucket> CreateMultipartUploadOptionsBuilder<'bucket> {
                 },
             }
             .into(),
-        );
+        )?;
         let inner: EdgeR2MultipartUpload = JsFuture::from(create_multipart_upload_promise)
             .await?
             .into();
@@ -325,12 +325,12 @@ impl From<HttpMetadata> for JsObject {
 impl From<R2HttpMetadataSys> for HttpMetadata {
     fn from(val: R2HttpMetadataSys) -> Self {
         Self {
-            content_type: val.content_type(),
-            content_language: val.content_language(),
-            content_disposition: val.content_disposition(),
-            content_encoding: val.content_encoding(),
-            cache_control: val.cache_control(),
-            cache_expiry: val.cache_expiry().map(Into::into),
+            content_type: val.content_type().unwrap(),
+            content_language: val.content_language().unwrap(),
+            content_disposition: val.content_disposition().unwrap(),
+            content_encoding: val.content_encoding().unwrap(),
+            cache_control: val.cache_control().unwrap(),
+            cache_expiry: val.cache_expiry().unwrap().map(Into::into),
         }
     }
 }
@@ -415,7 +415,7 @@ impl<'bucket> ListOptionsBuilder<'bucket> {
                     .unwrap_or(JsValue::UNDEFINED),
             }
             .into(),
-        );
+        )?;
         let inner = JsFuture::from(list_promise).await?.into();
         Ok(Objects { inner })
     }

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -27,7 +27,7 @@ pub struct Bucket {
 impl Bucket {
     /// Retrieves the [Object] for the given key containing only object metadata, if the key exists.
     pub async fn head(&self, key: impl Into<String>) -> Result<Option<Object>> {
-        let head_promise = self.inner.head(key.into());
+        let head_promise = self.inner.head(key.into())?;
         let value = JsFuture::from(head_promise).await?;
 
         if value.is_null() {
@@ -74,7 +74,7 @@ impl Bucket {
     /// R2 deletes are strongly consistent. Once the Promise resolves, all subsequent read
     /// operations will no longer see this key value pair globally.
     pub async fn delete(&self, key: impl Into<String>) -> Result<()> {
-        let delete_promise = self.inner.delete(key.into());
+        let delete_promise = self.inner.delete(key.into())?;
         JsFuture::from(delete_promise).await?;
         Ok(())
     }
@@ -122,7 +122,7 @@ impl Bucket {
         Ok(MultipartUpload {
             inner: self
                 .inner
-                .resume_multipart_upload(key.into(), upload_id.into())
+                .resume_multipart_upload(key.into(), upload_id.into())?
                 .into(),
         })
     }
@@ -168,67 +168,67 @@ pub struct Object {
 impl Object {
     pub fn key(&self) -> String {
         match &self.inner {
-            ObjectInner::NoBody(inner) => inner.key(),
-            ObjectInner::Body(inner) => inner.key(),
+            ObjectInner::NoBody(inner) => inner.key().unwrap(),
+            ObjectInner::Body(inner) => inner.key().unwrap(),
         }
     }
 
     pub fn version(&self) -> String {
         match &self.inner {
-            ObjectInner::NoBody(inner) => inner.version(),
-            ObjectInner::Body(inner) => inner.version(),
+            ObjectInner::NoBody(inner) => inner.version().unwrap(),
+            ObjectInner::Body(inner) => inner.version().unwrap(),
         }
     }
 
     pub fn size(&self) -> u32 {
         match &self.inner {
-            ObjectInner::NoBody(inner) => inner.size(),
-            ObjectInner::Body(inner) => inner.size(),
+            ObjectInner::NoBody(inner) => inner.size().unwrap(),
+            ObjectInner::Body(inner) => inner.size().unwrap(),
         }
     }
 
     pub fn etag(&self) -> String {
         match &self.inner {
-            ObjectInner::NoBody(inner) => inner.etag(),
-            ObjectInner::Body(inner) => inner.etag(),
+            ObjectInner::NoBody(inner) => inner.etag().unwrap(),
+            ObjectInner::Body(inner) => inner.etag().unwrap(),
         }
     }
 
     pub fn http_etag(&self) -> String {
         match &self.inner {
-            ObjectInner::NoBody(inner) => inner.http_etag(),
-            ObjectInner::Body(inner) => inner.http_etag(),
+            ObjectInner::NoBody(inner) => inner.http_etag().unwrap(),
+            ObjectInner::Body(inner) => inner.http_etag().unwrap(),
         }
     }
 
     pub fn uploaded(&self) -> Date {
         match &self.inner {
-            ObjectInner::NoBody(inner) => inner.uploaded(),
-            ObjectInner::Body(inner) => inner.uploaded(),
+            ObjectInner::NoBody(inner) => inner.uploaded().unwrap(),
+            ObjectInner::Body(inner) => inner.uploaded().unwrap(),
         }
         .into()
     }
 
     pub fn http_metadata(&self) -> HttpMetadata {
         match &self.inner {
-            ObjectInner::NoBody(inner) => inner.http_metadata(),
-            ObjectInner::Body(inner) => inner.http_metadata(),
+            ObjectInner::NoBody(inner) => inner.http_metadata().unwrap(),
+            ObjectInner::Body(inner) => inner.http_metadata().unwrap(),
         }
         .into()
     }
 
     pub fn checksum(&self) -> R2Checksums {
         match &self.inner {
-            ObjectInner::NoBody(inner) => inner.checksums(),
-            ObjectInner::Body(inner) => inner.checksums(),
+            ObjectInner::NoBody(inner) => inner.checksums().unwrap(),
+            ObjectInner::Body(inner) => inner.checksums().unwrap(),
         }
         .into()
     }
 
     pub fn custom_metadata(&self) -> Result<HashMap<String, String>> {
         let metadata = match &self.inner {
-            ObjectInner::NoBody(inner) => inner.custom_metadata(),
-            ObjectInner::Body(inner) => inner.custom_metadata(),
+            ObjectInner::NoBody(inner) => inner.custom_metadata().unwrap(),
+            ObjectInner::Body(inner) => inner.custom_metadata().unwrap(),
         };
 
         let keys = js_sys::Object::keys(&metadata).to_vec();
@@ -245,8 +245,8 @@ impl Object {
 
     pub fn range(&self) -> Result<Range> {
         match &self.inner {
-            ObjectInner::NoBody(inner) => inner.range(),
-            ObjectInner::Body(inner) => inner.range(),
+            ObjectInner::NoBody(inner) => inner.range().unwrap(),
+            ObjectInner::Body(inner) => inner.range().unwrap(),
         }
         .try_into()
     }
@@ -261,7 +261,7 @@ impl Object {
     pub fn body_used(&self) -> Option<bool> {
         match &self.inner {
             ObjectInner::NoBody(_) => None,
-            ObjectInner::Body(inner) => Some(inner.body_used()),
+            ObjectInner::Body(inner) => Some(inner.body_used().unwrap()),
         }
     }
 
@@ -283,11 +283,11 @@ pub struct ObjectBody<'body> {
 impl<'body> ObjectBody<'body> {
     /// Reads the data in the [Object] via a [ByteStream].
     pub fn stream(self) -> Result<ByteStream> {
-        if self.inner.body_used() {
+        if self.inner.body_used()? {
             return Err(Error::BodyUsed);
         }
 
-        let stream = self.inner.body();
+        let stream = self.inner.body()?;
         let stream = wasm_streams::ReadableStream::from_raw(stream.unchecked_into());
         Ok(ByteStream {
             inner: stream.into_stream(),
@@ -300,15 +300,15 @@ impl<'body> ObjectBody<'body> {
     /// to the client in a [crate::Response]. This ensures that the worker does not consume CPU time
     /// while the streaming occurs, which can be significant if instead [ObjectBody::stream] is used.
     pub fn response_body(self) -> Result<ResponseBody> {
-        if self.inner.body_used() {
+        if self.inner.body_used()? {
             return Err(Error::BodyUsed);
         }
 
-        Ok(ResponseBody::Stream(self.inner.body()))
+        Ok(ResponseBody::Stream(self.inner.body()?))
     }
 
     pub async fn bytes(self) -> Result<Vec<u8>> {
-        let js_buffer = JsFuture::from(self.inner.array_buffer()).await?;
+        let js_buffer = JsFuture::from(self.inner.array_buffer()?).await?;
         let js_buffer = Uint8Array::new(&js_buffer);
         let mut bytes = vec![0; js_buffer.length() as usize];
         js_buffer.copy_to(&mut bytes);
@@ -330,11 +330,11 @@ pub struct UploadedPart {
 
 impl UploadedPart {
     pub fn part_number(&self) -> u16 {
-        self.inner.part_number()
+        self.inner.part_number().unwrap()
     }
 
     pub fn etag(&self) -> String {
-        self.inner.etag()
+        self.inner.etag().unwrap()
     }
 }
 
@@ -361,7 +361,7 @@ impl MultipartUpload {
         value: impl Into<Data>,
     ) -> Result<UploadedPart> {
         let uploaded_part =
-            JsFuture::from(self.inner.upload_part(part_number, value.into().into())).await?;
+            JsFuture::from(self.inner.upload_part(part_number, value.into().into())?).await?;
         Ok(UploadedPart {
             inner: uploaded_part.into(),
         })
@@ -369,12 +369,12 @@ impl MultipartUpload {
 
     /// Request the upload id.
     pub async fn upload_id(&self) -> String {
-        self.inner.upload_id()
+        self.inner.upload_id().unwrap()
     }
 
     /// Aborts the multipart upload.
     pub async fn abort(&self) -> Result<()> {
-        JsFuture::from(self.inner.abort()).await?;
+        JsFuture::from(self.inner.abort()?).await?;
         Ok(())
     }
 
@@ -390,7 +390,7 @@ impl MultipartUpload {
                     .into_iter()
                     .map(|part| part.inner.into())
                     .collect(),
-            ),
+            )?,
         )
         .await?;
         Ok(Object {
@@ -409,6 +409,7 @@ impl Objects {
     pub fn objects(&self) -> Vec<Object> {
         self.inner
             .objects()
+            .unwrap()
             .into_iter()
             .map(|raw| Object {
                 inner: ObjectInner::NoBody(raw),
@@ -419,13 +420,13 @@ impl Objects {
     /// If true, indicates there are more results to be retrieved for the current
     /// [list](Bucket::list) request.
     pub fn truncated(&self) -> bool {
-        self.inner.truncated()
+        self.inner.truncated().unwrap()
     }
 
     /// A token that can be passed to future [list](Bucket::list) calls to resume listing from that
     /// point. Only present if truncated is true.
     pub fn cursor(&self) -> Option<String> {
-        self.inner.cursor()
+        self.inner.cursor().unwrap()
     }
 
     /// If a delimiter has been specified, contains all prefixes between the specified prefix and
@@ -437,6 +438,7 @@ impl Objects {
     pub fn delimited_prefixes(&self) -> Vec<String> {
         self.inner
             .delimited_prefixes()
+            .unwrap()
             .into_iter()
             .map(Into::into)
             .collect()

--- a/worker/src/schedule.rs
+++ b/worker/src/schedule.rs
@@ -14,8 +14,8 @@ pub struct ScheduledEvent {
 impl From<EdgeScheduledEvent> for ScheduledEvent {
     fn from(schedule: EdgeScheduledEvent) -> Self {
         Self {
-            cron: schedule.cron(),
-            scheduled_time: schedule.scheduled_time(),
+            cron: schedule.cron().unwrap(),
+            scheduled_time: schedule.scheduled_time().unwrap(),
             ty: String::from("scheduled"),
         }
     }
@@ -54,9 +54,11 @@ impl ScheduleContext {
     where
         T: Future<Output = ()> + 'static,
     {
-        self.edge.wait_until(future_to_promise(async {
-            handler.await;
-            Ok(JsValue::null())
-        }))
+        self.edge
+            .wait_until(future_to_promise(async {
+                handler.await;
+                Ok(JsValue::null())
+            }))
+            .unwrap()
     }
 }

--- a/worker/src/socket.rs
+++ b/worker/src/socket.rs
@@ -79,8 +79,8 @@ unsafe impl Sync for Socket {}
 
 impl Socket {
     fn new(inner: worker_sys::Socket) -> Self {
-        let writable = inner.writable();
-        let readable = inner.readable();
+        let writable = inner.writable().unwrap();
+        let readable = inner.readable().unwrap();
         Socket {
             inner,
             writable,
@@ -93,19 +93,19 @@ impl Socket {
 
     /// Closes the TCP socket. Both the readable and writable streams are forcibly closed.
     pub async fn close(&mut self) -> Result<()> {
-        JsFuture::from(self.inner.close()).await?;
+        JsFuture::from(self.inner.close()?).await?;
         Ok(())
     }
 
     /// This Future is resolved when the socket is closed
     /// and is rejected if the socket encounters an error.
     pub async fn closed(&self) -> Result<()> {
-        JsFuture::from(self.inner.closed()).await?;
+        JsFuture::from(self.inner.closed()?).await?;
         Ok(())
     }
 
     pub async fn opened(&self) -> Result<SocketInfo> {
-        let value = JsFuture::from(self.inner.opened()).await?;
+        let value = JsFuture::from(self.inner.opened()?).await?;
         value.try_into()
     }
 
@@ -115,7 +115,7 @@ impl Socket {
     /// to [`StartTls`](SecureTransport::StartTls) when initially
     /// calling [`connect`](connect) to create the socket.
     pub fn start_tls(self) -> Socket {
-        let inner = self.inner.start_tls();
+        let inner = self.inner.start_tls().unwrap();
         Socket::new(inner)
     }
 
@@ -373,7 +373,7 @@ impl ConnectionBuilder {
         )
         .into();
 
-        let inner = worker_sys::connect(address, options);
+        let inner = worker_sys::connect(address, options)?;
         Ok(Socket::new(inner))
     }
 }

--- a/worker/src/streams.rs
+++ b/worker/src/streams.rs
@@ -96,9 +96,9 @@ impl Stream for FixedLengthStream {
 impl From<FixedLengthStream> for FixedLengthStreamSys {
     fn from(stream: FixedLengthStream) -> Self {
         let raw = if stream.length < u32::MAX as u64 {
-            FixedLengthStreamSys::new(stream.length as u32)
+            FixedLengthStreamSys::new(stream.length as u32).unwrap()
         } else {
-            FixedLengthStreamSys::new_big_int(BigInt::from(stream.length))
+            FixedLengthStreamSys::new_big_int(BigInt::from(stream.length)).unwrap()
         };
 
         let js_stream = stream

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -32,7 +32,7 @@ unsafe impl Sync for WebSocketPair {}
 impl WebSocketPair {
     /// Creates a new `WebSocketPair`.
     pub fn new() -> Result<Self> {
-        let mut pair = worker_sys::WebSocketPair::new();
+        let mut pair = worker_sys::WebSocketPair::new()?;
         let client = pair.client()?.into();
         let server = pair.server()?.into();
         Ok(Self { client, server })


### PR DESCRIPTION
This is quite a big PR trying to address https://github.com/cloudflare/workers-rs/issues/545 that should serve as a starting point/discussion point wrt to using `catch` project wide in all `method`, `constructor` and `static_method_of` calls.

This is a blanket replacement and fixup of all calls into `worker-sys` without changing the higher level API. This means that we introduce a few `.unwrap` calls and that I'll piggyback on methods that already were returning a `Result` so we can `?` unwrap all the errors.

Going forward, if we choose to go down this route, I'd suggest enforcing this as a project-wide rule.