### PR TITLE
chore: bump worker-build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "worker-build"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/worker-build/Cargo.toml
+++ b/worker-build/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Cloudflare Workers Team <workers@cloudflare.com>"]
 edition = "2018"
 name = "worker-build"
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0"
 repository = "https://github.com/cloudflare/workers-rs/tree/main/worker-build"
 readme = "README.md"


### PR DESCRIPTION
Bumps `worker-build` for a release since it doesn't seem to be covered by the existing release workflow, which i checked by running `cargo release version patch`.