### PR TITLE
feat(EmailWorkers): Implement email worker functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,6 +2086,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "receive-email-on-workers"
+version = "0.1.0"
+dependencies = [
+ "mail-builder",
+ "worker",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/receive-email/Cargo.toml
+++ b/examples/receive-email/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "receive-email-on-workers"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.release]
+release = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# Default feature `gethostname` pulls in a crate that doesn't build for
+# `wasm32-unknown-unknown`, so disable it. The remaining core API is enough
+# to assemble a message as long as we set `date` and `message_id` ourselves
+# (the auto-generated ones rely on `SystemTime::now()` / `gethostname`).
+mail-builder = { version = "0.4", default-features = false }
+worker.workspace = true

--- a/examples/receive-email/README.md
+++ b/examples/receive-email/README.md
@@ -1,0 +1,51 @@
+# Receiving email on Cloudflare Workers
+
+Example of an [Email Worker](https://developers.cloudflare.com/email-routing/email-workers/) that auto-replies with `message received` to every inbound message.
+
+The handler is wired up via `#[event(email)]`. It receives a [`worker::InboundEmail`](https://docs.rs/worker/latest/worker/struct.InboundEmail.html), pulls `Message-ID` and `Subject` off the original headers, assembles a reply with [`mail-builder`](https://crates.io/crates/mail-builder), and hands it to [`InboundEmail::reply`](https://docs.rs/worker/latest/worker/struct.InboundEmail.html#method.reply).
+
+Unlike `[[send_email]]`, inbound delivery is not declared in `wrangler.toml` — once deployed, attach an address to this worker from the **Email → Email Routing** section of the Cloudflare dashboard.
+
+## Local development
+
+`wrangler dev --local` exposes a `/cdn-cgi/handler/email` endpoint that simulates an inbound delivery. The reply is written to a local `.eml` file rather than actually being sent (see the [Cloudflare docs](https://developers.cloudflare.com/email-routing/email-workers/local-development/)).
+
+```bash
+npm install
+npm run dev
+# then, in another shell:
+curl -X POST 'http://localhost:8787/cdn-cgi/handler/email' \
+  --url-query 'from=sender@example.com' \
+  --url-query 'to=recipient@example.com' \
+  --header 'Content-Type: application/octet-stream' \
+  --data-binary @sample.eml
+```
+
+`sample.eml` is any RFC 5322 message, e.g.:
+
+```
+From: sender@example.com
+To: recipient@example.com
+Subject: hello
+Message-ID: <abc@example.com>
+
+hi there
+```
+
+## Deploying
+
+```bash
+npm run deploy
+```
+
+After deploying, go to **Email → Email Routing → Email Workers** in the Cloudflare dashboard and route an address to `receive-email-on-workers`.
+
+## Replies require valid DMARC on the sender's domain
+
+Cloudflare's `reply()` only succeeds if the inbound message passes DMARC ([docs](https://developers.cloudflare.com/email-routing/email-workers/reply-email-workers/#requirements)). A *missing* DMARC record at `_dmarc.<sender-domain>` is treated as a failure (`policy.dmarc=none`) and the runtime throws `original email cannot be replied to`. SPF and DKIM passing on their own are not enough.
+
+If you're testing from a domain you control and the reply fails, publish a minimal record — monitor-only `p=none` is sufficient:
+
+```
+_dmarc.example.com.  TXT  "v=DMARC1; p=none;"
+```

--- a/examples/receive-email/package.json
+++ b/examples/receive-email/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "receive-email-on-workers",
+	"version": "0.0.0",
+	"private": true,
+	"scripts": {
+		"deploy": "cargo install worker-build ; wrangler deploy",
+		"dev": "cargo install worker-build ; wrangler dev --local"
+	},
+	"devDependencies": {
+		"wrangler": "^4.83.0"
+	}
+}

--- a/examples/receive-email/src/lib.rs
+++ b/examples/receive-email/src/lib.rs
@@ -1,0 +1,57 @@
+use mail_builder::MessageBuilder as MimeBuilder;
+use worker::*;
+
+#[event(email)]
+async fn email(message: ForwardableEmailMessage, _env: Env, _ctx: Context) -> Result<()> {
+    let from = message.from();
+    let to = message.to();
+
+    let headers = Headers(message.headers());
+    // The header value includes the surrounding angle brackets (`<id@host>`),
+    // but `mail-builder` adds its own when serializing — pass the bare id.
+    let in_reply_to = headers.get("message-id")?.map(|id| {
+        id.trim()
+            .trim_start_matches('<')
+            .trim_end_matches('>')
+            .to_string()
+    });
+    let original_subject = headers.get("subject")?.unwrap_or_default();
+    let reply_subject = if original_subject.starts_with("Re:") {
+        original_subject
+    } else {
+        format!("Re: {original_subject}")
+    };
+
+    // mail-builder's auto-generated `Date:` and `Message-ID:` headers rely on
+    // `SystemTime::now()` and `gethostname`, neither of which work on
+    // `wasm32-unknown-unknown`. https://github.com/stalwartlabs/mail-builder/pull/26
+    let now_ms = Date::now().as_millis();
+    let message_id = format!("{now_ms}@{}", domain_of(&to));
+
+    let mut builder = MimeBuilder::new()
+        .from(to.as_str())
+        .to(from.as_str())
+        .subject(reply_subject.as_str())
+        .date((now_ms / 1000) as i64)
+        .message_id(message_id)
+        .text_body("message received");
+
+    if let Some(id) = in_reply_to {
+        builder = builder.in_reply_to(id.clone()).references(id);
+    }
+
+    let raw = builder
+        .write_to_string()
+        .map_err(|e| Error::RustError(e.to_string()))?;
+
+    let reply = email::EmailMessage::new(&to, &from, &raw)?;
+    message.reply(&reply).await?;
+    Ok(())
+}
+
+fn domain_of(address: &str) -> &str {
+    address
+        .rsplit_once('@')
+        .map(|(_, d)| d)
+        .unwrap_or("example.com")
+}

--- a/examples/receive-email/wrangler.toml
+++ b/examples/receive-email/wrangler.toml
@@ -1,0 +1,8 @@
+name = "receive-email-on-workers"
+main = "build/index.js"
+compatibility_date = "2024-10-01"
+
+[build]
+command = "cargo install \"worker-build@^0.8\" && worker-build --release"
+# For development: use local worker-build binary
+# command = "../../target/release/worker-build --release"

--- a/worker-build/src/main.rs
+++ b/worker-build/src/main.rs
@@ -187,7 +187,11 @@ fn generate_handlers(out_dir: &Path) -> Result<String> {
   return response;
 }
 ";
-        } else if func_name == "fetch" || func_name == "queue" || func_name == "scheduled" {
+        } else if func_name == "fetch"
+            || func_name == "queue"
+            || func_name == "scheduled"
+            || func_name == "email"
+        {
             // TODO: Switch these over to https://github.com/wasm-bindgen/wasm-bindgen/pull/4757
             // once that lands.
             handlers += &format!(

--- a/worker-macros/src/event.rs
+++ b/worker-macros/src/event.rs
@@ -264,7 +264,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 pub fn #wrapper_fn_ident(message: ::worker::ForwardableEmailMessage, env: ::worker::Env, ctx: ::worker::worker_sys::Context) -> ::worker::js_sys::Promise {
                     ::worker::wasm_bindgen_futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
                         let ctx = worker::Context::new(ctx);
-                        match #input_fn_ident(::worker::InboundEmail { inner: message }, env, ctx).await {
+                        match #input_fn_ident(message, env, ctx).await {
                             Ok(()) => {},
                             Err(e) => {
                                 ::worker::console_log!("{}", &e);

--- a/worker-macros/src/event.rs
+++ b/worker-macros/src/event.rs
@@ -10,6 +10,7 @@ enum HandlerType {
     Start,
     #[cfg(feature = "queue")]
     Queue,
+    Email,
 }
 
 fn validate_event_fn(
@@ -59,7 +60,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
     let handler_type = handler_type.expect(
-        "must have either 'fetch', 'scheduled', 'queue' or 'start' attribute, e.g. #[event(fetch)]",
+        "must have either 'fetch', 'scheduled', 'queue', 'email', or 'start' attribute, e.g. #[event(fetch)]",
     );
 
     // create new var using syn item of the attributed fn
@@ -247,6 +248,46 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #wasm_bindgen_code
             };
 
+            TokenStream::from(output)
+        }
+        Email => {
+            validate_event_fn(&input_fn, Email, 3, true);
+            let input_fn_ident = Ident::new(
+                &(input_fn.sig.ident.to_string() + "_email_glue"),
+                input_fn.sig.ident.span(),
+            );
+            let wrapper_fn_ident = Ident::new("email", input_fn.sig.ident.span());
+            // rename the original attributed fn
+            input_fn.sig.ident = input_fn_ident.clone();
+
+            let wrapper_fn = quote! {
+                pub fn #wrapper_fn_ident(message: ::worker::ForwardableEmailMessage, env: ::worker::Env, ctx: ::worker::worker_sys::Context) -> ::worker::js_sys::Promise {
+                    ::worker::wasm_bindgen_futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
+                        let ctx = worker::Context::new(ctx);
+                        match #input_fn_ident(::worker::InboundEmail { inner: message }, env, ctx).await {
+                            Ok(()) => {},
+                            Err(e) => {
+                                ::worker::console_log!("{}", &e);
+                                panic!("{}", e);
+                            }
+                        }
+                        Ok(::worker::wasm_bindgen::JsValue::UNDEFINED)
+                    }))
+                }
+            };
+            let wasm_bindgen_code =
+                wasm_bindgen_macro_support::expand(TokenStream::new().into(), wrapper_fn)
+                    .expect("wasm_bindgen macro failed to expand");
+
+            let output = quote! {
+                #input_fn
+
+                mod _worker_email {
+                    use ::worker::{wasm_bindgen, wasm_bindgen_futures};
+                    use super::#input_fn_ident;
+                    #wasm_bindgen_code
+                }
+            };
             TokenStream::from(output)
         }
     }

