### PR TITLE
Adding support for http report method

### DIFF
--- a/worker/src/http.rs
+++ b/worker/src/http.rs
@@ -25,6 +25,7 @@ pub enum Method {
     Options,
     Connect,
     Trace,
+    Report,
 }
 
 impl Method {
@@ -39,6 +40,7 @@ impl Method {
             Method::Options,
             Method::Connect,
             Method::Trace,
+            Method::Report,
         ]
     }
 }
@@ -54,6 +56,7 @@ impl From<String> for Method {
             "OPTIONS" => Method::Options,
             "CONNECT" => Method::Connect,
             "TRACE" => Method::Trace,
+            "REPORT" => Method::Report,
             _ => Method::Get,
         }
     }
@@ -77,6 +80,7 @@ impl AsRef<str> for Method {
             Method::Connect => "CONNECT",
             Method::Trace => "TRACE",
             Method::Get => "GET",
+            Method::Report => "REPORT",
         }
     }
 }

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -173,6 +173,12 @@ impl<'a, D: 'a> Router<'a, D> {
         self
     }
 
+    /// Register an HTTP handler that will exclusively respond to REPORT requests.
+    pub fn report(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
+        self.add_handler(pattern, Handler::Sync(func), vec![Method::Report]);
+        self
+    }
+
     /// Register an HTTP handler that will respond to any requests.
     pub fn on(mut self, pattern: &str, func: HandlerFn<D>) -> Self {
         self.add_handler(pattern, Handler::Sync(func), Method::all());


### PR DESCRIPTION
We support `REPORT` requests for a subset of our requests.

Currently if a `REPORT` request is sent to the worker, the method returned is `GET` because it is the default and creating a subrequest throws an error.

In this PR we are merely adding a new tag to support `REPORT` http request to help us move forward with supporting REPORT requests sent to our worker. 