### PR TITLE
Fix typos in CORS argument names

### DIFF
--- a/worker/src/cors.rs
+++ b/worker/src/cors.rs
@@ -61,9 +61,9 @@ impl Cors {
     /// Configures which headers are allowed for cors.
     pub fn with_allowed_headers<S: Into<String>, V: IntoIterator<Item = S>>(
         mut self,
-        origins: V,
+        headers: V,
     ) -> Self {
-        self.allowed_headers = origins
+        self.allowed_headers = headers
             .into_iter()
             .map(|item| item.into())
             .collect::<Vec<String>>();
@@ -73,9 +73,9 @@ impl Cors {
     /// Configures which headers the client is allowed to access.
     pub fn with_exposed_headers<S: Into<String>, V: IntoIterator<Item = S>>(
         mut self,
-        origins: V,
+        headers: V,
     ) -> Self {
-        self.exposed_headers = origins
+        self.exposed_headers = headers
             .into_iter()
             .map(|item| item.into())
             .collect::<Vec<String>>();


### PR DESCRIPTION
Small fix: I just noticed that the parameters should be named `headers` instead of `origins`.