--- a/worker/src/email.rs
+++ b/worker/src/email.rs
@@ -1,7 +1,8 @@
+use futures_util::TryStreamExt;
 use wasm_bindgen::JsCast;
 
 pub use crate::bindings::email::*;
-use crate::{EnvBinding, Result};
+use crate::{send::SendFuture, ByteStream, EnvBinding, Headers, Result};
 
 impl EnvBinding for SendEmail {
     const TYPE_NAME: &'static str = "SendEmail";
@@ -17,16 +18,91 @@ impl EnvBinding for SendEmail {
     }
 }
 
+/// High-level wrapper around the inbound `ForwardableEmailMessage` handed to
+/// an `#[event(email)]` handler. Returns `worker::Headers` / `ByteStream` and
+/// `Send`-safe futures so the handler composes with async frameworks like
+/// axum that require `Send` bounds.
+#[derive(Debug)]
+pub struct InboundEmail {
+    pub inner: ForwardableEmailMessage,
+}
+
+impl InboundEmail {
+    /// Envelope `From` of the inbound message.
+    pub fn from_email(&self) -> String {
+        self.inner.from()
+    }
+
+    /// Envelope `To` of the inbound message.
+    pub fn to_email(&self) -> String {
+        self.inner.to()
+    }
+
+    /// Headers of the inbound message.
+    pub fn headers(&self) -> Headers {
+        Headers(self.inner.headers())
+    }
+
+    /// Stream of the raw email content.
+    pub fn raw(&self) -> ByteStream {
+        ByteStream {
+            inner: wasm_streams::ReadableStream::from_raw(self.inner.raw()).into_stream(),
+        }
+    }
+
+    /// Convenience: collect the raw email content into a `Vec<u8>`.
+    pub async fn raw_bytes(&self) -> Result<Vec<u8>> {
+        self.raw()
+            .try_fold(Vec::new(), |mut bytes, mut chunk| async move {
+                bytes.append(&mut chunk);
+                Ok(bytes)
+            })
+            .await
+    }
+
+    /// Size of the raw email content in bytes.
+    pub fn raw_size(&self) -> f64 {
+        self.inner.raw_size()
+    }
+
+    /// Reject this message with a permanent SMTP error.
+    pub fn reject(&self, reason: &str) {
+        self.inner.set_reject(reason)
+    }
+
+    /// Forward this message to a verified destination address.
+    pub async fn forward(
+        &self,
+        recipient: &str,
+        headers: Option<Headers>,
+    ) -> Result<EmailSendResult> {
+        let fut = SendFuture::new(async move {
+            match headers {
+                Some(h) => self.inner.forward_with_headers(recipient, &h.0).await,
+                None => self.inner.forward(recipient).await,
+            }
+        });
+        Ok(fut.await?)
+    }
+
+    /// Reply to the sender of this message with a new `EmailMessage`.
+    pub async fn reply(&self, message: &EmailMessage) -> Result<EmailSendResult> {
+        let fut = SendFuture::new(async move { self.inner.reply(message).await });
+        Ok(fut.await?)
+    }
+}
+
 #[cfg(test)]
 mod send_check {
-    // `SendEmail` is `Send` automatically — wasm-bindgen makes `JsValue`
-    // `Send + Sync` and every extern `pub type` in `email.rs` carries that
-    // through. This compile-time check guards against an upstream
-    // regression.
-    use super::SendEmail;
+    // `SendEmail` and `InboundEmail` are `Send` automatically —
+    // wasm-bindgen makes `JsValue` `Send + Sync` and every extern `pub type`
+    // carries that through. This compile-time check guards against an
+    // upstream regression.
+    use super::{InboundEmail, SendEmail};
     fn _assert_send<T: Send>() {}
     #[allow(dead_code)]
     fn _check() {
         _assert_send::<SendEmail>();
+        _assert_send::<InboundEmail>();
     }
 }

