### PR TITLE
chore: bump worker-kv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "worker-kv"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "fs_extra",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ wasm-bindgen-test = "0.3.50"
 worker = { path = "worker", version = "0.6.0", features = ["queue", "d1", "axum", "timezone"] }
 worker-build = { path = "worker-build", version = "0.1.3" }
 worker-codegen = { path = "worker-codegen", version = "0.1.1" }
-worker-kv = { path = "worker-kv", version = "0.7.0" }
+worker-kv = { path = "worker-kv", version = "0.9.0" }
 worker-macros = { path = "worker-macros", version = "0.6.0", features = ["queue"] }
 worker-sys = { path = "worker-sys", version = "0.6.0", features = ["d1", "queue"] }
 

--- a/worker-kv/Cargo.toml
+++ b/worker-kv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worker-kv"
-version = "0.7.0"
+version = "0.9.0"
 authors = ["Zeb Piasecki <zeb@zebulon.dev>"]
 edition = "2018"
 description = "Rust bindings to Cloudflare Worker KV Stores."


### PR DESCRIPTION
Bumps worker-kv due to major dependency updates not detected by the release PR workflow.