### PR TITLE
[draft] http: remove use of unwrap for iterators

### DIFF
--- a/worker/src/headers.rs
+++ b/worker/src/headers.rs
@@ -65,8 +65,6 @@ impl Headers {
     pub fn entries(&self) -> HeaderIterator {
         self.0
             .entries()
-            // Header.entries() doesn't error: https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries
-            .unwrap()
             .into_iter()
             // The entries iterator.next() will always return a proper value: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
             .map((|a| a.unwrap().into()) as F1)
@@ -79,8 +77,6 @@ impl Headers {
     pub fn keys(&self) -> impl Iterator<Item = String> {
         self.0
             .keys()
-            // Header.keys() doesn't error: https://developer.mozilla.org/en-US/docs/Web/API/Headers/keys
-            .unwrap()
             .into_iter()
             // The keys iterator.next() will always return a proper value containing a string
             .map(|a| a.unwrap().as_string().unwrap())
@@ -91,8 +87,6 @@ impl Headers {
     pub fn values(&self) -> impl Iterator<Item = String> {
         self.0
             .values()
-            // Header.values() doesn't error: https://developer.mozilla.org/en-US/docs/Web/API/Headers/values
-            .unwrap()
             .into_iter()
             // The values iterator.next() will always return a proper value containing a string
             .map(|a| a.unwrap().as_string().unwrap())

--- a/worker/src/http/header.rs
+++ b/worker/src/http/header.rs
@@ -8,7 +8,7 @@ pub(crate) fn header_map_from_web_sys_headers(
     to_headers: &mut HeaderMap,
 ) -> Result<()> {
     // Header.entries() doesn't error: https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries
-    for res in from_headers.entries()?.into_iter() {
+    for res in from_headers.entries().into_iter() {
         // The entries iterator.next() will always return a proper value: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
         let a: Array = res?.into();
         // The entries iterator always returns an array[2] of strings


### PR DESCRIPTION
The latest release of the js-sys crate removes the need for us to have this.

Fixes #617 