### PR TITLE
feat: auto-import DurableObject when using durable_object macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ To define a Durable Object using the `worker` crate you need to implement the `D
 on your own struct. Additionally, the `#[durable_object]` attribute macro must be applied to the struct definition.
 
 ```rust
-use worker::*;
+use worker::{durable_object, State, Env, Result, Request, Response};
 
 #[durable_object]
 pub struct Chatroom {
@@ -274,7 +274,7 @@ new_classes = ["Chatroom"] # Array of new classes
 Durable Objects can use SQLite for persistent storage, providing a relational database interface. To enable SQLite storage, you need to use `new_sqlite_classes` in your migration and access the SQL storage through `state.storage().sql()`.
 
 ```rust
-use worker::*;
+use worker::{durable_object, State, Env, Result, Request, Response, SqlStorage};
 
 #[durable_object]
 pub struct SqlCounter {

--- a/worker-macros/src/durable_object.rs
+++ b/worker-macros/src/durable_object.rs
@@ -184,6 +184,9 @@ pub fn expand_macro(attr: TokenStream, tokens: TokenStream) -> syn::Result<Token
     Ok(quote! {
         #target
 
+        #[allow(unused_imports)]
+        use ::worker::DurableObject;
+
         impl ::worker::has_durable_object_attribute for #target_name {}
 
         const _: () = {

--- a/worker-sandbox/src/test/auto_response.rs
+++ b/worker-sandbox/src/test/auto_response.rs
@@ -1,4 +1,4 @@
-use worker::*;
+use worker::{durable_object, Env, Request, Response, Result, State, WebSocketRequestResponsePair};
 
 #[durable_object]
 pub struct AutoResponseObject {

--- a/worker-sandbox/src/test/export_durable_object.rs
+++ b/worker-sandbox/src/test/export_durable_object.rs
@@ -1,7 +1,10 @@
 use serde::Serialize;
 use std::{cell::RefCell, collections::HashMap};
 
-use worker::{js_sys::Uint8Array, wasm_bindgen::JsValue, *};
+use worker::{
+    durable_object, js_sys, js_sys::Uint8Array, wasm_bindgen::JsValue, Env, Request, Response,
+    Result, State,
+};
 
 use crate::ensure;
 


### PR DESCRIPTION
As a follow-on to https://github.com/cloudflare/workers-rs/commit/f21e19ea4e92acc2ed15a5f0cceb51c109909af4 this automatically brings the `DurableObject` trait into scope when using the `durable_object` macro.