### PR TITLE
Make R2 Object::size return u64

### DIFF
--- a/worker-sys/src/types/r2/object.rs
+++ b/worker-sys/src/types/r2/object.rs
@@ -15,7 +15,7 @@ extern "C" {
     pub fn version(this: &R2Object) -> Result<String, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
-    pub fn size(this: &R2Object) -> Result<u32, JsValue>;
+    pub fn size(this: &R2Object) -> Result<f64, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
     pub fn etag(this: &R2Object) -> Result<String, JsValue>;

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -180,11 +180,12 @@ impl Object {
         }
     }
 
-    pub fn size(&self) -> u32 {
-        match &self.inner {
+    pub fn size(&self) -> u64 {
+        let size = match &self.inner {
             ObjectInner::NoBody(inner) => inner.size().unwrap(),
             ObjectInner::Body(inner) => inner.size().unwrap(),
-        }
+        };
+        size.round() as u64
     }
 
     pub fn etag(&self) -> String {


### PR DESCRIPTION
This makes `Object::size()` return `u64`, in case the R2 object is larger than 2^32 bits.

Tested using an object that was smaller than 2^32 that the type conversion was successful.