--- a/worker/src/email.rs
+++ b/worker/src/email.rs
@@ -2,7 +2,7 @@ use futures_util::TryStreamExt;
 use wasm_bindgen::JsCast;
 
 pub use crate::bindings::email::*;
-use crate::{send::SendFuture, ByteStream, EnvBinding, Headers, Result};
+use crate::{ByteStream, EnvBinding, Result};
 
 impl EnvBinding for SendEmail {
     const TYPE_NAME: &'static str = "SendEmail";
@@ -18,77 +18,20 @@ impl EnvBinding for SendEmail {
     }
 }
 
-/// High-level wrapper around the inbound `ForwardableEmailMessage` handed to
-/// an `#[event(email)]` handler. Returns `worker::Headers` / `ByteStream` and
-/// `Send`-safe futures so the handler composes with async frameworks like
-/// axum that require `Send` bounds.
-#[derive(Debug)]
-pub struct InboundEmail {
-    pub inner: ForwardableEmailMessage,
-}
-
-impl InboundEmail {
-    /// Envelope `From` of the inbound message.
-    pub fn from_email(&self) -> String {
-        self.inner.from()
-    }
-
-    /// Envelope `To` of the inbound message.
-    pub fn to_email(&self) -> String {
-        self.inner.to()
-    }
-
-    /// Headers of the inbound message.
-    pub fn headers(&self) -> Headers {
-        Headers(self.inner.headers())
-    }
-
+impl ForwardableEmailMessage {
     /// Stream of the raw email content.
-    pub fn raw(&self) -> ByteStream {
-        ByteStream {
-            inner: wasm_streams::ReadableStream::from_raw(self.inner.raw()).into_stream(),
-        }
+    pub fn raw_byte_stream(&self) -> ByteStream {
+        self.raw().into()
     }
 
     /// Convenience: collect the raw email content into a `Vec<u8>`.
     pub async fn raw_bytes(&self) -> Result<Vec<u8>> {
-        self.raw()
+        Into::<ByteStream>::into(self.raw())
             .try_fold(Vec::new(), |mut bytes, mut chunk| async move {
                 bytes.append(&mut chunk);
                 Ok(bytes)
             })
             .await
-    }
-
-    /// Size of the raw email content in bytes.
-    pub fn raw_size(&self) -> f64 {
-        self.inner.raw_size()
-    }
-
-    /// Reject this message with a permanent SMTP error.
-    pub fn reject(&self, reason: &str) {
-        self.inner.set_reject(reason)
-    }
-
-    /// Forward this message to a verified destination address.
-    pub async fn forward(
-        &self,
-        recipient: &str,
-        headers: Option<Headers>,
-    ) -> Result<EmailSendResult> {
-        let fut = SendFuture::new(async move {
-            match headers {
-                Some(h) => self.inner.forward_with_headers(recipient, &h.0).await,
-                None => self.inner.forward(recipient).await,
-            }
-        });
-        Ok(fut.await?)
-    }
-
-    /// Reply to the sender of this message with a new `EmailMessage`.
-    pub async fn reply(&self, message: &EmailMessage) -> Result<EmailSendResult> {
-        let fut = SendFuture::new(async move { self.inner.reply(message).await });
-        Ok(fut.await?)
     }
 }
 
@@ -98,11 +41,11 @@ mod send_check {
     // wasm-bindgen makes `JsValue` `Send + Sync` and every extern `pub type`
     // carries that through. This compile-time check guards against an
     // upstream regression.
-    use super::{InboundEmail, SendEmail};
+    use super::{ForwardableEmailMessage, SendEmail};
     fn _assert_send<T: Send>() {}
     #[allow(dead_code)]
     fn _check() {
         _assert_send::<SendEmail>();
-        _assert_send::<InboundEmail>();
+        _assert_send::<ForwardableEmailMessage>();
     }
 }

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -174,6 +174,7 @@ pub use crate::date::{Date, DateInit};
 pub use crate::delay::Delay;
 pub use crate::durable::*;
 pub use crate::dynamic_dispatch::*;
+pub use crate::email::*;
 pub use crate::env::{Env, EnvBinding, Secret, Var};
 pub use crate::error::Error;
 pub use crate::fetcher::Fetcher;


### PR DESCRIPTION
Closes #274 

Looking for initial comments so I can wrap up this implementation. I've successfully validated reply and forward functionality. 


example handler: 

```rust
use uuid::Uuid;
use worker::*;

#[event(email)]
async fn main(message: EmailMessage, _env: Env, _ctx: Context) -> Result<()> {
    let message_id = message.headers().get("Message-ID")?.unwrap();

    let msg = format!(
        "From: Cloudflare bot <{}>
To: Toon <{}>
In-Reply-To: {}
Message-ID: <{}@redacted.com>
Subject: Email well received!

I've parsed the mail!

",
        message.to_email(),
        message.from_email(),
        message_id,
        Uuid::new_v4()
    );

    let new_message = EmailMessage::new(&message.to_email(), &message.from_email(), &msg)?;

    message.reply(new_message).await?;
    Ok(())
}
```