### PR TITLE
Add note to readme about runtime-agnostic primitives from tokio

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ please [take a look](https://www.cloudflare.com/careers/).
 1. Can I deploy a Worker that uses `tokio` or `async_std` runtimes?
 
 - Currently no. All crates in your Worker project must compile to `wasm32-unknown-unknown` target,
-  which is more limited in some ways than targets for x86 and ARM64.
+  which is more limited in some ways than targets for x86 and ARM64. However, you should still be able to use runtime-agnostic primitives from those crates such as those from [tokio::sync](https://docs.rs/tokio/latest/tokio/sync/index.html#runtime-compatibility).
 
 2. The `worker` crate doesn't have _X_! Why not?
 


### PR DESCRIPTION
I'd mistakenly assumed when first reading this warning that I couldn't use anything from `tokio` (even through the existing text does just say the tokio async runtime).  Add a note to make it clear that runtime-agnostic tokio crates are still usable.