### PR TITLE
Update web-sys dependency to not allow v0.4 and above

### DIFF
--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -45,7 +45,7 @@ version = "0.8.4"
 default-features = false
 
 [dependencies.web-sys]
-version = ">=0.3.70"
+version = "0.3.70"
 features = [
     "File",
     "WorkerGlobalScope",


### PR DESCRIPTION
This was added in https://github.com/cloudflare/workers-rs/pull/621#discussion_r1721770799, but I think the author misunderstood what this constraint means.

In Cargo, a version specification like `0.5.1` means `>=0.5.1 <0.6.0` (like `^0.5.1` in NPM, it can also be written that way in Cargo if you want to be more explicit). A version specification like `>=0.5.1` puts no upper bound, so even a breaking-change release like 0.7.x or 0.8.x would get selected.

cc @kflansburg