### PR TITLE
Tower Service Trait implementation

### DIFF
--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -71,7 +71,6 @@ default-features = false
 features = ["util", "buffer"]
 
 [features]
-default = [ "http" ]
 queue = ["worker-macros/queue", "worker-sys/queue"]
 d1 = ["worker-sys/d1"]
 http = ["worker-macros/http", "dep:tower"]

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -64,9 +64,16 @@ version = "0.7"
 optional = true
 default-features = false
 
+[dependencies.tower]
+version = "0.5.1"
+optional = true
+default-features = false
+features = ["util", "buffer"]
+
 [features]
+default = [ "http" ]
 queue = ["worker-macros/queue", "worker-sys/queue"]
 d1 = ["worker-sys/d1"]
-http = ["worker-macros/http"]
+http = ["worker-macros/http", "dep:tower"]
 axum = ["dep:axum"]
 timezone = ["dep:chrono-tz"]

--- a/worker/src/global.rs
+++ b/worker/src/global.rs
@@ -14,18 +14,18 @@ pub enum Fetch {
 
 impl Fetch {
     /// Execute a Fetch call and receive a Response.
-    pub async fn send(&self) -> Result<Response> {
+    pub async fn send(self) -> Result<Response> {
         match self {
             Fetch::Url(url) => fetch_with_str(url.as_ref(), None).await,
-            Fetch::Request(req) => fetch_with_request(req, None).await,
+            Fetch::Request(req) => fetch_with_request(req.to_owned(), None).await,
         }
     }
 
     /// Execute a Fetch call and receive a Response.
-    pub async fn send_with_signal(&self, signal: &AbortSignal) -> Result<Response> {
+    pub async fn send_with_signal(self, signal: &AbortSignal) -> Result<Response> {
         match self {
             Fetch::Url(url) => fetch_with_str(url.as_ref(), Some(signal)).await,
-            Fetch::Request(req) => fetch_with_request(req, Some(signal)).await,
+            Fetch::Request(req) => fetch_with_request(req.to_owned(), Some(signal)).await,
         }
     }
 }
@@ -41,7 +41,7 @@ async fn fetch_with_str(url: &str, signal: Option<&AbortSignal>) -> Result<Respo
     Ok(resp.into())
 }
 
-async fn fetch_with_request(request: &Request, signal: Option<&AbortSignal>) -> Result<Response> {
+async fn fetch_with_request(request: Request, signal: Option<&AbortSignal>) -> Result<Response> {
     let init = web_sys::RequestInit::new();
     init.set_signal(signal.map(|x| x.deref()));
 

--- a/worker/src/http.rs
+++ b/worker/src/http.rs
@@ -10,6 +10,8 @@ mod redirect;
 pub mod request;
 #[cfg(feature = "http")]
 pub mod response;
+#[cfg(feature = "http")]
+pub mod service;
 
 /// A [`Method`](https://developer.mozilla.org/en-US/docs/Web/API/Request/method) representation
 /// used on Request objects.

--- a/worker/src/http/service.rs
+++ b/worker/src/http/service.rs
@@ -1,0 +1,43 @@
+use std::convert::TryInto;
+use std::task::Context;
+use std::{future::Future, pin::Pin, task::Poll};
+
+use crate::send::SendFuture;
+use crate::{Body, Error, Fetch, HttpResponse, Request};
+
+/// A Tower-compatible Service implementation for Cloudflare Workers.
+///
+/// This struct implements the `tower::Service` trait, allowing it to be used
+/// as a service in the Tower middleware ecosystem.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Service;
+
+impl<B: http_body::Body<Data = bytes::Bytes> + Clone + 'static> tower::Service<http::Request<B>>
+    for Service
+{
+    type Response = http::Response<Body>;
+    type Error = Error;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        // Convert a http Request to a worker Request
+        let worker_request: Request = req.try_into().unwrap();
+
+        // Send the request with Fetch and receive a Future
+        let fut = Fetch::Request(worker_request).send();
+
+        // Convert the Future output to a HttpResponse
+        let http_response =
+            async { Ok(TryInto::<HttpResponse>::try_into(fut.await.unwrap()).unwrap()) };
+
+        // Wrap the Future in a SendFuture to make it Send
+        let wrapped = SendFuture::new(http_response);
+
+        Box::pin(wrapped)
+    }
+}

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -248,3 +248,5 @@ pub type HttpRequest = ::http::Request<http::body::Body>;
 #[cfg(feature = "http")]
 /// **Requires** `http` feature. Type alias for `http::Response<worker::Body>`.
 pub type HttpResponse = ::http::Response<http::body::Body>;
+#[cfg(feature = "http")]
+pub use http::service::Service;

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -16,7 +16,7 @@ use worker_sys::ext::RequestExt;
 
 /// A [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) representation for
 /// handling incoming and creating outbound HTTP requests.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Request {
     method: Method,
     path: String,


### PR DESCRIPTION
This PR adds a Service struct that implements Tower Service Trait. This makes it possible to use crates that rely on this standard. The PR was only tested with Octocrab.

There is a minor change, too. `Fetch::Request` uses `&self` which leaves a dangling borrow. The PR changes this so that `Fetch::Request` consumes the original `Fetch` object. This should be harmless since `Fetch` is not returned anyway.

Example usage:

```rust
let service = worker::Service::default();

let octocrabi = octocrab::OctocrabBuilder::new_empty()
                .with_service(service)
                .with_layer(&BaseUriLayer::new(http::Uri::from_static(
                    "https://api.github.com",
                )))
                .with_layer(&ExtraHeadersLayer::new(Arc::new(vec![(
                    USER_AGENT,
                    "octocrab".parse().unwrap(),
                )])))
                .with_layer(&ExtraHeadersLayer::new(Arc::new(vec![(
                    "Authorization".parse().unwrap(),
                    "Bearer xxxxxxxxxxxxxxxxxxxxx"
                        .parse()
                        .unwrap(),
                )])))
                .with_auth(AuthState::None);
```