### PR TITLE
wip: shared durable object approach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,6 +952,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,6 +3837,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "getrandom",
+ "gloo-timers",
  "hex",
  "http 1.2.0",
  "md5",

--- a/worker-macros/src/durable_object.rs
+++ b/worker-macros/src/durable_object.rs
@@ -2,20 +2,22 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{spanned::Spanned, Error, FnArg, ImplItem, Item, Type, TypePath, Visibility};
 
-pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
+pub fn expand_macro(tokens: TokenStream, shared: bool) -> syn::Result<TokenStream> {
     let item = syn::parse2::<Item>(tokens)?;
     match item {
         Item::Impl(imp) => {
             let impl_token = imp.impl_token;
             let trai = imp.trait_.clone();
             let (_, trai, _) = trai.ok_or_else(|| Error::new_spanned(impl_token, "Must be a DurableObject trait impl"))?;
-            if !trai.segments.last().map(|x| x.ident == "DurableObject").unwrap_or(false) {
-                return Err(Error::new(trai.span(), "Must be a DurableObject trait impl"))
+
+            // Check for the correct trait based on shared parameter
+            let expected_trait = if shared { "SharedDurableObject" } else { "DurableObject" };
+            if !trai.segments.last().map(|x| x.ident == expected_trait).unwrap_or(false) {
+                return Err(Error::new(trai.span(), format!("Must be a {} trait impl", expected_trait)));
             }
 
             let pound = syn::Token![#](imp.span()).to_token_stream();
             let wasm_bindgen_attr = quote! {#pound[wasm_bindgen::prelude::wasm_bindgen]};
-
 
             let struct_name = imp.self_ty;
             let items = imp.items;
@@ -31,6 +33,14 @@ pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
 
             let mut optional_methods = OptionalMethods::default();
 
+            let self_name = if shared { quote! { SharedDurableObject } } else  { quote! { DurableObject } };
+            let self_param = if shared { quote! { &self } } else { quote! { &mut self } };
+            let self_cast = if shared {
+                quote! { let static_self: &'static Self = unsafe {&*(self as *const _)}; }
+            } else {
+                quote! { let static_self: &'static mut Self = unsafe {&mut *(self as *mut _)}; }
+            };
+
             for item in items {
                 let impl_method = match item {
                     ImplItem::Fn(func) => func,
@@ -44,7 +54,6 @@ pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
                         let mut method = impl_method.clone();
                         method.sig.ident = Ident::new("_new", method.sig.ident.span());
                         method.vis = Visibility::Inherited;
-
 
                         // modify the `state` argument so it is type ObjectState
                         let arg_tokens = method.sig.inputs.first_mut().expect("DurableObject `new` method must have 2 arguments: state and env").into_token_stream();                        
@@ -80,16 +89,26 @@ pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
                         method.sig.ident = Ident::new("_fetch_raw", method.sig.ident.span());
                         method.vis = Visibility::Inherited;
 
+                        // For shared objects, we need to use &self instead of &mut self
+                        if shared {
+                            // Update the method signature to use &self
+                            if let Some(first_arg) = method.sig.inputs.first_mut() {
+                                if let FnArg::Receiver(receiver) = first_arg {
+                                    receiver.mutability = None; // Remove mut
+                                }
+                            }
+                        }
+
                         Ok(quote! {
                             #pound[wasm_bindgen::prelude::wasm_bindgen(js_name = fetch)]
-                            pub fn _fetch(&mut self, req: worker::worker_sys::web_sys::Request) -> worker::js_sys::Promise {
+                            pub fn _fetch(#self_param, req: worker::worker_sys::web_sys::Request) -> worker::js_sys::Promise {
                                 // SAFETY:
                                 // On the surface, this is unsound because the Durable Object could be dropped
                                 // while JavaScript still has possession of the future. However,
                                 // we know something that Rust doesn't: that the Durable Object will never be destroyed
                                 // while there is still a running promise inside of it, therefore we can let a reference
                                 // to the durable object escape into a static-lifetime future.
-                                let static_self: &'static mut Self = unsafe {&mut *(self as *mut _)};
+                                #self_cast
 
                                 wasm_bindgen_futures::future_to_promise(async move {
                                     static_self._fetch_raw(req.into()).await.map(worker::worker_sys::web_sys::Response::from).map(wasm_bindgen::JsValue::from)
@@ -107,16 +126,18 @@ pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
                         method.sig.ident = Ident::new("_alarm_raw", method.sig.ident.span());
                         method.vis = Visibility::Inherited;
 
+                        if shared {
+                            if let Some(first_arg) = method.sig.inputs.first_mut() {
+                                if let FnArg::Receiver(receiver) = first_arg {
+                                    receiver.mutability = None;
+                                }
+                            }
+                        }
+
                         Ok(quote! {
                             #pound[wasm_bindgen::prelude::wasm_bindgen(js_name = alarm)]
-                            pub fn _alarm(&mut self) -> worker::js_sys::Promise {
-                                // SAFETY:
-                                // On the surface, this is unsound because the Durable Object could be dropped
-                                // while JavaScript still has possession of the future. However,
-                                // we know something that Rust doesn't: that the Durable Object will never be destroyed
-                                // while there is still a running promise inside of it, therefore we can let a reference
-                                // to the durable object escape into a static-lifetime future.
-                                let static_self: &'static mut Self = unsafe {&mut *(self as *mut _)};
+                            pub fn _alarm(#self_param) -> worker::js_sys::Promise {
+                                #self_cast
 
                                 wasm_bindgen_futures::future_to_promise(async move {
                                     static_self._alarm_raw().await.map(worker::worker_sys::web_sys::Response::from).map(wasm_bindgen::JsValue::from)
@@ -134,9 +155,11 @@ pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
                         method.sig.ident = Ident::new("_websocket_message_raw", method.sig.ident.span());
                         method.vis = Visibility::Inherited;
 
+
+
                         Ok(quote! {
                             #pound[wasm_bindgen::prelude::wasm_bindgen(js_name = webSocketMessage)]
-                            pub fn _websocket_message(&mut self, ws: worker::worker_sys::web_sys::WebSocket, message: wasm_bindgen::JsValue) -> worker::js_sys::Promise {
+                            pub fn _websocket_message(#self_param, ws: worker::worker_sys::web_sys::WebSocket, message: wasm_bindgen::JsValue) -> worker::js_sys::Promise {
                                 let ws_message = if let Some(string_message) = message.as_string() {
                                     worker::WebSocketIncomingMessage::String(string_message)
                                 } else {
@@ -144,13 +167,7 @@ pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
                                     worker::WebSocketIncomingMessage::Binary(v)
                                 };
 
-                                // SAFETY:
-                                // On the surface, this is unsound because the Durable Object could be dropped
-                                // while JavaScript still has possession of the future. However,
-                                // we know something that Rust doesn't: that the Durable Object will never be destroyed
-                                // while there is still a running promise inside of it, therefore we can let a reference
-                                // to the durable object escape into a static-lifetime future.
-                                let static_self: &'static mut Self = unsafe {&mut *(self as *mut _)};
+                                #self_cast
 
                                 wasm_bindgen_futures::future_to_promise(async move {
                                     static_self._websocket_message_raw(ws.into(), ws_message).await.map(|_| wasm_bindgen::JsValue::NULL)
@@ -168,16 +185,18 @@ pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
                         method.sig.ident = Ident::new("_websocket_close_raw", method.sig.ident.span());
                         method.vis = Visibility::Inherited;
 
+                        if shared {
+                            if let Some(first_arg) = method.sig.inputs.first_mut() {
+                                if let FnArg::Receiver(receiver) = first_arg {
+                                    receiver.mutability = None;
+                                }
+                            }
+                        }
+
                         Ok(quote! {
                             #pound[wasm_bindgen::prelude::wasm_bindgen(js_name = webSocketClose)]
-                            pub fn _websocket_close(&mut self, ws: worker::worker_sys::web_sys::WebSocket, code: usize, reason: String, was_clean: bool) -> worker::js_sys::Promise {
-                                // SAFETY:
-                                // On the surface, this is unsound because the Durable Object could be dropped
-                                // while JavaScript still has possession of the future. However,
-                                // we know something that Rust doesn't: that the Durable Object will never be destroyed
-                                // while there is still a running promise inside of it, therefore we can let a reference
-                                // to the durable object escape into a static-lifetime future.
-                                let static_self: &'static mut Self = unsafe {&mut *(self as *mut _)};
+                            pub fn _websocket_close(#self_param, ws: worker::worker_sys::web_sys::WebSocket, code: usize, reason: String, was_clean: bool) -> worker::js_sys::Promise {
+                                #self_cast
 
                                 wasm_bindgen_futures::future_to_promise(async move {
                                     static_self._websocket_close_raw(ws.into(), code, reason, was_clean).await.map(|_| wasm_bindgen::JsValue::NULL)
@@ -195,16 +214,18 @@ pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
                         method.sig.ident = Ident::new("_websocket_error_raw", method.sig.ident.span());
                         method.vis = Visibility::Inherited;
 
+                        if shared {
+                            if let Some(first_arg) = method.sig.inputs.first_mut() {
+                                if let FnArg::Receiver(receiver) = first_arg {
+                                    receiver.mutability = None;
+                                }
+                            }
+                        }
+
                         Ok(quote! {
                             #pound[wasm_bindgen::prelude::wasm_bindgen(js_name = webSocketError)]
-                            pub fn _websocket_error(&mut self, ws: worker::worker_sys::web_sys::WebSocket, error: wasm_bindgen::JsValue) -> worker::js_sys::Promise {
-                                // SAFETY:
-                                // On the surface, this is unsound because the Durable Object could be dropped
-                                // while JavaScript still has possession of the future. However,
-                                // we know something that Rust doesn't: that the Durable Object will never be destroyed
-                                // while there is still a running promise inside of it, therefore we can let a reference
-                                // to the durable object escape into a static-lifetime future.
-                                let static_self: &'static mut Self = unsafe {&mut *(self as *mut _)};
+                            pub fn _websocket_error(#self_param, ws: worker::worker_sys::web_sys::WebSocket, error: wasm_bindgen::JsValue) -> worker::js_sys::Promise {
+                                #self_cast
 
                                 wasm_bindgen_futures::future_to_promise(async move {
                                     static_self._websocket_error_raw(ws.into(), error.into()).await.map(|_| wasm_bindgen::JsValue::NULL)
@@ -220,43 +241,40 @@ pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
                 tokenized.push(tokens?);
             }
 
+            // Generate optional method implementations with correct self type
             let alarm_tokens = optional_methods.has_alarm.then(|| quote! {
-                async fn alarm(&mut self) -> ::worker::Result<worker::Response> {
-                    self._alarm_raw().await
-                }
-            });
+                    async fn alarm(#self_param) -> ::worker::Result<worker::Response> {
+                        self._alarm_raw().await
+                    }
+                });
 
             let websocket_message_tokens = optional_methods.has_websocket_message.then(|| quote! {
-                async fn websocket_message(&mut self, ws: ::worker::WebSocket, message: ::worker::WebSocketIncomingMessage) -> ::worker::Result<()> {
-                    self._websocket_message_raw(ws, message).await
-                }
-            });
+                    async fn websocket_message(#self_param, ws: ::worker::WebSocket, message: ::worker::WebSocketIncomingMessage) -> ::worker::Result<()> {
+                        self._websocket_message_raw(ws, message).await
+                    }
+                    });
 
             let websocket_close_tokens = optional_methods.has_websocket_close.then(|| quote! {
-                async fn websocket_close(&mut self, ws: ::worker::WebSocket, code: usize, reason: String, was_clean: bool) -> ::worker::Result<()> {
-                    self._websocket_close_raw(ws, code, reason, was_clean).await
-                }
-            });
+                    async fn websocket_close(#self_param, ws: ::worker::WebSocket, code: usize, reason: String, was_clean: bool) -> ::worker::Result<()> {
+                        self._websocket_close_raw(ws, code, reason, was_clean).await
+                    }
+                });
 
             let websocket_error_tokens = optional_methods.has_websocket_error.then(|| quote! {
-                async fn websocket_error(&mut self, ws: ::worker::WebSocket, error: ::worker::Error) -> ::worker::Result<()> {
-                    self._websocket_error_raw(ws, error).await
-                }
-            });
+                    async fn websocket_error(#self_param, ws: ::worker::WebSocket, error: ::worker::Error) -> ::worker::Result<()> {
+                        self._websocket_error_raw(ws, error).await
+                    }
+                });
 
-            Ok(quote! {
-                #wasm_bindgen_attr
-                impl #struct_name {
-                    #(#tokenized)*
-                }
-
+            // Generate the appropriate trait implementation
+            let trait_impl = quote! {
                 #pound[async_trait::async_trait(?Send)]
-                impl ::worker::durable::DurableObject for #struct_name {
+                impl ::worker::durable::#self_name for #struct_name {
                     fn new(state: ::worker::durable::State, env: ::worker::Env) -> Self {
                         Self::_new(state._inner(), env)
                     }
 
-                    async fn fetch(&mut self, req: ::worker::Request) -> ::worker::Result<worker::Response> {
+                    async fn fetch(#self_param, req: ::worker::Request) -> ::worker::Result<worker::Response> {
                         self._fetch_raw(req).await
                     }
 
@@ -271,12 +289,22 @@ pub fn expand_macro(tokens: TokenStream) -> syn::Result<TokenStream> {
 
                 trait __Need_Durable_Object_Trait_Impl_With_durable_object_Attribute { const MACROED: bool = true; }
                 impl __Need_Durable_Object_Trait_Impl_With_durable_object_Attribute for #struct_name {}
+            };
+
+            Ok(quote! {
+                #wasm_bindgen_attr
+                impl #struct_name {
+                    #(#tokenized)*
+                }
+
+                #trait_impl
             })
         },
         Item::Struct(struc) => {
             let tokens = struc.to_token_stream();
             let pound = syn::Token![#](struc.span()).to_token_stream();
             let struct_name = struc.ident;
+
             Ok(quote! {
                 #pound[wasm_bindgen::prelude::wasm_bindgen]
                 #tokens

--- a/worker-macros/src/durable_object.rs
+++ b/worker-macros/src/durable_object.rs
@@ -92,10 +92,8 @@ pub fn expand_macro(tokens: TokenStream, shared: bool) -> syn::Result<TokenStrea
                         // For shared objects, we need to use &self instead of &mut self
                         if shared {
                             // Update the method signature to use &self
-                            if let Some(first_arg) = method.sig.inputs.first_mut() {
-                                if let FnArg::Receiver(receiver) = first_arg {
-                                    receiver.mutability = None; // Remove mut
-                                }
+                            if let Some(FnArg::Receiver(receiver)) = method.sig.inputs.first_mut() {
+                                receiver.mutability = None;
                             }
                         }
 
@@ -127,10 +125,8 @@ pub fn expand_macro(tokens: TokenStream, shared: bool) -> syn::Result<TokenStrea
                         method.vis = Visibility::Inherited;
 
                         if shared {
-                            if let Some(first_arg) = method.sig.inputs.first_mut() {
-                                if let FnArg::Receiver(receiver) = first_arg {
-                                    receiver.mutability = None;
-                                }
+                            if let Some(FnArg::Receiver(receiver)) = method.sig.inputs.first_mut() {
+                                receiver.mutability = None;
                             }
                         }
 
@@ -186,10 +182,8 @@ pub fn expand_macro(tokens: TokenStream, shared: bool) -> syn::Result<TokenStrea
                         method.vis = Visibility::Inherited;
 
                         if shared {
-                            if let Some(first_arg) = method.sig.inputs.first_mut() {
-                                if let FnArg::Receiver(receiver) = first_arg {
-                                    receiver.mutability = None;
-                                }
+                            if let Some(FnArg::Receiver(receiver)) = method.sig.inputs.first_mut() {
+                                receiver.mutability = None;
                             }
                         }
 
@@ -215,10 +209,8 @@ pub fn expand_macro(tokens: TokenStream, shared: bool) -> syn::Result<TokenStrea
                         method.vis = Visibility::Inherited;
 
                         if shared {
-                            if let Some(first_arg) = method.sig.inputs.first_mut() {
-                                if let FnArg::Receiver(receiver) = first_arg {
-                                    receiver.mutability = None;
-                                }
+                            if let Some(FnArg::Receiver(receiver)) = method.sig.inputs.first_mut() {
+                                receiver.mutability = None;
                             }
                         }
 

--- a/worker-macros/src/lib.rs
+++ b/worker-macros/src/lib.rs
@@ -6,7 +6,14 @@ use proc_macro::TokenStream;
 
 #[proc_macro_attribute]
 pub fn durable_object(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    durable_object::expand_macro(item.into())
+    durable_object::expand_macro(item.into(), false)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_attribute]
+pub fn shared_durable_object(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    durable_object::expand_macro(item.into(), true)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }

--- a/worker-sandbox/Cargo.toml
+++ b/worker-sandbox/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { version = "0.4.35", default-features = false, features = [
 cfg-if = "1.0.0"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 getrandom = { version = "0.2.10", features = ["js"] }
+gloo-timers = { version = "0.3.0", features = ["futures"] }
 hex = "0.4.3"
 http.workspace=true
 regex = "1.8.4"

--- a/worker-sandbox/src/alarm.rs
+++ b/worker-sandbox/src/alarm.rs
@@ -54,8 +54,13 @@ pub async fn handle_alarm(_req: Request, env: Env, _data: SomeSharedData) -> Res
 }
 
 #[worker::send]
-pub async fn handle_id(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
-    let namespace = env.durable_object("COUNTER").expect("DAWJKHDAD");
+pub async fn handle_id(req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
+    let durable_object_name = if req.path().contains("shared") {
+        "SHARED_COUNTER"
+    } else {
+        "COUNTER"
+    };
+    let namespace = env.durable_object(durable_object_name).expect("DAWJKHDAD");
     let stub = namespace.id_from_name("A")?.get_stub()?;
     // when calling fetch to a Durable Object, a full URL must be used. Alternatively, a
     // compatibility flag can be provided in wrangler.toml to opt-in to older behavior:
@@ -72,7 +77,12 @@ pub async fn handle_put_raw(req: Request, env: Env, _data: SomeSharedData) -> Re
 }
 
 #[worker::send]
-pub async fn handle_websocket(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
+pub async fn handle_websocket(req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
+    let durable_object_name = if req.path().contains("shared") {
+        "SHARED_COUNTER"
+    } else {
+        "COUNTER"
+    };
     // Accept / handle a websocket connection
     let pair = WebSocketPair::new()?;
     let server = pair.server;
@@ -80,7 +90,7 @@ pub async fn handle_websocket(_req: Request, env: Env, _data: SomeSharedData) ->
 
     // Connect to Durable Object via WS
     let namespace = env
-        .durable_object("COUNTER")
+        .durable_object(durable_object_name)
         .expect("failed to get namespace");
     let stub = namespace.id_from_name("A")?.get_stub()?;
     let mut req = Request::new("https://fake-host/ws", Method::Get)?;

--- a/worker-sandbox/src/lib.rs
+++ b/worker-sandbox/src/lib.rs
@@ -21,6 +21,7 @@ mod r2;
 mod request;
 mod router;
 mod service;
+mod shared_counter;
 mod socket;
 mod test;
 mod user;

--- a/worker-sandbox/src/router.rs
+++ b/worker-sandbox/src/router.rs
@@ -109,6 +109,11 @@ pub fn make_router(data: SomeSharedData, env: Env) -> axum::Router {
         .route("/durable/:id", get(handler!(alarm::handle_id)))
         .route("/durable/put-raw", get(handler!(alarm::handle_put_raw)))
         .route("/durable/websocket", get(handler!(alarm::handle_websocket)))
+        .route("/durable-shared/:id", get(handler!(alarm::handle_id)))
+        .route(
+            "/durable-shared/websocket",
+            get(handler!(alarm::handle_websocket)),
+        )
         .route("/var", get(handler!(request::handle_var)))
         .route("/object-var", get(handler!(request::handle_object_var)))
         .route("/secret", get(handler!(request::handle_secret)))
@@ -277,6 +282,11 @@ pub fn make_router<'a>(data: SomeSharedData) -> Router<'a, SomeSharedData> {
         .get_async("/durable/:id", handler!(alarm::handle_id))
         .get_async("/durable/put-raw", handler!(alarm::handle_put_raw))
         .get_async("/durable/websocket", handler!(alarm::handle_websocket))
+        .get_async("/durable-shared/:id", handler!(alarm::handle_id))
+        .get_async(
+            "/durable-shared/websocket",
+            handler!(alarm::handle_websocket),
+        )
         .get_async("/secret", handler!(request::handle_secret))
         .get_async("/var", handler!(request::handle_var))
         .get_async("/object-var", handler!(request::handle_object_var))

--- a/worker-sandbox/src/shared_counter.rs
+++ b/worker-sandbox/src/shared_counter.rs
@@ -46,10 +46,8 @@ impl SharedDurableObject for SharedCounter {
         TimeoutFuture::new(1_000).await;
 
         *self.count.borrow_mut() += 15;
-        self.state
-            .storage()
-            .put("count", *self.count.borrow())
-            .await?;
+        let count = *self.count.borrow();
+        self.state.storage().put("count", count).await?;
 
         Response::ok(format!(
             "[durable_object]: self.count: {}, secret value: {}",

--- a/worker-sandbox/src/shared_counter.rs
+++ b/worker-sandbox/src/shared_counter.rs
@@ -1,0 +1,110 @@
+use gloo_timers::future::TimeoutFuture;
+use std::cell::RefCell;
+use worker::*;
+
+#[shared_durable_object]
+pub struct SharedCounter {
+    count: RefCell<usize>,
+    state: RefCell<State>,
+    initialized: RefCell<bool>,
+    env: Env,
+}
+
+#[shared_durable_object]
+impl SharedDurableObject for SharedCounter {
+    fn new(state: State, env: Env) -> Self {
+        Self {
+            count: RefCell::new(0),
+            initialized: RefCell::new(false),
+            state: RefCell::new(state),
+            env,
+        }
+    }
+
+    async fn fetch(&self, req: Request) -> Result<Response> {
+        if !*self.initialized.borrow() {
+            *self.initialized.borrow_mut() = true;
+            let count = self
+                .state
+                .borrow()
+                .storage()
+                .get("count")
+                .await
+                .unwrap_or(0);
+            *self.count.borrow_mut() = count;
+        }
+
+        if req.path().eq("/ws") {
+            let pair = WebSocketPair::new()?;
+            let server = pair.server;
+            // accept websocket with hibernation api
+            self.state.borrow().accept_web_socket(&server);
+            server
+                .serialize_attachment("hello")
+                .expect("failed to serialize attachment");
+
+            return Ok(ResponseBuilder::new()
+                .with_status(101)
+                .with_websocket(pair.client)
+                .empty());
+        }
+
+        // simulated delay, to allow testing concurrency
+        TimeoutFuture::new(1_000).await;
+
+        *self.count.borrow_mut() += 15;
+        self.state
+            .borrow()
+            .storage()
+            .put("count", *self.count.borrow())
+            .await?;
+
+        Response::ok(format!(
+            "[durable_object]: self.count: {}, secret value: {}",
+            self.count.borrow(),
+            self.env.secret("SOME_SECRET")?
+        ))
+    }
+
+    async fn websocket_message(
+        &self,
+        ws: WebSocket,
+        _message: WebSocketIncomingMessage,
+    ) -> Result<()> {
+        let _attach: String = ws
+            .deserialize_attachment()?
+            .expect("websockets should have an attachment");
+
+        // simulated delay, to allow testing concurrency
+        TimeoutFuture::new(1_000).await;
+
+        // get and increment storage by 15
+        let mut count: usize = self
+            .state
+            .borrow()
+            .storage()
+            .get("count")
+            .await
+            .unwrap_or(0);
+        count += 15;
+        self.state.borrow().storage().put("count", count).await?;
+        // send value to client
+        ws.send_with_str(format!("{}", count))
+            .expect("failed to send value to client");
+        Ok(())
+    }
+
+    async fn websocket_close(
+        &self,
+        _ws: WebSocket,
+        _code: usize,
+        _reason: String,
+        _was_clean: bool,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn websocket_error(&self, _ws: WebSocket, _error: Error) -> Result<()> {
+        Ok(())
+    }
+}

--- a/worker-sandbox/tests/mf.ts
+++ b/worker-sandbox/tests/mf.ts
@@ -58,6 +58,7 @@ export const mf = new Miniflare({
       },
       durableObjects: {
         COUNTER: "Counter",
+        SHARED_COUNTER: "SharedCounter",
         PUT_RAW_TEST_OBJECT: "PutRawTestObject",
       },
       kvNamespaces: ["SOME_NAMESPACE", "FILE_SIZES", "TEST"],

--- a/worker-sandbox/tests/request.spec.ts
+++ b/worker-sandbox/tests/request.spec.ts
@@ -108,7 +108,7 @@ test("fetch json", async () => {
 
 test("proxy request", async () => {
   const resp = await mf.dispatchFetch(
-    "https://fake.host/proxy_request/https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding/contributors.txt"
+    "https://fake.host/proxy_request/https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding/contributors.txt"
   );
   expect(resp.status).toBe(200);
 });

--- a/worker-sandbox/wrangler.toml
+++ b/worker-sandbox/wrangler.toml
@@ -27,6 +27,7 @@ remote-service = "./remote-service"
 [durable_objects]
 bindings = [
     { name = "COUNTER", class_name = "Counter" },
+    { name = "SHARED_COUNTER", class_name = "SharedCounter" },
     { name = "ALARM", class_name = "AlarmObject" },
     { name = "PUT_RAW_TEST_OBJECT", class_name = "PutRawTestObject" },
 ]

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -846,3 +846,40 @@ pub trait DurableObject {
         unimplemented!("websocket_error() handler not implemented")
     }
 }
+
+#[async_trait(?Send)]
+pub trait SharedDurableObject {
+    fn new(state: State, env: Env) -> Self;
+
+    async fn fetch(&self, req: Request) -> Result<Response>;
+
+    #[allow(clippy::diverging_sub_expression)]
+    async fn alarm(&self) -> Result<Response> {
+        unimplemented!("alarm() handler not implemented")
+    }
+
+    #[allow(unused_variables, clippy::diverging_sub_expression)]
+    async fn websocket_message(
+        &self,
+        ws: WebSocket,
+        message: WebSocketIncomingMessage,
+    ) -> Result<()> {
+        unimplemented!("websocket_message() handler not implemented")
+    }
+
+    #[allow(unused_variables, clippy::diverging_sub_expression)]
+    async fn websocket_close(
+        &self,
+        ws: WebSocket,
+        code: usize,
+        reason: String,
+        was_clean: bool,
+    ) -> Result<()> {
+        unimplemented!("websocket_close() handler not implemented")
+    }
+
+    #[allow(unused_variables, clippy::diverging_sub_expression)]
+    async fn websocket_error(&self, ws: WebSocket, error: Error) -> Result<()> {
+        unimplemented!("websocket_error() handler not implemented")
+    }
+}

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -157,7 +157,7 @@ pub use wasm_bindgen_futures;
 pub use worker_kv as kv;
 
 pub use cf::{Cf, CfResponseProperties, TlsClientAuth};
-pub use worker_macros::{durable_object, event, send};
+pub use worker_macros::{durable_object, event, send, shared_durable_object};
 #[doc(hidden)]
 pub use worker_sys;
 pub use worker_sys::{console_debug, console_error, console_log, console_warn};

--- a/worker/src/socket.rs
+++ b/worker/src/socket.rs
@@ -1,6 +1,5 @@
 use std::{
     convert::TryFrom,
-    io::ErrorKind,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -150,7 +149,7 @@ fn js_value_to_std_io_error(value: JsValue) -> IoError {
     } else {
         format!("Error interpreting JsError: {:?}", value)
     };
-    IoError::new(ErrorKind::Other, s)
+    IoError::other(s)
 }
 impl AsyncRead for Socket {
     fn poll_read(
@@ -173,10 +172,7 @@ impl AsyncRead for Socket {
                             Ok(value) => value.into(),
                             Err(error) => {
                                 let msg = format!("Unable to interpret field 'done' in ReadableStreamDefaultReader.read(): {:?}", error);
-                                return (
-                                    Reading::None,
-                                    Poll::Ready(Err(IoError::new(ErrorKind::Other, msg))),
-                                );
+                                return (Reading::None, Poll::Ready(Err(IoError::other(msg))));
                             }
                         };
                         if done.is_truthy() {
@@ -189,10 +185,7 @@ impl AsyncRead for Socket {
                                 Ok(value) => value.into(),
                                 Err(error) => {
                                     let msg = format!("Unable to interpret field 'value' in ReadableStreamDefaultReader.read(): {:?}", error);
-                                    return (
-                                        Reading::None,
-                                        Poll::Ready(Err(IoError::new(ErrorKind::Other, msg))),
-                                    );
+                                    return (Reading::None, Poll::Ready(Err(IoError::other(msg))));
                                 }
                             };
                             let data = arr.to_vec();
@@ -214,7 +207,7 @@ impl AsyncRead for Socket {
                                 "Unable to cast JsObject to ReadableStreamDefaultReader: {:?}",
                                 error
                             );
-                            return Poll::Ready(Err(IoError::new(ErrorKind::Other, msg)));
+                            return Poll::Ready(Err(IoError::other(msg)));
                         }
                     };
 
@@ -241,7 +234,7 @@ impl AsyncWrite for Socket {
                     Ok(writer) => writer,
                     Err(error) => {
                         let msg = format!("Could not retrieve Writer: {:?}", error);
-                        return Poll::Ready(Err(IoError::new(ErrorKind::Other, msg)));
+                        return Poll::Ready(Err(IoError::other(msg)));
                     }
                 };
                 Self::handle_write_future(


### PR DESCRIPTION
This provides a possible implementation for a `SharedDurableObject` trait which does not implement the `&mut self` pattern but instead implements `&self` to allow multiple concurrent borrowers.

This then pushes the concurrency problem for durable object access down into field cells, where any standard Rust techniques can then be used to manage mutable field access - `Mutex` / `RwLock` / `RefCell` etc.

The test here uses the `RefCell` approach for mutable fields, where so long as mutable borrows are not held over async points there will never be a panic.

While formally we are single threaded, blanket turning off concurrency checks on mutable access may have implications for undefined Rust compiler behaviours. So instead this approach aligns with Rust conventions, even though threaded code is not in play.

I think these idioms should be perfectly comfortable to Rust devs (far more than relaxing mutable behaviours), even if they don't fully apply in this single threaded JS embedding environment it remains closer to the proper way of doing things without much ergonomic cost.