### PR TITLE
Add support for Version Metadata Binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
 
 ## Durable Object, KV, Secret, & Variable Bindings
 
-All "bindings" to your script (Durable Object & KV Namespaces, Secrets, and Variables) are
+All "bindings" to your script (Durable Object & KV Namespaces, Secrets, Variables and Version) are
 accessible from the `env` parameter provided to both the entrypoint (`main` in this example), and to
 the route handler callback (in the `ctx` argument), if you use the `Router` from the `worker` crate.
 
@@ -214,6 +214,7 @@ For more information about how to configure these bindings, see:
 
 - https://developers.cloudflare.com/workers/cli-wrangler/configuration#keys
 - https://developers.cloudflare.com/workers/learning/using-durable-objects#configuring-durable-object-bindings
+- https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata/
 
 ## Durable Objects
 

--- a/worker-sys/src/types.rs
+++ b/worker-sys/src/types.rs
@@ -14,6 +14,7 @@ mod r2;
 mod schedule;
 mod socket;
 mod tls_client_auth;
+mod version;
 mod websocket_pair;
 
 pub use context::*;
@@ -32,4 +33,5 @@ pub use r2::*;
 pub use schedule::*;
 pub use socket::*;
 pub use tls_client_auth::*;
+pub use version::*;
 pub use websocket_pair::*;

--- a/worker-sys/src/types/version.rs
+++ b/worker-sys/src/types/version.rs
@@ -12,4 +12,7 @@ extern "C" {
 
     #[wasm_bindgen(method, getter, js_name=tag)]
     pub fn tag(this: &CfVersionMetadata) -> String;
+
+    #[wasm_bindgen(method, getter, js_name=timestamp)]
+    pub fn timestamp(this: &CfVersionMetadata) -> String;
 }

--- a/worker-sys/src/types/version.rs
+++ b/worker-sys/src/types/version.rs
@@ -1,0 +1,15 @@
+use wasm_bindgen::prelude::*;
+
+/// This type was created to support https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata/
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends=js_sys::Object)]
+    #[derive(Clone, PartialEq, Eq)]
+    pub type CfVersionMetadata;
+
+    #[wasm_bindgen(method, getter, js_name=id)]
+    pub fn id(this: &CfVersionMetadata) -> String;
+
+    #[wasm_bindgen(method, getter, js_name=tag)]
+    pub fn tag(this: &CfVersionMetadata) -> String;
+}

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -225,6 +225,7 @@ mod schedule;
 pub mod send;
 mod socket;
 mod streams;
+mod version;
 mod websocket;
 
 pub type Result<T> = StdResult<T, error::Error>;

--- a/worker/src/version.rs
+++ b/worker/src/version.rs
@@ -1,0 +1,48 @@
+use crate::EnvBinding;
+use wasm_bindgen::{JsCast, JsValue};
+use worker_sys::types::CfVersionMetadata;
+
+pub struct WorkerVersionMetadata(CfVersionMetadata);
+
+unsafe impl Send for WorkerVersionMetadata {}
+unsafe impl Sync for WorkerVersionMetadata {}
+
+impl EnvBinding for WorkerVersionMetadata {
+    const TYPE_NAME: &'static str = "Object";
+}
+
+impl WorkerVersionMetadata {
+    pub fn id(&self) -> String {
+        self.0.id()
+    }
+
+    pub fn tag(&self) -> String {
+        self.0.tag()
+    }
+}
+
+impl JsCast for WorkerVersionMetadata {
+    fn instanceof(val: &JsValue) -> bool {
+        val.is_instance_of::<CfVersionMetadata>()
+    }
+
+    fn unchecked_from_js(val: JsValue) -> Self {
+        Self(val.into())
+    }
+
+    fn unchecked_from_js_ref(val: &JsValue) -> &Self {
+        unsafe { &*(val as *const JsValue as *const Self) }
+    }
+}
+
+impl From<WorkerVersionMetadata> for JsValue {
+    fn from(cf_version: WorkerVersionMetadata) -> Self {
+        JsValue::from(cf_version.0)
+    }
+}
+
+impl AsRef<JsValue> for WorkerVersionMetadata {
+    fn as_ref(&self) -> &JsValue {
+        &self.0
+    }
+}

--- a/worker/src/version.rs
+++ b/worker/src/version.rs
@@ -19,6 +19,10 @@ impl WorkerVersionMetadata {
     pub fn tag(&self) -> String {
         self.0.tag()
     }
+
+    pub fn timestamp(&self) -> String {
+        self.0.timestamp()
+    }
 }
 
 impl JsCast for WorkerVersionMetadata {


### PR DESCRIPTION
Allows users to fetch the version metadata fron the worker environment. This is useful when using Gradual Deployments.