### PR TITLE
Support sha256 cert fingerprints in TlsClientAuth

### DIFF
--- a/worker-sys/src/types/tls_client_auth.rs
+++ b/worker-sys/src/types/tls_client_auth.rs
@@ -29,6 +29,9 @@ extern "C" {
     #[wasm_bindgen(method, catch, getter, js_name=certFingerprintSHA1)]
     pub fn cert_fingerprint_sha1(this: &TlsClientAuth) -> Result<String, JsValue>;
 
+    #[wasm_bindgen(method, catch, getter, js_name=certFingerprintSHA256)]
+    pub fn cert_fingerprint_sha256(this: &TlsClientAuth) -> Result<String, JsValue>;
+
     #[wasm_bindgen(method, catch, getter, js_name=certNotBefore)]
     pub fn cert_not_before(this: &TlsClientAuth) -> Result<String, JsValue>;
 

--- a/worker/src/cf.rs
+++ b/worker/src/cf.rs
@@ -235,6 +235,10 @@ impl TlsClientAuth {
         self.inner.cert_fingerprint_sha1().unwrap()
     }
 
+    pub fn cert_fingerprint_sha256(&self) -> String {
+        self.inner.cert_fingerprint_sha256().unwrap()
+    }
+
     pub fn cert_not_before(&self) -> String {
         self.inner.cert_not_before().unwrap()
     }


### PR DESCRIPTION
This adds support for getting a client's sha256 fingerprint.