### PR TITLE
fix: support for externref

### DIFF
--- a/worker-build/src/js/glue.js
+++ b/worker-build/src/js/glue.js
@@ -1,5 +1,0 @@
-import wasmModule from "./index.wasm";
-import * as imports from "./index_bg.js";
-
-const instance = new WebAssembly.Instance(wasmModule, { "./index_bg.js": imports });
-export default instance.exports;

--- a/worker-build/src/js/shim.js
+++ b/worker-build/src/js/shim.js
@@ -10,44 +10,44 @@ const instance = new WebAssembly.Instance(wasmModule, {
 imports.__wbg_set_wasm(instance.exports);
 
 // Run the worker's initialization function.
-imports.start?.();
+instance.exports.__wbindgen_start?.();
 
 export { wasmModule };
 
 class Entrypoint extends WorkerEntrypoint {
-    async fetch(request) {
-        let response = imports.fetch(request, this.env, this.ctx);
-        $WAIT_UNTIL_RESPONSE
-        return await response;
-    }
+	async fetch(request) {
+		let response = imports.fetch(request, this.env, this.ctx);
+		$WAIT_UNTIL_RESPONSE;
+		return await response;
+	}
 
-    async queue(batch) {
-        return await imports.queue(batch, this.env, this.ctx)
-    }
+	async queue(batch) {
+		return await imports.queue(batch, this.env, this.ctx);
+	}
 
-    async scheduled(event) {
-        return await imports.scheduled(event, this.env, this.ctx)
-    }
+	async scheduled(event) {
+		return await imports.scheduled(event, this.env, this.ctx);
+	}
 }
 
 const EXCLUDE_EXPORT = [
-    "IntoUnderlyingByteSource",
-    "IntoUnderlyingSink",
-    "IntoUnderlyingSource",
-    "MinifyConfig",
-    "PolishConfig",
-    "R2Range",
-    "RequestRedirect",
-    "fetch",
-    "queue",
-    "scheduled",
-    "getMemory"
+	"IntoUnderlyingByteSource",
+	"IntoUnderlyingSink",
+	"IntoUnderlyingSource",
+	"MinifyConfig",
+	"PolishConfig",
+	"R2Range",
+	"RequestRedirect",
+	"fetch",
+	"queue",
+	"scheduled",
+	"getMemory",
 ];
 
-Object.keys(imports).map(k => {
-    if (!(EXCLUDE_EXPORT.includes(k) | k.startsWith("__"))) {
-        Entrypoint.prototype[k] = imports[k];
-    }
-})
+Object.keys(imports).map((k) => {
+	if (!(EXCLUDE_EXPORT.includes(k) | k.startsWith("__"))) {
+		Entrypoint.prototype[k] = imports[k];
+	}
+});
 
 export default Entrypoint;

--- a/worker-build/src/js/shim.js
+++ b/worker-build/src/js/shim.js
@@ -3,6 +3,12 @@ export * from "./index_bg.js";
 import wasmModule from "./index.wasm";
 import { WorkerEntrypoint } from "cloudflare:workers";
 
+const instance = new WebAssembly.Instance(wasmModule, {
+	"./index_bg.js": imports,
+});
+
+imports.__wbg_set_wasm(instance.exports);
+
 // Run the worker's initialization function.
 imports.start?.();
 

--- a/worker-build/src/main.rs
+++ b/worker-build/src/main.rs
@@ -1,7 +1,6 @@
 //! Arguments are forwarded directly to wasm-pack
 
 use std::{
-    convert::TryInto,
     env::{self, VarError},
     fs::{self, File},
     io::{Read, Write},
@@ -19,21 +18,6 @@ const OUT_NAME: &str = "index";
 const WORKER_SUBDIR: &str = "worker";
 
 const SHIM_TEMPLATE: &str = include_str!("./js/shim.js");
-
-const WASM_IMPORT: &str = r#"let wasm;
-export function __wbg_set_wasm(val) {
-    wasm = val;
-}
-
-"#;
-
-const WASM_IMPORT_REPLACEMENT: &str = r#"
-import wasm from './glue.js';
-
-export function getMemory() {
-    return wasm.memory;
-}
-"#;
 
 mod install;
 
@@ -53,9 +37,7 @@ pub fn main() -> Result<()> {
 
     create_worker_dir()?;
     copy_generated_code_to_worker_dir()?;
-    use_glue_import()?;
 
-    write_string_to_file(worker_path("glue.js"), include_str!("./js/glue.js"))?;
     let shim = if env::var("RUN_TO_COMPLETION").is_ok() {
         SHIM_TEMPLATE.replace("$WAIT_UNTIL_RESPONSE", "this.ctx.waitUntil(response);")
     } else {
@@ -220,15 +202,6 @@ fn copy_generated_code_to_worker_dir() -> Result<()> {
     Ok(())
 }
 
-// Replaces the wasm import with an import that instantiates the WASM modules itself.
-fn use_glue_import() -> Result<()> {
-    let bindgen_glue_path = worker_path(format!("{OUT_NAME}_bg.js"));
-    let old_bindgen_glue = read_file_to_string(&bindgen_glue_path)?;
-    let fixed_bindgen_glue = old_bindgen_glue.replace(WASM_IMPORT, WASM_IMPORT_REPLACEMENT);
-    write_string_to_file(bindgen_glue_path, fixed_bindgen_glue)?;
-    Ok(())
-}
-
 // Bundles the snippets and worker-related code into a single file.
 fn bundle(esbuild_path: &Path) -> Result<()> {
     let no_minify = !matches!(env::var("NO_MINIFY"), Err(VarError::NotPresent));
@@ -266,23 +239,10 @@ fn remove_unused_js() -> Result<()> {
         std::fs::remove_dir_all(&snippets_dir)?;
     }
 
-    for to_remove in [
-        format!("{OUT_NAME}_bg.js"),
-        "shim.js".into(),
-        "glue.js".into(),
-    ] {
-        std::fs::remove_file(worker_path(to_remove))?;
-    }
+    std::fs::remove_file(worker_path(format!("{OUT_NAME}_bg.js")))?;
+    std::fs::remove_file(worker_path("shim.js"))?;
 
     Ok(())
-}
-
-fn read_file_to_string<P: AsRef<Path>>(path: P) -> Result<String> {
-    let file_size = path.as_ref().metadata()?.len().try_into()?;
-    let mut file = File::open(path)?;
-    let mut buf = Vec::with_capacity(file_size);
-    file.read_to_end(&mut buf)?;
-    String::from_utf8(buf).map_err(anyhow::Error::from)
 }
 
 fn write_string_to_file<P: AsRef<Path>>(path: P, contents: impl AsRef<str>) -> Result<()> {

--- a/worker-sandbox/wrangler.toml
+++ b/worker-sandbox/wrangler.toml
@@ -68,3 +68,6 @@ main = "./shim.mjs"
 [[build.upload.rules]]
 globs = ["**/*.wasm"]
 type = "CompiledWasm"
+
+[package.metadata.wasm-pack.profile.dev.wasm-bindgen]
+dwarf-debug-info = true

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -113,7 +113,7 @@ impl<D> RouteContext<D> {
     }
 }
 
-impl<'a> Router<'a, ()> {
+impl Router<'_, ()> {
     /// Construct a new `Router`. Or, call `Router::with_data(D)` to add arbitrary data that will be
     /// available to your various routes.
     pub fn new() -> Self {

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -300,7 +300,7 @@ pub struct EventStream<'ws> {
     )>,
 }
 
-impl<'ws> Stream for EventStream<'ws> {
+impl Stream for EventStream<'_> {
     type Item = Result<WebsocketEvent>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {


### PR DESCRIPTION
Fixes #668 

1. When reference types are enabled, which is the default in Rust 1.82, `wasm-bindgen` will generate JS where some wasm imports that were previously functions get generated as variables due to the difference in the JS/wasm interop barrier. After we bundled with esbuild we ran into the issue where a wasm import was defined after the instance was initialized, which wasn't a problem for the pre-reference type builds since functions get automatically hoisted in JS.

2. Previously we weren't calling `wasm-bindgen`'s `__wbindgen_start` function but instead called our `start` function for any function with `#[event(start)]`, but when reference types are enabled this function setups the externref table. This was causing us to change the value in the externref table for the `UNDEFINED` constant (index 128) to an http request causing our tests to fail. This was not fun to debug.