### PR TITLE
Install version ^0.12 of wasm-pack

### DIFF
--- a/worker-build/src/install.rs
+++ b/worker-build/src/install.rs
@@ -35,7 +35,7 @@ pub fn ensure_wasm_pack() -> Result<()> {
     if is_installed("wasm-pack")?.is_none() {
         println!("Installing wasm-pack...");
         let exit_status = Command::new("cargo")
-            .args(["install", "wasm-pack"])
+            .args(["install", "wasm-pack", "--version", "^0.12"])
             .spawn()?
             .wait()?;
 


### PR DESCRIPTION
Version 0.13 introduces a breaking change by adding a dependency on cmake. We'll automatically install that version when running this and wasm-pack isn't yet installed in the environment.

Closes #589