### PR TITLE
feat: Allow instantiating an UploadPart from its constituent parts

### DIFF
--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -330,12 +330,13 @@ pub struct UploadedPart {
 
 impl UploadedPart {
     pub fn new(part_number: u16, etag: String) -> Self {
-        let obj: JsValue = js_sys::Object::new().into();
+        let obj = js_sys::Object::new();
         Reflect::set(&obj, &JsValue::from_str("partNumber"), &JsValue::from_f64(part_number as f64)).unwrap();
         Reflect::set(&obj, &JsValue::from_str("etag"), &JsValue::from_str(&etag)).unwrap();
 
+        let val: JsValue = obj.into();
         Self {
-            inner: obj.into()
+            inner: val.into()
         }
     }
 

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, convert::TryInto};
 
 pub use builder::*;
 
-use js_sys::{JsString, Promise, Reflect, Uint8Array};
+use js_sys::{JsString, Reflect, Uint8Array};
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use worker_sys::{
@@ -331,8 +331,8 @@ pub struct UploadedPart {
 impl UploadedPart {
     pub fn new(part_number: u16, etag: String) -> Self {
         let obj: JsValue = js_sys::Object::new().into();
-        Reflect::set(&obj, &JsValue::from_str("partNumber"), &JsValue::from_f64(part_number as f64).dyn_into::<Promise>().unwrap()).unwrap();
-        Reflect::set(&obj, &JsValue::from_str("etag"), &JsValue::from_str(&etag).dyn_into::<Promise>().unwrap()).unwrap();
+        Reflect::set(&obj, &JsValue::from_str("partNumber"), &JsValue::from_f64(part_number as f64)).unwrap();
+        Reflect::set(&obj, &JsValue::from_str("etag"), &JsValue::from_str(&etag)).unwrap();
 
         Self {
             inner: obj.into()

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, convert::TryInto};
 
 pub use builder::*;
 
-use js_sys::{JsString, Reflect, Uint8Array};
+use js_sys::{JsString, Promise, Reflect, Uint8Array};
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use worker_sys::{
@@ -329,6 +329,16 @@ pub struct UploadedPart {
 }
 
 impl UploadedPart {
+    pub fn new(part_number: u16, etag: String) -> Self {
+        let obj: JsValue = js_sys::Object::new().into();
+        Reflect::set(&obj, &JsValue::from_str("partNumber"), &JsValue::from_f64(part_number as f64).dyn_into::<Promise>().unwrap()).unwrap();
+        Reflect::set(&obj, &JsValue::from_str("etag"), &JsValue::from_str(&etag).dyn_into::<Promise>().unwrap()).unwrap();
+
+        Self {
+            inner: obj.into()
+        }
+    }
+
     pub fn part_number(&self) -> u16 {
         self.inner.part_number().unwrap()
     }

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -331,13 +331,16 @@ pub struct UploadedPart {
 impl UploadedPart {
     pub fn new(part_number: u16, etag: String) -> Self {
         let obj = js_sys::Object::new();
-        Reflect::set(&obj, &JsValue::from_str("partNumber"), &JsValue::from_f64(part_number as f64)).unwrap();
+        Reflect::set(
+            &obj,
+            &JsValue::from_str("partNumber"),
+            &JsValue::from_f64(part_number as f64),
+        )
+        .unwrap();
         Reflect::set(&obj, &JsValue::from_str("etag"), &JsValue::from_str(&etag)).unwrap();
 
         let val: JsValue = obj.into();
-        Self {
-            inner: val.into()
-        }
+        Self { inner: val.into() }
     }
 
     pub fn part_number(&self) -> u16 {


### PR DESCRIPTION
Fixes #316

Objective here was to provide an easy way to create an `UploadedPart` -- currently in my worker code I'm deserializing a custom object into a `part_number` and an `etag`, which I then use to construct the `UploadedPart` to be passed to `MultipartUpload::complete`