### PR TITLE
Workers Assets Binding

### DIFF
--- a/worker-sandbox/src/assets.rs
+++ b/worker-sandbox/src/assets.rs
@@ -1,0 +1,17 @@
+#[cfg(not(feature = "http"))]
+pub async fn handle_asset(
+    req: worker::Request,
+    env: worker::Env,
+    _data: crate::SomeSharedData,
+) -> worker::Result<worker::Response> {
+    use worker::Url;
+
+    let url: Url = req.url()?;
+    let name: String = url.path_segments().unwrap().nth(1).unwrap().to_string();
+    let url: String = ["https://dummyurl.com/", &name].concat();
+    Ok(env
+        .assets("ASSETS")
+        .expect("ASSETS BINDING")
+        .fetch(url, None)
+        .await?)
+}

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -6,7 +6,9 @@ use std::sync::{
 #[cfg(feature = "http")]
 use tower_service::Service;
 use worker::*;
+
 mod alarm;
+mod assets;
 mod cache;
 mod counter;
 mod d1;

--- a/worker-sandbox/src/router.rs
+++ b/worker-sandbox/src/router.rs
@@ -1,5 +1,5 @@
 use crate::{
-    alarm, cache, d1, fetch, form, kv, queue, r2, request, service, socket, user, ws,
+    alarm, assets, cache, d1, fetch, form, kv, queue, r2, request, service, socket, user, ws,
     SomeSharedData, GLOBAL_STATE,
 };
 #[cfg(feature = "http")]
@@ -228,6 +228,7 @@ pub fn make_router<'a>(data: SomeSharedData) -> Router<'a, SomeSharedData> {
     Router::with_data(data)
         .get("/request", handler_sync!(request::handle_a_request)) // can pass a fn pointer to keep routes tidy
         .get_async("/async-request", handler!(request::handle_async_request))
+        .get_async("/asset/:name", handler!(assets::handle_asset))
         .get_async("/websocket", handler!(ws::handle_websocket))
         .get_async("/got-close-event", handler!(handle_close_event))
         .get_async("/ws-client", handler!(ws::handle_websocket_client))

--- a/worker-sandbox/wrangler.toml
+++ b/worker-sandbox/wrangler.toml
@@ -11,6 +11,10 @@ kv_namespaces = [
 
 vars = { SOME_VARIABLE = "some value" }
 
+[assets]
+binding = "ASSETS"
+directory = "./public/"
+
 [[services]]
 binding = "remote"
 service = "remote-service"

--- a/worker/src/env.rs
+++ b/worker/src/env.rs
@@ -86,6 +86,11 @@ impl Env {
         self.get_binding(binding)
     }
 
+    /// Access the worker assets by the binding name configured in your wrangler.toml file.
+    pub fn assets(&self, binding: &str) -> Result<Fetcher> {
+        self.get_binding(binding)
+    }
+
     pub fn hyperdrive(&self, binding: &str) -> Result<Hyperdrive> {
         self.get_binding(binding)
     }


### PR DESCRIPTION
closes #644 

I went down a rabbit hole creating an entire new `Assets` env binding just to find out it's a `Fetcher`. In fact, you can use assets without this PR by just calling `env.get_binding::<Fetcher>("ASSETS")`.

Testing:
- Run `npx wrangler dev` in `worker-sandbox`
- Go to `/asset/test.txt`
- See `TEST` in browser
- Go to `/asset/doesnotexist.txt`
- See 404