### PR TITLE
Fix `RateLimiter` binding name

### DIFF
--- a/worker/src/rate_limit.rs
+++ b/worker/src/rate_limit.rs
@@ -20,7 +20,7 @@ unsafe impl Send for RateLimiter {}
 unsafe impl Sync for RateLimiter {}
 
 impl EnvBinding for RateLimiter {
-    const TYPE_NAME: &'static str = "RateLimiter";
+    const TYPE_NAME: &'static str = "Ratelimit";
 }
 impl RateLimiter {
     pub async fn limit(&self, key: String) -> Result<RateLimitOutcome> {


### PR DESCRIPTION
This PR fixes an issue where the `RateLimiter` could not be retrieved with `Env::get_binding`, as described in #700.

When trying to retrieve the rate limiter I was getting the following error:

```
Binding cannot be cast to the type RateLimiter from RateLimit
```

From what I can tell, the underlying issue is that the runtime constructor name is actually `Ratelimit`, based on this code here: https://github.com/cloudflare/workers-rs/blob/38af58acc4e54b29c73336c1720188f3c3e86cc4/worker/src/env.rs#L123

I was able to fix this by updating the type name from `RateLimiter` to `Ratelimit` in the `EnvBinding` impl.

If there is a different way this should be fixed, I am happy to pursue other avenues.
