### PR TITLE
Add a binding to meta object for `D1Result`.

### DIFF
--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -387,10 +387,10 @@ impl D1Result {
 
     /// Return the meta data in this result.
     ///
-    /// Returns `None` if it's not exists.
+    /// Returns `None` if `meta` field is not populated.
     pub fn meta(&self) -> Result<Option<D1ResultMeta>> {
         if let Ok(meta) = self.0.meta() {
-            let meta: D1ResultMeta = serde_wasm_bindgen::from_value(meta.into()).unwrap();
+            let meta: D1ResultMeta = serde_wasm_bindgen::from_value(meta.into())?;
             Ok(Some(meta))
         } else {
             Ok(None)

--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -343,6 +343,18 @@ impl From<D1PreparedStatementSys> for D1PreparedStatement {
 // The result of a D1 query execution.
 pub struct D1Result(D1ResultSys);
 
+// The meta object of D1 result.
+#[derive(Debug, Clone, Deserialize)]
+pub struct D1ResultMeta {
+    pub changed_db: Option<bool>,
+    pub changes: Option<usize>,
+    pub duration: Option<f64>,
+    pub last_row_id: Option<i64>,
+    pub rows_read: Option<usize>,
+    pub rows_written: Option<usize>,
+    pub size_after: Option<usize>,
+}
+
 impl D1Result {
     /// Returns `true` if the result indicates a success, otherwise `false`.
     pub fn success(&self) -> bool {
@@ -370,6 +382,18 @@ impl D1Result {
             Ok(vec)
         } else {
             Ok(Vec::new())
+        }
+    }
+
+    /// Return the meta data in this result.
+    ///
+    /// Returns `None` if it's not exists.
+    pub fn meta(&self) -> Result<Option<D1ResultMeta>> {
+        if let Ok(meta) = self.0.meta() {
+            let meta: D1ResultMeta = serde_wasm_bindgen::from_value(meta.into()).unwrap();
+            Ok(Some(meta))
+        } else {
+            Ok(None)
         }
     }
 }


### PR DESCRIPTION
Thanks to the official staff for reviewing. This PR is based on #337 .

When I tried to use `sea-orm` proxy connection, I found that the `D1Result` object could not obtain other information except data, so I traced the source code.

In fact, `worker-sys` has already declared the `meta` function, but `D1Result` under `worker` did not further extract and serialize this part of data. I made some simple work that `D1Result` can obtain this part of the content.

[Demo is here](https://github.com/langyo/cloudflare_worker_rust_demo).