### PR TITLE
Update Leptos version to 0.7 in the leptos template

### DIFF
--- a/templates/leptos/Cargo.toml
+++ b/templates/leptos/Cargo.toml
@@ -2,7 +2,7 @@
 name = "{{project-name}}"
 version = "0.1.0"
 edition = "2021"
-authors = [ "{{authors}}" ]
+authors = ["{{authors}}"]
 
 [profile.release]
 opt-level = "s"   # optimize for size in release builds
@@ -14,43 +14,35 @@ codegen-units = 1
 crate-type = ["cdylib"]
 
 [dependencies]
-worker = { version="0.5.0", features=['http', 'axum', 'd1'], optional = true }
-axum  = { version = "0.7", default-features = false, optional = true }
+worker = { version = "0.5.0", features = [
+  'http',
+  'axum',
+  'd1',
+], optional = true }
+axum = { version = "0.7", default-features = false, optional = true }
 tower-service = "0.3"
 console_error_panic_hook = { version = "0.1" }
 console_log = { version = "1.0", optional = true }
-gloo-net = { version = "0.6", features = ["http"] }
-gloo-timers = { version = "0.3", features = ["futures"] }
-leptos = "0.6"
-leptos_axum = { version = "0.6", default-features = false, features = [
+leptos = "0.7"
+leptos_axum = { version = "0.7", default-features = false, features = [
   "wasm",
 ], optional = true }
-leptos_meta = "0.6"
-leptos_router = "0.6"
-leptos_dom = "0.6"
+leptos_meta = "0.7"
+leptos_router = "0.7"
+leptos_dom = "0.7"
 log = "0.4"
-once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tower = { version = "0.5", optional = true }
-wasm-bindgen = { version = "0.2.92", optional = true }
 wasm-bindgen-futures = "0.4"
+getrandom = { version = "0.2", features = ["js"] }
 
 [features]
-hydrate = [
-  "dep:console_log",
-  "leptos/hydrate",
-  "leptos_meta/hydrate",
-  "leptos_router/hydrate",
-  "leptos_dom/hydrate",
-  "dep:wasm-bindgen",
-]
+hydrate = ["dep:console_log", "leptos/hydrate"]
 ssr = [
   "dep:axum",
   "leptos/ssr",
   "leptos_meta/ssr",
   "leptos_router/ssr",
-  "leptos_dom/ssr",
   "dep:leptos_axum",
   "dep:worker",
 ]

--- a/templates/leptos/src/api/say_hello.rs
+++ b/templates/leptos/src/api/say_hello.rs
@@ -1,4 +1,4 @@
-use leptos::*;
+use leptos::prelude::*;
 
 #[server(SayHello)]
 pub async fn say_hello(num: i32) -> Result<String, ServerFnError> {

--- a/templates/leptos/src/app.rs
+++ b/templates/leptos/src/app.rs
@@ -1,11 +1,35 @@
-use leptos::*;
-
 use crate::components::show_data_from_api::ShowDataFromApi;
+use leptos::prelude::*;
 
 #[component]
 pub fn App() -> impl IntoView {
     view! {
         <h1>"Hello world!"</h1>
         <ShowDataFromApi />
+    }
+}
+
+// Leptos 0.7
+#[cfg(feature = "ssr")]
+pub fn shell(options: LeptosOptions) -> impl IntoView {
+    use leptos_meta::*;
+
+    view! {
+        <!DOCTYPE html>
+        <html lang="en">
+            <head>
+                <meta charset="utf-8"/>
+                <meta name="viewport" content="width=device-width, initial-scale=1"/>
+
+                <AutoReload options=options.clone() />
+
+                <HydrationScripts options />
+
+                <MetaTags />
+            </head>
+            <body>
+                <App />
+            </body>
+        </html>
     }
 }

--- a/templates/leptos/src/components/show_data_from_api.rs
+++ b/templates/leptos/src/components/show_data_from_api.rs
@@ -1,14 +1,14 @@
-use leptos::*;
+use leptos::prelude::*;
 
 use crate::api::say_hello::say_hello;
 
 #[component]
 pub fn ShowDataFromApi() -> impl IntoView {
-    let value = create_rw_signal("".to_string());
-    let counter = create_rw_signal(0);
+    let value = RwSignal::new("".to_string());
+    let counter = RwSignal::new(0);
 
     let on_click = move |_| {
-        spawn_local(async move {
+        leptos::task::spawn_local(async move {
             let api_said = say_hello(counter.get()).await.unwrap();
             value.set(api_said);
             counter.update(|v| *v += 1);

--- a/templates/leptos/src/lib.rs
+++ b/templates/leptos/src/lib.rs
@@ -1,10 +1,10 @@
 //! Setup our Cloudflare worker (`feature == "ssr"`) and our leptos hydration function (`feature ==
 //! "hydrate"`)
 
+#[cfg(feature = "hydrate")]
+use leptos::wasm_bindgen;
 #[cfg(feature = "ssr")]
 use worker::*;
-
-use leptos::*;
 
 mod api;
 mod app;
@@ -14,12 +14,12 @@ use crate::app::App;
 
 #[cfg(feature = "ssr")]
 async fn router(env: Env) -> axum::Router {
-    use std::sync::Arc;
-
-    use axum::{routing::post, Extension};
-    use leptos_axum::{generate_route_list, LeptosRoutes};
-
     use crate::api::register_server_functions;
+    use crate::app::shell;
+    use axum::{routing::post, Extension};
+    use leptos::prelude::*;
+    use leptos_axum::{generate_route_list, LeptosRoutes};
+    use std::sync::Arc;
 
     // Match what's in Cargo.toml
     // Doesn't seem to be able to do this automatically
@@ -27,23 +27,27 @@ async fn router(env: Env) -> axum::Router {
         output_name: "leptos_worker".into(),
         site_root: "public".into(),
         site_pkg_dir: "pkg".into(),
-        env: leptos_config::Env::DEV,
+        env: Env::DEV,
         site_addr: "127.0.0.1:8787".parse().unwrap(),
         reload_port: 3001,
         reload_external_port: None,
-        reload_ws_protocol: leptos_config::ReloadWSProtocol::WS,
+        reload_ws_protocol: ReloadWSProtocol::WS,
         not_found_path: "/404".into(),
         hash_file: "hash.txt".into(),
         hash_files: false,
     };
-    let routes = generate_route_list(|| view! { <App /> });
 
     register_server_functions();
+
+    let routes = generate_route_list(|| view! { <App /> });
 
     // build our application with a route
     axum::Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
-        .leptos_routes(&leptos_options, routes, || view! { <App/> })
+        .leptos_routes(&leptos_options, routes, {
+            let leptos_options = leptos_options.clone();
+            move || shell(leptos_options.clone())
+        })
         .with_state(leptos_options)
         .layer(Extension(Arc::new(env))) // <- Allow leptos server functions to access Worker stuff
 }
@@ -65,8 +69,9 @@ async fn fetch(
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]
 pub fn hydrate() {
+    use leptos::prelude::*;
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
 
-    leptos::mount_to_body(|| view! { <App/> });
+    leptos::mount::hydrate_body(|| view! { <App/> });
 }

--- a/templates/leptos/wrangler.toml
+++ b/templates/leptos/wrangler.toml
@@ -1,9 +1,16 @@
 name = "leptos-worker"
 main = "build/worker/shim.mjs"
-compatibility_date = "2024-09-01"
+compatibility_date = "2024-12-20"
 
 [build]
-command = "cargo leptos build --release && LEPTOS_OUTPUT_NAME=start-axum worker-build --release --features ssr"
+command = "cargo leptos build --release && LEPTOS_OUTPUT_NAME=leptos_worker worker-build --release --features ssr"
+# Windows
+# command = """
+# powershell -Command "cargo leptos build --release; $env:LEPTOS_OUTPUT_NAME='leptos_worker'; worker-build --release --features ssr"
+# """
+# Unix/Linux
+# command = "cargo leptos build --release && LEPTOS_OUTPUT_NAME=leptos_worker worker-build --release --features ssr"
+
 
 [assets]
 directory = "./public"


### PR DESCRIPTION
Also added build commands for Windows users.
Remove dependencies: gloo-net, gloo-timers, once_cell, tower, wasm-bindgen