### PR TITLE
Relax type of callback arguments to Router methods

### DIFF
--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -190,7 +190,11 @@ impl<'a, D: 'a> Router<'a, D> {
 
     /// Register an HTTP handler that will exclusively respond to HEAD requests. Enables the use of
     /// `async/await` syntax in the callback.
-    pub fn head_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    pub fn head_async<T>(
+        mut self,
+        pattern: &str,
+        func: impl Fn(Request, RouteContext<D>) -> T + 'a,
+    ) -> Self
     where
         T: Future<Output = Result<Response>> + 'a,
     {
@@ -204,7 +208,11 @@ impl<'a, D: 'a> Router<'a, D> {
 
     /// Register an HTTP handler that will exclusively respond to GET requests. Enables the use of
     /// `async/await` syntax in the callback.
-    pub fn get_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    pub fn get_async<T>(
+        mut self,
+        pattern: &str,
+        func: impl Fn(Request, RouteContext<D>) -> T + 'a,
+    ) -> Self
     where
         T: Future<Output = Result<Response>> + 'a,
     {
@@ -218,7 +226,11 @@ impl<'a, D: 'a> Router<'a, D> {
 
     /// Register an HTTP handler that will exclusively respond to POST requests. Enables the use of
     /// `async/await` syntax in the callback.
-    pub fn post_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    pub fn post_async<T>(
+        mut self,
+        pattern: &str,
+        func: impl Fn(Request, RouteContext<D>) -> T + 'a,
+    ) -> Self
     where
         T: Future<Output = Result<Response>> + 'a,
     {
@@ -232,7 +244,11 @@ impl<'a, D: 'a> Router<'a, D> {
 
     /// Register an HTTP handler that will exclusively respond to PUT requests. Enables the use of
     /// `async/await` syntax in the callback.
-    pub fn put_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    pub fn put_async<T>(
+        mut self,
+        pattern: &str,
+        func: impl Fn(Request, RouteContext<D>) -> T + 'a,
+    ) -> Self
     where
         T: Future<Output = Result<Response>> + 'a,
     {
@@ -246,7 +262,11 @@ impl<'a, D: 'a> Router<'a, D> {
 
     /// Register an HTTP handler that will exclusively respond to PATCH requests. Enables the use of
     /// `async/await` syntax in the callback.
-    pub fn patch_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    pub fn patch_async<T>(
+        mut self,
+        pattern: &str,
+        func: impl Fn(Request, RouteContext<D>) -> T + 'a,
+    ) -> Self
     where
         T: Future<Output = Result<Response>> + 'a,
     {
@@ -260,7 +280,11 @@ impl<'a, D: 'a> Router<'a, D> {
 
     /// Register an HTTP handler that will exclusively respond to DELETE requests. Enables the use
     /// of `async/await` syntax in the callback.
-    pub fn delete_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    pub fn delete_async<T>(
+        mut self,
+        pattern: &str,
+        func: impl Fn(Request, RouteContext<D>) -> T + 'a,
+    ) -> Self
     where
         T: Future<Output = Result<Response>> + 'a,
     {
@@ -277,7 +301,7 @@ impl<'a, D: 'a> Router<'a, D> {
     pub fn options_async<T>(
         mut self,
         pattern: &str,
-        func: fn(Request, RouteContext<D>) -> T,
+        func: impl Fn(Request, RouteContext<D>) -> T + 'a,
     ) -> Self
     where
         T: Future<Output = Result<Response>> + 'a,
@@ -292,7 +316,11 @@ impl<'a, D: 'a> Router<'a, D> {
 
     /// Register an HTTP handler that will respond to any requests. Enables the use of `async/await`
     /// syntax in the callback.
-    pub fn on_async<T>(mut self, pattern: &str, func: fn(Request, RouteContext<D>) -> T) -> Self
+    pub fn on_async<T>(
+        mut self,
+        pattern: &str,
+        func: impl Fn(Request, RouteContext<D>) -> T + 'a,
+    ) -> Self
     where
         T: Future<Output = Result<Response>> + 'a,
     {
@@ -309,7 +337,7 @@ impl<'a, D: 'a> Router<'a, D> {
     pub fn or_else_any_method_async<T>(
         mut self,
         pattern: &str,
-        func: fn(Request, RouteContext<D>) -> T,
+        func: impl Fn(Request, RouteContext<D>) -> T + 'a,
     ) -> Self
     where
         T: Future<Output = Result<Response>> + 'a,


### PR DESCRIPTION
This PR relaxes the type of the callback

> `func: fn(Request, RouteContext<D>) -> T`

into

> `func: impl Fn(Request, RouteContext<D>) -> T + 'static`

which is an argument-position impl trait type (APIT), since I don't see any reason for requiring the passed-in callback is a function pointer, since we're immediately boxing it up and erasing the type.

Specifically, this ensures that you can pass a (currently nightly-only) async closure (`async ||`), which currently does *not* support being coerced to a fn ptr type. I'd like to avoid needing to implement that functionality that if possible.
