### PR TITLE
Optionally run Response Promise to completion in waitUntil context

### DIFF
--- a/worker-build/src/js/shim.js
+++ b/worker-build/src/js/shim.js
@@ -10,7 +10,9 @@ export { wasmModule };
 
 class Entrypoint extends WorkerEntrypoint {
     async fetch(request) {
-        return await imports.fetch(request, this.env, this.ctx)
+        let response = imports.fetch(request, this.env, this.ctx);
+        $WAIT_UNTIL_RESPONSE
+        return await response;
     }
 
     async queue(batch) {


### PR DESCRIPTION
When a client disconnects, code is not run to clean up `wasm-bindgen`'s "heap", and thus objects associated with the request leak. `wasm-bindgen` suggests the use of `FinalizationRegistry`, which we do not currently support due to security reasons. 

This change allows user's to specify `RUN_TO_COMPLETION` environment variable when running `worker-build`, which tricks the Workers runtime into executing the Promise that resolves the Response in a `waitUntil` context, even if the client disconnects. This should be used with caution, as your code may have side effects that you would not want to run if the client disconnects. 

Below is a graph of Wasm heap usage over time during a load test, first with existing behavior, and second with `RUN_TO_COMPLETION` enabled. 

![output](https://github.com/user-attachments/assets/d94bd7a0-e7b1-446b-8d46-1d0fc25110c1)
