### PR TITLE
Expose `Hyperdrive` from the worker crate

### DIFF
--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -179,6 +179,7 @@ pub use crate::formdata::*;
 pub use crate::global::Fetch;
 pub use crate::headers::Headers;
 pub use crate::http::Method;
+pub use crate::hyperdrive::*;
 #[cfg(feature = "queue")]
 pub use crate::queue::*;
 pub use crate::r2::*;


### PR DESCRIPTION
This allows users to pass around the instance of `Hyperdrive`.