### PR TITLE
Use u64 for R2 range requests

### DIFF
--- a/worker-sys/src/types/r2/range.rs
+++ b/worker-sys/src/types/r2/range.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
 pub struct R2Range {
-    pub offset: Option<u32>,
-    pub length: Option<u32>,
-    pub suffix: Option<u32>,
+    pub offset: Option<f64>,
+    pub length: Option<f64>,
+    pub suffix: Option<f64>,
 }

--- a/worker/src/r2/builder.rs
+++ b/worker/src/r2/builder.rs
@@ -99,11 +99,11 @@ pub enum Range {
     Suffix { suffix: u64 },
 }
 
-const MAX_INT: u64 = (2 ^ 53) - 1;
+const MAX_SAFE_INTEGER: u64 = js_sys::Number::MAX_SAFE_INTEGER as u64;
 
 fn check_range_precision(value: u64) -> f64 {
     assert!(
-        value <= MAX_INT,
+        value <= MAX_SAFE_INTEGER,
         "Integer precision loss when converting to JavaScript number"
     );
     value as f64


### PR DESCRIPTION
Closes #560

Waiting for guidance on the behavior of `limit` without `offset`. For now I'd like to continue to match the JavaScript behavior. 