### PR TITLE
Add MSRV to `worker` crate

### DIFF
--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["serverless", "ffi", "workers", "wasm", "cloudflare"]
 license = "Apache-2.0"
 description = "A Rust SDK for writing Cloudflare Workers."
 readme = "../README.md"
+rust-version = "1.75"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The `worker` crate makes use of `impl Trait` in trait method return types now, but the error that old Rust versions output can be a little confusing.

```rs
error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
   --> worker\src\request.rs:312:36
    |
312 |     ) -> std::result::Result<Self, impl Into<Box<dyn std::error::Error>>>;
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
```

[`rust-version`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) will instead output this:

``error: package `worker v0.2.0 (path)` cannot be built because it requires rustc 1.75 or newer, while the currently active rustc version is 1.74.0``