### PR TITLE
chore: bump worker-build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "worker-build"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/worker-build/Cargo.toml
+++ b/worker-build/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Cloudflare Workers Team <workers@cloudflare.com>"]
 edition = "2018"
 name = "worker-build"
-version = "0.1.1"
+version = "0.1.2"
 license = "Apache-2.0"
 repository = "https://github.com/cloudflare/workers-rs/tree/main/worker-build"
 readme = "README.md"
@@ -17,8 +17,8 @@ dirs-next = "2.0.0"
 flate2 = "1.0.26"
 tar = "0.4.38"
 ureq = { version = "2.6.2", features = ["tls", "gzip"] }
-clap= { version="4.5", features=['derive'] }
-worker-codegen = { path="../worker-codegen", version="0.1.0" }
+clap = { version = "4.5", features = ['derive'] }
+worker-codegen = { path = "../worker-codegen", version = "0.1.0" }
 wasm-pack = "0.13"
 
 [dev-dependencies]
@@ -26,4 +26,4 @@ wasm-bindgen-cli-support.workspace = true
 
 
 [[bin]]
-name="worker-codegen"
+name = "worker-codegen"


### PR DESCRIPTION
Bumps `worker-build` for a release since it doesn't seem to be covered by the existing release workflow, which i checked by running `cargo release version patch`.