### PR TITLE
Add `encodeBody` and `cf` to ResponseInit. Adopt builder pattern.

### DIFF
--- a/worker-sandbox/src/counter.rs
+++ b/worker-sandbox/src/counter.rs
@@ -34,10 +34,10 @@ impl DurableObject for Counter {
                 .serialize_attachment("hello")
                 .expect("failed to serialize attachment");
 
-            return Ok(Response::empty()
-                .unwrap()
+            return Ok(ResponseBuilder::new()
                 .with_status(101)
-                .with_websocket(Some(pair.client)));
+                .with_websocket(pair.client)
+                .empty());
         }
 
         self.count += 10;

--- a/worker-sandbox/src/router.rs
+++ b/worker-sandbox/src/router.rs
@@ -152,6 +152,10 @@ pub fn make_router(data: SomeSharedData, env: Env) -> axum::Router {
             get(handler!(request::handle_cloned_stream)),
         )
         .route("/cloned-fetch", get(handler!(fetch::handle_cloned_fetch)))
+        .route(
+            "/cloned-response",
+            get(handler!(fetch::handle_cloned_response_attributes)),
+        )
         .route("/wait/:delay", get(handler!(request::handle_wait_delay)))
         .route(
             "/custom-response-body",
@@ -300,6 +304,10 @@ pub fn make_router<'a>(data: SomeSharedData) -> Router<'a, SomeSharedData> {
         .get_async("/cloned", handler!(request::handle_cloned))
         .get_async("/cloned-stream", handler!(request::handle_cloned_stream))
         .get_async("/cloned-fetch", handler!(fetch::handle_cloned_fetch))
+        .get_async(
+            "/cloned-response",
+            handler!(fetch::handle_cloned_response_attributes),
+        )
         .get_async("/wait/:delay", handler!(request::handle_wait_delay))
         .get_async(
             "/custom-response-body",

--- a/worker-sandbox/tests/clone.spec.ts
+++ b/worker-sandbox/tests/clone.spec.ts
@@ -16,4 +16,9 @@ describe("cache", () => {
     const resp = await mf.dispatchFetch("https://fake.host/cloned-fetch");
     expect(await resp.text()).toBe("true");
   });
+
+  test("cloned response", async () => {
+    const resp = await mf.dispatchFetch("https://fake.host/cloned-response");
+    expect(await resp.text()).toBe("true");
+  });
 });

--- a/worker-sys/src/ext/response.rs
+++ b/worker-sys/src/ext/response.rs
@@ -1,6 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 mod glue {
+
     use super::*;
 
     #[wasm_bindgen]
@@ -10,16 +11,30 @@ mod glue {
 
         #[wasm_bindgen(method, catch, getter)]
         pub fn webSocket(this: &Response) -> Result<Option<web_sys::WebSocket>, JsValue>;
+
+        #[wasm_bindgen(method, catch, getter)]
+        pub fn cf(this: &Response) -> Result<Option<js_sys::Object>, JsValue>;
     }
 }
 
 pub trait ResponseExt {
     /// Getter for the `webSocket` field of this object.
     fn websocket(&self) -> Option<web_sys::WebSocket>;
+
+    /// Getter for the `cf` field of this object.
+    fn cf(&self) -> Option<js_sys::Object>;
 }
 
 impl ResponseExt for web_sys::Response {
     fn websocket(&self) -> Option<web_sys::WebSocket> {
-        self.unchecked_ref::<glue::Response>().webSocket().unwrap()
+        self.unchecked_ref::<glue::Response>()
+            .webSocket()
+            .expect("read response.webSocket")
+    }
+
+    fn cf(&self) -> Option<js_sys::Object> {
+        self.unchecked_ref::<glue::Response>()
+            .cf()
+            .expect("read response.cf")
     }
 }

--- a/worker-sys/src/ext/response_init.rs
+++ b/worker-sys/src/ext/response_init.rs
@@ -5,7 +5,7 @@ pub trait ResponseInitExt {
     fn websocket(&mut self, val: &web_sys::WebSocket) -> Result<&mut Self, JsValue>;
 
     /// Change the `encodeBody` field of this object.
-    fn encode_body(&mut self, val: String) -> Result<&mut Self, JsValue>;
+    fn encode_body(&mut self, val: &str) -> Result<&mut Self, JsValue>;
 
     /// Change the `cf` field of this object.
     fn cf(&mut self, val: &JsValue) -> Result<&mut Self, JsValue>;
@@ -17,7 +17,7 @@ impl ResponseInitExt for web_sys::ResponseInit {
         Ok(self)
     }
 
-    fn encode_body(&mut self, val: String) -> Result<&mut Self, JsValue> {
+    fn encode_body(&mut self, val: &str) -> Result<&mut Self, JsValue> {
         js_sys::Reflect::set(
             self.as_ref(),
             &JsValue::from("encodeBody"),

--- a/worker-sys/src/ext/response_init.rs
+++ b/worker-sys/src/ext/response_init.rs
@@ -2,17 +2,32 @@ use wasm_bindgen::prelude::*;
 
 pub trait ResponseInitExt {
     /// Change the `webSocket` field of this object.
-    fn websocket(&mut self, val: &web_sys::WebSocket) -> &mut Self;
+    fn websocket(&mut self, val: &web_sys::WebSocket) -> Result<&mut Self, JsValue>;
+
+    /// Change the `encodeBody` field of this object.
+    fn encode_body(&mut self, val: String) -> Result<&mut Self, JsValue>;
+
+    /// Change the `cf` field of this object.
+    fn cf(&mut self, val: &JsValue) -> Result<&mut Self, JsValue>;
 }
 
 impl ResponseInitExt for web_sys::ResponseInit {
-    fn websocket(&mut self, val: &web_sys::WebSocket) -> &mut Self {
-        let r = js_sys::Reflect::set(self.as_ref(), &JsValue::from("webSocket"), val.as_ref());
-        debug_assert!(
-            r.is_ok(),
-            "setting properties should never fail on our dictionary objects"
-        );
-        let _ = r;
-        self
+    fn websocket(&mut self, val: &web_sys::WebSocket) -> Result<&mut Self, JsValue> {
+        js_sys::Reflect::set(self.as_ref(), &JsValue::from("webSocket"), val.as_ref())?;
+        Ok(self)
+    }
+
+    fn encode_body(&mut self, val: String) -> Result<&mut Self, JsValue> {
+        js_sys::Reflect::set(
+            self.as_ref(),
+            &JsValue::from("encodeBody"),
+            &JsValue::from(val),
+        )?;
+        Ok(self)
+    }
+
+    fn cf(&mut self, val: &JsValue) -> Result<&mut Self, JsValue> {
+        js_sys::Reflect::set(self.as_ref(), &JsValue::from("cf"), val)?;
+        Ok(self)
     }
 }

--- a/worker/src/cf.rs
+++ b/worker/src/cf.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "timezone")]
 use crate::Result;
 
+use serde::de::DeserializeOwned;
+use wasm_bindgen::JsCast;
+
 /// In addition to the methods on the `Request` struct, the `Cf` struct on an inbound Request contains information about the request provided by Cloudflare’s edge.
 ///
 /// [Details](https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties)
@@ -254,3 +257,19 @@ impl From<worker_sys::TlsClientAuth> for TlsClientAuth {
         Self { inner }
     }
 }
+
+#[derive(Clone)]
+pub struct CfResponseProperties(pub(crate) js_sys::Object);
+
+impl CfResponseProperties {
+    pub fn into_raw(self) -> js_sys::Object {
+        self.0
+    }
+
+    pub fn try_into<T: DeserializeOwned>(self) -> crate::Result<T> {
+        Ok(serde_wasm_bindgen::from_value(self.0.unchecked_into())?)
+    }
+}
+
+unsafe impl Send for CfResponseProperties {}
+unsafe impl Sync for CfResponseProperties {}

--- a/worker/src/http/response.rs
+++ b/worker/src/http/response.rs
@@ -6,8 +6,11 @@ use crate::WebSocket;
 use bytes::Bytes;
 
 use crate::http::body::BodyStream;
+use crate::response::EncodeBody;
+use crate::CfResponseProperties;
+use crate::Headers;
+use crate::ResponseBuilder;
 use worker_sys::ext::ResponseExt;
-use worker_sys::ext::ResponseInitExt;
 
 /// **Requires** `http` feature. Convert generic [`http::Response<B>`](crate::HttpResponse)
 /// to [`web_sys::Resopnse`](web_sys::Response) where `B` can be any [`http_body::Body`](http_body::Body)
@@ -15,12 +18,19 @@ pub fn to_wasm<B>(mut res: http::Response<B>) -> Result<web_sys::Response>
 where
     B: http_body::Body<Data = Bytes> + 'static,
 {
-    let mut init = web_sys::ResponseInit::new();
-    init.status(res.status().as_u16());
     let headers = web_sys_headers_from_header_map(res.headers())?;
-    init.headers(headers.as_ref());
+    let mut init = ResponseBuilder::new()
+        .with_status(res.status().as_u16())
+        .with_headers(Headers(headers));
+
     if let Some(ws) = res.extensions_mut().remove::<WebSocket>() {
-        init.websocket(ws.as_ref())?;
+        init = init.with_websocket(ws);
+    }
+    if let Some(encode_body) = res.extensions_mut().remove::<EncodeBody>() {
+        init = init.with_encode_body(encode_body);
+    }
+    if let Some(CfResponseProperties(obj)) = res.extensions_mut().remove::<CfResponseProperties>() {
+        init = init.with_cf_raw(obj);
     }
 
     let body = res.into_body();
@@ -37,7 +47,7 @@ where
 
     Ok(web_sys::Response::new_with_opt_readable_stream_and_init(
         readable_stream.as_ref(),
-        &init,
+        &init.into(),
     )?)
 }
 
@@ -51,6 +61,9 @@ pub fn from_wasm(res: web_sys::Response) -> Result<HttpResponse> {
     }
     if let Some(ws) = res.websocket() {
         builder = builder.extension(WebSocket::from(ws));
+    }
+    if let Some(cf) = res.cf() {
+        builder = builder.extension(CfResponseProperties(cf));
     }
     Ok(if let Some(body) = res.body() {
         builder.body(Body::new(body))?
@@ -70,6 +83,9 @@ impl From<crate::Response> for http::Response<axum::body::Body> {
         }
         if let Some(ws) = res.websocket() {
             builder = builder.extension(WebSocket::from(ws));
+        }
+        if let Some(cf) = res.cf() {
+            builder = builder.extension(CfResponseProperties(cf));
         }
         if let Some(body) = res.body() {
             builder

--- a/worker/src/http/response.rs
+++ b/worker/src/http/response.rs
@@ -20,7 +20,7 @@ where
     let headers = web_sys_headers_from_header_map(res.headers())?;
     init.headers(headers.as_ref());
     if let Some(ws) = res.extensions_mut().remove::<WebSocket>() {
-        init.websocket(ws.as_ref());
+        init.websocket(ws.as_ref())?;
     }
 
     let body = res.into_body();

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -156,7 +156,7 @@ pub use wasm_bindgen;
 pub use wasm_bindgen_futures;
 pub use worker_kv as kv;
 
-pub use cf::{Cf, TlsClientAuth};
+pub use cf::{Cf, CfResponseProperties, TlsClientAuth};
 pub use worker_macros::{durable_object, event, send};
 #[doc(hidden)]
 pub use worker_sys;
@@ -184,7 +184,7 @@ pub use crate::queue::*;
 pub use crate::r2::*;
 pub use crate::request::{FromRequest, Request};
 pub use crate::request_init::*;
-pub use crate::response::{IntoResponse, Response, ResponseBody, ResponseBuilder};
+pub use crate::response::{EncodeBody, IntoResponse, Response, ResponseBody, ResponseBuilder};
 pub use crate::router::{RouteContext, RouteParams, Router};
 pub use crate::schedule::*;
 pub use crate::socket::*;

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -184,7 +184,7 @@ pub use crate::queue::*;
 pub use crate::r2::*;
 pub use crate::request::{FromRequest, Request};
 pub use crate::request_init::*;
-pub use crate::response::{IntoResponse, Response, ResponseBody};
+pub use crate::response::{IntoResponse, Response, ResponseBody, ResponseBuilder};
 pub use crate::router::{RouteContext, RouteParams, Router};
 pub use crate::schedule::*;
 pub use crate::socket::*;

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -175,10 +175,6 @@ impl Response {
 
     /// Access this response's body encoded as JSON.
     pub async fn json<B: DeserializeOwned>(&mut self) -> Result<B> {
-        let content_type = self.headers().get(CONTENT_TYPE)?.unwrap_or_default();
-        if !content_type.contains("application/json") {
-            return Err(Error::BadEncoding);
-        }
         serde_json::from_str(&self.text().await?).map_err(Error::from)
     }
 


### PR DESCRIPTION
This expands `ResponseInit` to support all of the options available in JavaScript. Additionally, the builder pattern is adopted so that users do not have to specify all of these new fields as we add them (breaking change). There are a few questions I want to answer before merging this. 

Closes #567