### PR TITLE
(feat) generate wasm-bindgen wrappers for #[rpc] methods in impl …

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,18 +347,62 @@ binding = "my_queue"
 ## RPC Support
 
 `workers-rs` has experimental support for [Workers RPC](https://developers.cloudflare.com/workers/runtime-apis/rpc/).
-For now, this relies on JavaScript bindings and may require some manual usage of `wasm-bindgen`. 
 
 Not all features of RPC are supported yet (or have not been tested), including:
 - Function arguments and return values
 - Class instances
 - Stub forwarding
 
-### RPC Server
+### RPC Server 
 
-Writing an RPC server with `workers-rs` is relatively simple. Simply export methods using `wasm-bindgen`. These
-will be automatically detected by `worker-build` and made available to other Workers. See
-[example](./examples/rpc-server).
+RPC methods can be exported using a custom `#[rpc]` attribute macro. 
+RPC methods must be defined inside an `impl` block annotated with `#[rpc]`, and individual methods must also be marked with `#[rpc]`.
+
+When the macro is expanded, it generates:
+- A `#[wasm_bindgen]`-annotated struct with `env: worker::Env`
+- A constructor function: `#[wasm_bindgen(constructor)] pub fn new(env: Env)`
+- A method `#[wasm_bindgen(js_name = "__is_rpc__")] fn is_rpc(&self) -> bool` for RPC auto-discovery
+- All methods marked with `#[rpc]` converted into `#[wasm_bindgen]`-annotated exports
+
+
+**RPC method names must be unique across all types.**
+
+Due to how the JavaScript shim dynamically attaches RPC methods to the `Entrypoint` prototype, each `#[rpc]` method must have a unique name, 
+even if it is defined on a different struct. If two methods share the same name, only one will be registered and the others will be silently skipped or overwritten.
+
+
+### Example
+
+```rust
+#[rpc]
+impl Rpc {
+    #[rpc]
+    pub async fn add(&self, a: u32, b: u32) -> u32 {
+        a + b
+    }
+}
+```
+
+Expands to:
+
+```rust
+#[wasm_bindgen]
+pub struct Rpc {
+    env: worker::Env,
+}
+
+#[wasm_bindgen]
+impl Rpc {
+    #[wasm_bindgen(js_name = "__is_rpc__")]
+    pub fn is_rpc(&self) -> bool {
+        true
+    }
+    #[wasm_bindgen(constructor)]
+    pub fn new(env: worker::
+```
+
+See [example](./examples/rpc-server).
+
 
 ### RPC Client
 

--- a/README.md
+++ b/README.md
@@ -398,7 +398,15 @@ impl Rpc {
         true
     }
     #[wasm_bindgen(constructor)]
-    pub fn new(env: worker::
+    pub fn new(env: worker::Env) -> Self {
+        Self { env }
+    }
+
+    #[wasm_bindgen]
+    pub async fn add(&self, a: u32, b: u32) -> u32 {
+        a + b
+    }
+}
 ```
 
 See [example](./examples/rpc-server).

--- a/examples/rpc-server/src/lib.rs
+++ b/examples/rpc-server/src/lib.rs
@@ -1,13 +1,18 @@
-use wasm_bindgen::prelude::wasm_bindgen;
 use worker::*;
+use wasm_bindgen::prelude::wasm_bindgen;
+
 
 #[event(fetch)]
 async fn main(_req: Request, _env: Env, _ctx: Context) -> Result<Response> {
     Response::ok("Hello World")
 }
 
-#[wasm_bindgen]
-pub async fn add(a: u32, b: u32) -> u32 {
-    console_error_panic_hook::set_once();
-    a + b
+#[rpc]
+impl Rpc {
+
+    #[rpc]
+    pub async fn add(&self, a: u32, b: u32) -> u32 {
+        console_error_panic_hook::set_once();
+        a + b
+    }
 }

--- a/worker-build/src/js/shim.js
+++ b/worker-build/src/js/shim.js
@@ -42,12 +42,47 @@ const EXCLUDE_EXPORT = [
 	"queue",
 	"scheduled",
 	"getMemory",
+	"Rpc"
 ];
 
-Object.keys(imports).map((k) => {
-	if (!(EXCLUDE_EXPORT.includes(k) | k.startsWith("__"))) {
-		Entrypoint.prototype[k] = imports[k];
+Object.keys(imports).forEach((key) => {
+	const fn = imports[key];
+	if (typeof fn === "function" && !EXCLUDE_EXPORT.includes(key) && !key.startsWith("__")) {
+		// Otherwise, assign the function as-is.
+		Entrypoint.prototype[key] = fn;
 	}
 });
+
+
+// Helper to lazily create the RPC instance
+Entrypoint.prototype._getRpc = function (Ctor) {
+  if (!this._rpcInstanceMap) this._rpcInstanceMap = new Map();
+  if (!this._rpcInstanceMap.has(Ctor)) {
+    this._rpcInstanceMap.set(Ctor, new Ctor(this.env));
+  }
+  return this._rpcInstanceMap.get(Ctor);
+};
+
+const EXCLUDE_RPC_EXPORT = ["constructor", "new", "free"];
+
+//Register RPC entrypoint methods into Endpoint
+Object.entries(imports).forEach(([exportName, exportValue]) => {
+  if (typeof exportValue === "function" && exportValue.prototype?.__is_rpc__) {
+    const Ctor = exportValue;
+
+    const methodNames = Object.getOwnPropertyNames(Ctor.prototype)
+      .filter(name => !EXCLUDE_RPC_EXPORT.includes(name) && typeof exportValue.prototype[name] === "function");
+
+    for (const methodName of methodNames) {
+      if (!Entrypoint.prototype.hasOwnProperty(methodName)) {
+        Entrypoint.prototype[methodName] = function (...args) {
+          const rpc = this._getRpc(Ctor);
+          return rpc[methodName](...args);
+        };
+      }
+    }
+  }
+});
+
 
 export default Entrypoint;

--- a/worker-macros/src/rpc.rs
+++ b/worker-macros/src/rpc.rs
@@ -1,0 +1,52 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ImplItem, ItemImpl, Type, Error};
+use syn::spanned::Spanned;
+
+pub fn expand_macro(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(item as ItemImpl);
+
+    let struct_ident = match &*input.self_ty {
+        Type::Path(p) => &p.path.segments.last().unwrap().ident,
+        _ => return Error::new(input.self_ty.span(), "Expected a named type").to_compile_error().into(),
+    };
+
+    let mut exported_methods = Vec::new();
+
+    for item in &mut input.items {
+        if let ImplItem::Fn(ref mut func) = item {
+            if let Some(rpc_pos) = func.attrs.iter().position(|attr| attr.path().is_ident("rpc")) {
+                func.attrs.remove(rpc_pos);
+                func.attrs.insert(0, syn::parse_quote!(#[wasm_bindgen]));
+                exported_methods.push(func.clone());
+            }
+        }
+    }
+
+    if exported_methods.is_empty() {
+        return Error::new(input.span(), "No methods marked with #[rpc] found.").to_compile_error().into();
+    }
+
+    TokenStream::from(quote! {
+        #[wasm_bindgen]
+        pub struct #struct_ident {
+            env: worker::Env,
+        }
+
+        #[wasm_bindgen]
+        impl #struct_ident {
+            #[wasm_bindgen(js_name = "__is_rpc__")]
+            pub fn is_rpc(&self) -> bool {
+                true
+            }
+
+            #[wasm_bindgen(constructor)]
+            pub fn new(env: worker::Env) -> Self {
+                Self { env }
+            }
+
+            #(#exported_methods)*
+        }
+    })
+}
+

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -155,7 +155,15 @@
 //!         true
 //!     }
 //!     #[wasm_bindgen(constructor)]
-//!     pub fn new(env: worker::
+//!     pub fn new(env: worker::Env) -> Self {
+//!         Self { env }
+//!     }
+//! 
+//!     #[wasm_bindgen]
+//!     pub async fn add(&self, a: u32, b: u32) -> u32 {
+//!         a + b
+//!     }
+//! }
 //! ```
 //! 
 //! See [example](./examples/rpc-server).


### PR DESCRIPTION
### Improvements

- Introduced #[rpc] attribute macro for impl blocks
- Automatically generates:
  - #[wasm_bindgen] struct with `env: worker::Env`
  - #[wasm_bindgen(constructor)] `new(env: Env)`
  - #[wasm_bindgen(js_name = "__is_rpc__")] method for JS discovery
- Replaces #[rpc] on methods with #[wasm_bindgen]
- Requires unique method names across all RPC exports
- Updated macro docs and runtime constraints

Allows using Env inside RPC methods. Open space for further improvements for the rpc functionality.

Related: https://github.com/cloudflare/workers-rs/issues/720


RPC methods can be exported using a custom `#[rpc]` attribute macro. 
RPC methods must be defined inside an `impl` block annotated with `#[rpc]`, and individual methods must also be marked with `#[rpc]`.

When the macro is expanded, it generates:
- A `#[wasm_bindgen]`-annotated struct with `env: worker::Env`
- A constructor function: `#[wasm_bindgen(constructor)] pub fn new(env: Env)`
- A method `#[wasm_bindgen(js_name = "__is_rpc__")] fn is_rpc(&self) -> bool` for RPC auto-discovery
- All methods marked with `#[rpc]` converted into `#[wasm_bindgen]`-annotated exports

### Example

```rust
#[rpc]
impl Rpc {
    #[rpc]
    pub async fn add(&self, a: u32, b: u32) -> u32 {
        // self.env available 
        a + b
    }
}
```

Expands to:

```rust
#[wasm_bindgen]
pub struct Rpc {
    env: worker::Env,
}

#[wasm_bindgen]
impl Rpc {
    #[wasm_bindgen(js_name = "__is_rpc__")]
    pub fn is_rpc(&self) -> bool {
        true
    }
    #[wasm_bindgen(constructor)]
    pub fn new(env: worker::Env) -> Self {
        Self { env }
    }

    #[wasm_bindgen]
    pub async fn add(&self, a: u32, b: u32) -> u32 {
        a + b
    }
}
```

Used in in rpc client workers:
```
export default {
  async fetch(request, env) {
    const result = await env.RPC_SERVICE.add(1,2);
    return new Response(JSON.stringify(result, null, 2));
  }
}
```