### PR TITLE
IntoSend Trait

### DIFF
--- a/worker/src/send.rs
+++ b/worker/src/send.rs
@@ -41,6 +41,29 @@ impl<F: Future> Future for SendFuture<F> {
     }
 }
 
+/// Trait for SendFuture. Implemented for any type that implements Future.
+///
+/// ```rust
+/// let fut = JsFuture::from(promise).into_send();
+/// fut.await
+/// ```
+trait IntoSendFuture {
+    type Output;
+    fn into_send(self) -> SendFuture<Self>
+    where
+        Self: Sized;
+}
+
+impl<F, T> IntoSendFuture for F
+where
+    F: Future<Output = T>,
+{
+    type Output = T;
+    fn into_send(self) -> SendFuture<Self> {
+        SendFuture::new(self)
+    }
+}
+
 /// Wrap any type to make it `Send`.
 ///
 /// ```rust

--- a/worker/src/send.rs
+++ b/worker/src/send.rs
@@ -47,7 +47,7 @@ impl<F: Future> Future for SendFuture<F> {
 /// let fut = JsFuture::from(promise).into_send();
 /// fut.await
 /// ```
-trait IntoSendFuture {
+pub trait IntoSendFuture {
     type Output;
     fn into_send(self) -> SendFuture<Self>
     where


### PR DESCRIPTION
This uses SendFuture to create and implement a Trait for any Future, allowing chaining syntax instead of wrapping

```rust
// using the wrapper
let fut = SendFuture::new(JsFuture::from(promise));
fut.await

// using the trait
let fut = jsFuture::from(promise).into_send();
fut.await
```
This is useful is you have lots of futures consuming each other and wrapping gets out of hand.