### PR TITLE
 🎏 Add ReadableStream to Data 

### DIFF
--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -452,10 +452,17 @@ pub(crate) enum ObjectInner {
 }
 
 pub enum Data {
+    ReadableStream(web_sys::ReadableStream),
     Stream(FixedLengthStream),
     Text(String),
     Bytes(Vec<u8>),
     Empty,
+}
+
+impl From<web_sys::ReadableStream> for Data {
+    fn from(stream: web_sys::ReadableStream) -> Self {
+        Data::ReadableStream(stream)
+    }
 }
 
 impl From<FixedLengthStream> for Data {
@@ -479,6 +486,7 @@ impl From<Vec<u8>> for Data {
 impl From<Data> for JsValue {
     fn from(data: Data) -> Self {
         match data {
+            Data::ReadableStream(stream) => stream.into(),
             Data::Stream(stream) => {
                 let stream_sys: EdgeFixedLengthStream = stream.into();
                 stream_sys.readable().into()


### PR DESCRIPTION
Sits on top of #547 
Better diff: 87098013e96f009b90e5667f66c30865176539e0

Currently `Data` only exposes `FixedLengthStream`, however the node.js also allows the `ReadableStream` to be the argument to `put`.

https://github.com/cloudflare/workers-sdk/blob/ad1d056cb2710b790ff5d4532e9f694e099c27e2/packages/wrangler/src/r2/helpers.ts#L156

This adds the ability for `put` and `upload_part` to forward the `ReadableStream` from the `Request` body directly by just passing `req.inner().body().unwrap()`.