### PR TITLE
Breaking Change: Use non-mutable methods for DurableObject, FormData, Headers & Response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4021,6 +4033,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "getrandom 0.3.3",
+ "gloo-timers",
  "hex",
  "http",
  "md5",

--- a/worker-sandbox/Cargo.toml
+++ b/worker-sandbox/Cargo.toml
@@ -33,6 +33,7 @@ chrono = { version = "0.4", default-features = false, features = [
 cfg-if = "1.0"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 getrandom = { version = "0.3", features = ["wasm_js"] }
+gloo-timers = { version = "0.3.0", features = ["futures"] }
 hex = "0.4"
 http.workspace = true
 regex = "1.8.4"

--- a/worker-sandbox/src/alarm.rs
+++ b/worker-sandbox/src/alarm.rs
@@ -16,7 +16,7 @@ impl DurableObject for AlarmObject {
         Self { state }
     }
 
-    async fn fetch(&mut self, _: Request) -> Result<Response> {
+    async fn fetch(&self, _: Request) -> Result<Response> {
         let alarmed: bool = match self.state.storage().get("alarmed").await {
             Ok(alarmed) => alarmed,
             Err(e) if e.to_string() == "No such value in storage." => {
@@ -34,7 +34,7 @@ impl DurableObject for AlarmObject {
         Response::ok(alarmed.to_string())
     }
 
-    async fn alarm(&mut self) -> Result<Response> {
+    async fn alarm(&self) -> Result<Response> {
         self.state.storage().put("alarmed", true).await?;
 
         console_log!("Alarm has been triggered!");
@@ -54,8 +54,13 @@ pub async fn handle_alarm(_req: Request, env: Env, _data: SomeSharedData) -> Res
 }
 
 #[worker::send]
-pub async fn handle_id(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
-    let namespace = env.durable_object("COUNTER").expect("DAWJKHDAD");
+pub async fn handle_id(req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
+    let durable_object_name = if req.path().contains("shared") {
+        "SHARED_COUNTER"
+    } else {
+        "COUNTER"
+    };
+    let namespace = env.durable_object(durable_object_name).expect("DAWJKHDAD");
     let stub = namespace.id_from_name("A")?.get_stub()?;
     // when calling fetch to a Durable Object, a full URL must be used. Alternatively, a
     // compatibility flag can be provided in wrangler.toml to opt-in to older behavior:
@@ -72,7 +77,12 @@ pub async fn handle_put_raw(req: Request, env: Env, _data: SomeSharedData) -> Re
 }
 
 #[worker::send]
-pub async fn handle_websocket(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
+pub async fn handle_websocket(req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
+    let durable_object_name = if req.path().contains("shared") {
+        "SHARED_COUNTER"
+    } else {
+        "COUNTER"
+    };
     // Accept / handle a websocket connection
     let pair = WebSocketPair::new()?;
     let server = pair.server;
@@ -80,7 +90,7 @@ pub async fn handle_websocket(_req: Request, env: Env, _data: SomeSharedData) ->
 
     // Connect to Durable Object via WS
     let namespace = env
-        .durable_object("COUNTER")
+        .durable_object(durable_object_name)
         .expect("failed to get namespace");
     let stub = namespace.id_from_name("A")?.get_stub()?;
     let mut req = Request::new("https://fake-host/ws", Method::Get)?;

--- a/worker-sandbox/src/counter.rs
+++ b/worker-sandbox/src/counter.rs
@@ -43,10 +43,8 @@ impl DurableObject for Counter {
         }
 
         *self.count.borrow_mut() += 10;
-        self.state
-            .storage()
-            .put("count", *self.count.borrow())
-            .await?;
+        let count = *self.count.borrow();
+        self.state.storage().put("count", count).await?;
 
         Response::ok(format!(
             "[durable_object]: self.count: {}, secret value: {}",

--- a/worker-sandbox/src/counter.rs
+++ b/worker-sandbox/src/counter.rs
@@ -1,10 +1,12 @@
+use std::cell::RefCell;
+
 use worker::*;
 
 #[durable_object]
 pub struct Counter {
-    count: usize,
+    count: RefCell<usize>,
     state: State,
-    initialized: bool,
+    initialized: RefCell<bool>,
     env: Env,
 }
 
@@ -12,17 +14,17 @@ pub struct Counter {
 impl DurableObject for Counter {
     fn new(state: State, env: Env) -> Self {
         Self {
-            count: 0,
-            initialized: false,
+            count: RefCell::new(0),
+            initialized: RefCell::new(false),
             state,
             env,
         }
     }
 
-    async fn fetch(&mut self, req: Request) -> Result<Response> {
-        if !self.initialized {
-            self.initialized = true;
-            self.count = self.state.storage().get("count").await.unwrap_or(0);
+    async fn fetch(&self, req: Request) -> Result<Response> {
+        if !*self.initialized.borrow() {
+            *self.initialized.borrow_mut() = true;
+            *self.count.borrow_mut() = self.state.storage().get("count").await.unwrap_or(0);
         }
 
         if req.path().eq("/ws") {
@@ -40,18 +42,21 @@ impl DurableObject for Counter {
                 .empty());
         }
 
-        self.count += 10;
-        self.state.storage().put("count", self.count).await?;
+        *self.count.borrow_mut() += 10;
+        self.state
+            .storage()
+            .put("count", *self.count.borrow())
+            .await?;
 
         Response::ok(format!(
             "[durable_object]: self.count: {}, secret value: {}",
-            self.count,
+            self.count.borrow(),
             self.env.secret("SOME_SECRET")?
         ))
     }
 
     async fn websocket_message(
-        &mut self,
+        &self,
         ws: WebSocket,
         _message: WebSocketIncomingMessage,
     ) -> Result<()> {
@@ -69,7 +74,7 @@ impl DurableObject for Counter {
     }
 
     async fn websocket_close(
-        &mut self,
+        &self,
         _ws: WebSocket,
         _code: usize,
         _reason: String,
@@ -78,7 +83,7 @@ impl DurableObject for Counter {
         Ok(())
     }
 
-    async fn websocket_error(&mut self, _ws: WebSocket, _error: Error) -> Result<()> {
+    async fn websocket_error(&self, _ws: WebSocket, _error: Error) -> Result<()> {
         Ok(())
     }
 }

--- a/worker-sandbox/src/test/export_durable_object.rs
+++ b/worker-sandbox/src/test/export_durable_object.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::collections::HashMap;
+use std::{cell::RefCell, collections::HashMap};
 
 use worker::{js_sys::Uint8Array, wasm_bindgen::JsValue, *};
 
@@ -8,21 +8,24 @@ use crate::ensure;
 #[durable_object]
 pub struct MyClass {
     state: State,
-    number: usize,
+    number: RefCell<usize>,
 }
 
 #[durable_object]
 impl DurableObject for MyClass {
     fn new(state: State, _env: Env) -> Self {
-        Self { state, number: 0 }
+        Self {
+            state,
+            number: RefCell::new(0),
+        }
     }
 
-    async fn fetch(&mut self, req: Request) -> Result<Response> {
+    async fn fetch(&self, req: Request) -> Result<Response> {
         let handler = async move {
             match req.path().as_str() {
                 "/hello" => Response::ok("Hello!"),
                 "/storage" => {
-                    let mut storage = self.state.storage();
+                    let storage = self.state.storage();
                     let map = [("one".to_string(), 1), ("two".to_string(), 2)]
                         .iter()
                         .cloned()
@@ -116,12 +119,13 @@ impl DurableObject for MyClass {
                         );
                     }
 
-                    self.number = storage.get("count").await.unwrap_or(0) + 1;
+                    *self.number.borrow_mut() = storage.get("count").await.unwrap_or(0) + 1;
 
                     storage.delete_all().await?;
 
-                    storage.put("count", self.number).await?;
-                    Response::ok(self.number.to_string())
+                    let count = *self.number.borrow();
+                    storage.put("count", count).await?;
+                    Response::ok(self.number.borrow().to_string())
                 }
                 "/transaction" => {
                     Response::error("transactional storage API is still unstable", 501)

--- a/worker-sandbox/src/test/put_raw.rs
+++ b/worker-sandbox/src/test/put_raw.rs
@@ -6,8 +6,8 @@ pub struct PutRawTestObject {
 }
 
 impl PutRawTestObject {
-    async fn put_raw(&mut self) -> Result<()> {
-        let mut storage = self.state.storage();
+    async fn put_raw(&self) -> Result<()> {
+        let storage = self.state.storage();
         let bytes = Uint8Array::new_with_length(3);
         bytes.copy_from(b"123");
         storage.put_raw("bytes", bytes).await?;
@@ -20,8 +20,8 @@ impl PutRawTestObject {
         Ok(())
     }
 
-    async fn put_multiple_raw(&mut self) -> Result<()> {
-        let mut storage = self.state.storage();
+    async fn put_multiple_raw(&self) -> Result<()> {
+        let storage = self.state.storage();
         let obj = js_sys::Object::new();
         const BAR: &[u8] = b"bar";
         let value = Uint8Array::new_with_length(BAR.len() as _);
@@ -45,7 +45,7 @@ impl DurableObject for PutRawTestObject {
         Self { state }
     }
 
-    async fn fetch(&mut self, _: Request) -> Result<Response> {
+    async fn fetch(&self, _: Request) -> Result<Response> {
         self.put_raw().await?;
         self.put_multiple_raw().await?;
 

--- a/worker-sandbox/tests/durable.spec.ts
+++ b/worker-sandbox/tests/durable.spec.ts
@@ -43,4 +43,3 @@ describe("durable", () => {
     expect(closeHandlerWrapper).toBeCalled();
   });
 });
-

--- a/worker-sandbox/tests/mf.ts
+++ b/worker-sandbox/tests/mf.ts
@@ -58,6 +58,7 @@ export const mf = new Miniflare({
       },
       durableObjects: {
         COUNTER: "Counter",
+        SHARED_COUNTER: "SharedCounter",
         PUT_RAW_TEST_OBJECT: "PutRawTestObject",
       },
       kvNamespaces: ["SOME_NAMESPACE", "FILE_SIZES", "TEST"],

--- a/worker-sandbox/wrangler.toml
+++ b/worker-sandbox/wrangler.toml
@@ -27,6 +27,7 @@ remote-service = "./remote-service"
 [durable_objects]
 bindings = [
     { name = "COUNTER", class_name = "Counter" },
+    { name = "SHARED_COUNTER", class_name = "SharedCounter" },
     { name = "ALARM", class_name = "AlarmObject" },
     { name = "PUT_RAW_TEST_OBJECT", class_name = "PutRawTestObject" },
 ]

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -481,7 +481,7 @@ impl Storage {
         fut.await.map(|_| ()).map_err(Error::from)
     }
 
-    pub async fn transaction<F, Fut>(&mut self, mut closure: F) -> Result<()>
+    pub async fn transaction<F, Fut>(&self, mut closure: F) -> Result<()>
     where
         F: FnMut(Transaction) -> Fut + Copy + 'static,
         Fut: Future<Output = Result<()>> + 'static,
@@ -600,7 +600,7 @@ impl Transaction {
             .map_err(Error::from)
     }
 
-    pub fn rollback(&mut self) -> Result<()> {
+    pub fn rollback(&self) -> Result<()> {
         self.inner.rollback().map_err(Error::from)
     }
 }

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -309,12 +309,12 @@ impl Storage {
     }
 
     /// Stores the value and associates it with the given key.
-    pub async fn put<T: Serialize>(&mut self, key: &str, value: T) -> Result<()> {
+    pub async fn put<T: Serialize>(&self, key: &str, value: T) -> Result<()> {
         self.put_raw(key, serde_wasm_bindgen::to_value(&value)?)
             .await
     }
 
-    pub async fn put_raw(&mut self, key: &str, value: impl Into<JsValue>) -> Result<()> {
+    pub async fn put_raw(&self, key: &str, value: impl Into<JsValue>) -> Result<()> {
         JsFuture::from(self.inner.put(key, value.into())?)
             .await
             .map_err(Error::from)
@@ -322,7 +322,7 @@ impl Storage {
     }
 
     /// Takes a serializable struct and stores each of its keys and values to storage.
-    pub async fn put_multiple<T: Serialize>(&mut self, values: T) -> Result<()> {
+    pub async fn put_multiple<T: Serialize>(&self, values: T) -> Result<()> {
         let values = serde_wasm_bindgen::to_value(&values)?;
         if !values.is_object() {
             return Err("Must pass in a struct type".to_string().into());
@@ -343,7 +343,7 @@ impl Storage {
     ///
     /// storage.put_multiple_raw(obj);
     /// ```
-    pub async fn put_multiple_raw(&mut self, values: Object) -> Result<()> {
+    pub async fn put_multiple_raw(&self, values: Object) -> Result<()> {
         JsFuture::from(self.inner.put_multiple(values.into())?)
             .await
             .map_err(Error::from)
@@ -351,7 +351,7 @@ impl Storage {
     }
 
     /// Deletes the key and associated value. Returns true if the key existed or false if it didn't.
-    pub async fn delete(&mut self, key: &str) -> Result<bool> {
+    pub async fn delete(&self, key: &str) -> Result<bool> {
         let fut: JsFuture = self.inner.delete(key)?.into();
         fut.await
             .and_then(|jsv| {
@@ -363,7 +363,7 @@ impl Storage {
 
     /// Deletes the provided keys and their associated values. Returns a count of the number of
     /// key-value pairs deleted.
-    pub async fn delete_multiple(&mut self, keys: Vec<impl Deref<Target = str>>) -> Result<usize> {
+    pub async fn delete_multiple(&self, keys: Vec<impl Deref<Target = str>>) -> Result<usize> {
         let fut: JsFuture = self
             .inner
             .delete_multiple(
@@ -384,7 +384,7 @@ impl Storage {
     /// Deletes all keys and associated values, effectively deallocating all storage used by the
     /// Durable Object. In the event of a failure while the operation is still in flight, it may be
     /// that only a subset of the data is properly deleted.
-    pub async fn delete_all(&mut self) -> Result<()> {
+    pub async fn delete_all(&self) -> Result<()> {
         let fut: JsFuture = self.inner.delete_all()?.into();
         fut.await.map(|_| ()).map_err(Error::from)
     }
@@ -531,7 +531,7 @@ impl Transaction {
         keys.dyn_into::<Map>().map_err(Error::from)
     }
 
-    pub async fn put<T: Serialize>(&mut self, key: &str, value: T) -> Result<()> {
+    pub async fn put<T: Serialize>(&self, key: &str, value: T) -> Result<()> {
         JsFuture::from(self.inner.put(key, serde_wasm_bindgen::to_value(&value)?)?)
             .await
             .map_err(Error::from)
@@ -539,7 +539,7 @@ impl Transaction {
     }
 
     // Each key-value pair in the serialized object will be added to the storage
-    pub async fn put_multiple<T: Serialize>(&mut self, values: T) -> Result<()> {
+    pub async fn put_multiple<T: Serialize>(&self, values: T) -> Result<()> {
         let values = serde_wasm_bindgen::to_value(&values)?;
         if !values.is_object() {
             return Err("Must pass in a struct type".to_string().into());
@@ -550,7 +550,7 @@ impl Transaction {
             .map(|_| ())
     }
 
-    pub async fn delete(&mut self, key: &str) -> Result<bool> {
+    pub async fn delete(&self, key: &str) -> Result<bool> {
         let fut: JsFuture = self.inner.delete(key)?.into();
         fut.await
             .and_then(|jsv| {
@@ -560,7 +560,7 @@ impl Transaction {
             .map_err(Error::from)
     }
 
-    pub async fn delete_multiple(&mut self, keys: Vec<impl Deref<Target = str>>) -> Result<usize> {
+    pub async fn delete_multiple(&self, keys: Vec<impl Deref<Target = str>>) -> Result<usize> {
         let fut: JsFuture = self
             .inner
             .delete_multiple(
@@ -578,7 +578,7 @@ impl Transaction {
             .map_err(Error::from)
     }
 
-    pub async fn delete_all(&mut self) -> Result<()> {
+    pub async fn delete_all(&self) -> Result<()> {
         let fut: JsFuture = self.inner.delete_all()?.into();
         fut.await.map(|_| ()).map_err(Error::from)
     }
@@ -802,7 +802,7 @@ impl DurableObject for Chatroom {
         }
     }
 
-    async fn fetch(&mut self, _req: Request) -> Result<Response> {
+    async fn fetch(&self, _req: Request) -> Result<Response> {
         // do some work when a worker makes a request to this DO
         Response::ok(&format!("{} active users.", self.users.len()))
     }
@@ -814,16 +814,16 @@ impl DurableObject for Chatroom {
 pub trait DurableObject {
     fn new(state: State, env: Env) -> Self;
 
-    async fn fetch(&mut self, req: Request) -> Result<Response>;
+    async fn fetch(&self, req: Request) -> Result<Response>;
 
     #[allow(clippy::diverging_sub_expression)]
-    async fn alarm(&mut self) -> Result<Response> {
+    async fn alarm(&self) -> Result<Response> {
         unimplemented!("alarm() handler not implemented")
     }
 
     #[allow(unused_variables, clippy::diverging_sub_expression)]
     async fn websocket_message(
-        &mut self,
+        &self,
         ws: WebSocket,
         message: WebSocketIncomingMessage,
     ) -> Result<()> {
@@ -832,7 +832,7 @@ pub trait DurableObject {
 
     #[allow(unused_variables, clippy::diverging_sub_expression)]
     async fn websocket_close(
-        &mut self,
+        &self,
         ws: WebSocket,
         code: usize,
         reason: String,
@@ -842,7 +842,7 @@ pub trait DurableObject {
     }
 
     #[allow(unused_variables, clippy::diverging_sub_expression)]
-    async fn websocket_error(&mut self, ws: WebSocket, error: Error) -> Result<()> {
+    async fn websocket_error(&self, ws: WebSocket, error: Error) -> Result<()> {
         unimplemented!("websocket_error() handler not implemented")
     }
 }

--- a/worker/src/formdata.rs
+++ b/worker/src/formdata.rs
@@ -95,18 +95,18 @@ impl FormData {
 
     /// Appends a new value onto an existing key inside a `FormData` object, or adds the key if it
     /// does not already exist.
-    pub fn append(&mut self, name: &str, value: &str) -> Result<()> {
+    pub fn append(&self, name: &str, value: &str) -> Result<()> {
         self.0.append_with_str(name, value).map_err(Error::from)
     }
 
     /// Sets a new value for an existing key inside a `FormData` object, or adds the key/value if it
     /// does not already exist.
-    pub fn set(&mut self, name: &str, value: &str) -> Result<()> {
+    pub fn set(&self, name: &str, value: &str) -> Result<()> {
         self.0.set_with_str(name, value).map_err(Error::from)
     }
 
     /// Deletes a key/value pair from a `FormData` object.
-    pub fn delete(&mut self, name: &str) {
+    pub fn delete(&self, name: &str) {
         self.0.delete(name)
     }
 }
@@ -119,7 +119,7 @@ impl From<JsValue> for FormData {
 
 impl From<HashMap<&dyn AsRef<&str>, &dyn AsRef<&str>>> for FormData {
     fn from(m: HashMap<&dyn AsRef<&str>, &dyn AsRef<&str>>) -> Self {
-        let mut formdata = FormData::new();
+        let formdata = FormData::new();
         for (k, v) in m {
             // TODO: determine error case and consider how to handle
             formdata.set(k.as_ref(), v.as_ref()).unwrap();

--- a/worker/src/headers.rs
+++ b/worker/src/headers.rs
@@ -44,20 +44,20 @@ impl Headers {
     }
 
     /// Returns an error if the name is invalid (e.g. contains spaces)
-    pub fn append(&mut self, name: &str, value: &str) -> Result<()> {
+    pub fn append(&self, name: &str, value: &str) -> Result<()> {
         self.0.append(name, value).map_err(Error::from)
     }
 
     /// Sets a new value for an existing header inside a `Headers` object, or adds the header if it does not already exist.
     /// Returns an error if the name is invalid (e.g. contains spaces)
-    pub fn set(&mut self, name: &str, value: &str) -> Result<()> {
+    pub fn set(&self, name: &str, value: &str) -> Result<()> {
         self.0.set(name, value).map_err(Error::from)
     }
 
     /// Deletes a header from a `Headers` object.
     /// Returns an error if the name is invalid (e.g. contains spaces)
     /// or if the JS Headers object's guard is immutable (e.g. for an incoming request)
-    pub fn delete(&mut self, name: &str) -> Result<()> {
+    pub fn delete(&self, name: &str) -> Result<()> {
         self.0.delete(name).map_err(Error::from)
     }
 
@@ -127,7 +127,7 @@ impl IntoIterator for &Headers {
 
 impl<T: AsRef<str>> FromIterator<(T, T)> for Headers {
     fn from_iter<U: IntoIterator<Item = (T, T)>>(iter: U) -> Self {
-        let mut headers = Headers::new();
+        let headers = Headers::new();
         iter.into_iter().for_each(|(name, value)| {
             headers.append(name.as_ref(), value.as_ref()).ok();
         });
@@ -137,7 +137,7 @@ impl<T: AsRef<str>> FromIterator<(T, T)> for Headers {
 
 impl<'a, T: AsRef<str>> FromIterator<&'a (T, T)> for Headers {
     fn from_iter<U: IntoIterator<Item = &'a (T, T)>>(iter: U) -> Self {
-        let mut headers = Headers::new();
+        let headers = Headers::new();
         iter.into_iter().for_each(|(name, value)| {
             headers.append(name.as_ref(), value.as_ref()).ok();
         });

--- a/worker/src/response.rs
+++ b/worker/src/response.rs
@@ -376,7 +376,7 @@ impl ResponseBuilder {
     }
 
     /// Set a single header on this response.
-    pub fn with_header(mut self, key: &str, value: &str) -> Result<Self> {
+    pub fn with_header(self, key: &str, value: &str) -> Result<Self> {
         self.headers.set(key, value)?;
         Ok(self)
     }
@@ -458,7 +458,7 @@ impl ResponseBuilder {
 
     /// Create a `Response` using `B` as the body encoded as JSON. Sets the associated
     /// `Content-Type` header for the `Response` as `application/json`.
-    pub fn from_json<B: Serialize>(mut self, value: &B) -> Result<Response> {
+    pub fn from_json<B: Serialize>(self, value: &B) -> Result<Response> {
         if let Ok(data) = serde_json::to_string(value) {
             self.headers.set(CONTENT_TYPE, "application/json")?;
             Ok(self.fixed(data.into_bytes()))
@@ -469,7 +469,7 @@ impl ResponseBuilder {
 
     /// Create a `Response` using the body encoded as HTML. Sets the associated `Content-Type`
     /// header for the `Response` as `text/html; charset=utf-8`.
-    pub fn from_html(mut self, html: impl AsRef<str>) -> Result<Response> {
+    pub fn from_html(self, html: impl AsRef<str>) -> Result<Response> {
         self.headers.set(CONTENT_TYPE, "text/html; charset=utf-8")?;
         let data = html.as_ref().as_bytes().to_vec();
         Ok(self.fixed(data))
@@ -477,7 +477,7 @@ impl ResponseBuilder {
 
     /// Create a `Response` using unprocessed bytes provided. Sets the associated `Content-Type`
     /// header for the `Response` as `application/octet-stream`.
-    pub fn from_bytes(mut self, bytes: Vec<u8>) -> Result<Response> {
+    pub fn from_bytes(self, bytes: Vec<u8>) -> Result<Response> {
         self.headers.set(CONTENT_TYPE, "application/octet-stream")?;
         Ok(self.fixed(bytes))
     }
@@ -510,7 +510,7 @@ impl ResponseBuilder {
 
     /// Create a `Response` using unprocessed text provided. Sets the associated `Content-Type`
     /// header for the `Response` as `text/plain; charset=utf-8`.
-    pub fn ok(mut self, body: impl Into<String>) -> Result<Response> {
+    pub fn ok(self, body: impl Into<String>) -> Result<Response> {
         self.headers
             .set(CONTENT_TYPE, "text/plain; charset=utf-8")?;
 


### PR DESCRIPTION
This updates to `&self` over `&mut self` references where possible, as a breaking alternative to https://github.com/cloudflare/workers-rs/pull/737.

This then correctly allows concurrent calls to methods, while retaining safe Rust semantics.

Durable object code will need to be updated to work with this new implementation shape - in particular using standard Rust cell idioms to protect mutable data fields on the durable object.