### PR TITLE
[worker] Add FormData conversion into JsValue

### DIFF
--- a/worker/src/formdata.rs
+++ b/worker/src/formdata.rs
@@ -128,6 +128,12 @@ impl From<HashMap<&dyn AsRef<&str>, &dyn AsRef<&str>>> for FormData {
     }
 }
 
+impl From<FormData> for wasm_bindgen::JsValue {
+    fn from(val: FormData) -> Self {
+        val.0.into()
+    }
+}
+
 /// A [File](https://developer.mozilla.org/en-US/docs/Web/API/File) representation used with
 /// `FormData`.
 pub struct File(web_sys::File);


### PR DESCRIPTION
This allows FormData to be constructed and passed as JsValue later on. For instance, `RequestInit::new().with_body(formdata.into())`.
