### PR TITLE
BREAKING: Implement more of the R2 API

### DIFF
--- a/worker/src/r2/builder.rs
+++ b/worker/src/r2/builder.rs
@@ -379,6 +379,7 @@ pub struct ListOptionsBuilder<'bucket> {
     pub(crate) edge_bucket: &'bucket EdgeR2Bucket,
     pub(crate) limit: Option<u32>,
     pub(crate) prefix: Option<String>,
+    pub(crate) start_after: Option<String>,
     pub(crate) cursor: Option<String>,
     pub(crate) delimiter: Option<String>,
     pub(crate) include: Option<Vec<Include>>,
@@ -394,6 +395,12 @@ impl ListOptionsBuilder<'_> {
     /// The prefix to match keys against. Keys will only be returned if they start with given prefix.
     pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
         self.prefix = Some(prefix.into());
+        self
+    }
+
+    /// Start listing after this key.
+    pub fn start_after(mut self, start_after: impl Into<String>) -> Self {
+        self.start_after = Some(start_after.into());
         self
     }
 
@@ -437,6 +444,7 @@ impl ListOptionsBuilder<'_> {
             js_object! {
                 "limit" => self.limit,
                 "prefix" => self.prefix,
+                "startAfter" => self.start_after.map(JsValue::from),
                 "cursor" => self.cursor,
                 "delimiter" => self.delimiter,
                 "include" => self

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -104,6 +104,7 @@ impl Bucket {
             edge_bucket: &self.inner,
             limit: None,
             prefix: None,
+            start_after: None,
             cursor: None,
             delimiter: None,
             include: None,

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -65,6 +65,7 @@ impl Bucket {
             custom_metadata: None,
             checksum: None,
             checksum_algorithm: "md5".into(),
+            only_if: None,
         }
     }
 


### PR DESCRIPTION
This PR adds two missing parts of the R2 API:

- An (accidentally) undocmented `startAfter` option in R2's list objects call
- R2 PutObject Conditional Support. 
  - This is a BREAKING change. When a provided conditional to an R2 PutObject fails, the resultant Object could be `null`, or `None` in Rust. The returned object from a PUT is not a `Option<Object>`.

This API is successfully being used to implement a compare-and-swap (CAS) primitive for an internal project. We ended up not needing the list changes, but I thought it'd be useful nonetheless.

Tasks:
- [ ] clean up workers-rs tests