### PR TITLE
feat: implement Debug trait for various structs across the codebase

### DIFF
--- a/worker-sys/src/types/crypto.rs
+++ b/worker-sys/src/types/crypto.rs
@@ -5,6 +5,7 @@ use web_sys::WritableStream;
 extern "C" {
     /// Bindings for the non-standard [crypto.DigestStream](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#constructors) API
     #[wasm_bindgen(extends = WritableStream)]
+    #[derive(Debug)]
     pub type DigestStream;
 
     #[wasm_bindgen(constructor, js_namespace = crypto)]

--- a/worker-sys/src/types/durable_object.rs
+++ b/worker-sys/src/types/durable_object.rs
@@ -17,7 +17,7 @@ pub use transaction::*;
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(extends=js_sys::Object)]
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub type DurableObject;
 
     #[wasm_bindgen(method, catch, js_name=fetch)]

--- a/worker-sys/src/types/durable_object/id.rs
+++ b/worker-sys/src/types/durable_object/id.rs
@@ -14,3 +14,11 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn name(this: &DurableObjectId) -> Option<String>;
 }
+
+impl std::fmt::Debug for DurableObjectId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DurableObjectId")
+            .field("name", &self.name())
+            .finish()
+    }
+}

--- a/worker-sys/src/types/durable_object/namespace.rs
+++ b/worker-sys/src/types/durable_object/namespace.rs
@@ -5,7 +5,7 @@ use crate::types::{DurableObject, DurableObjectId};
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(extends=js_sys::Object)]
-    #[derive(Clone)]
+    #[derive(Debug, Clone)]
     pub type DurableObjectNamespace;
 
     #[wasm_bindgen(method, catch, js_name=idFromName)]

--- a/worker-sys/src/types/durable_object/state.rs
+++ b/worker-sys/src/types/durable_object/state.rs
@@ -55,3 +55,11 @@ extern "C" {
         this: &DurableObjectState,
     ) -> Result<Option<WebSocketRequestResponsePair>, JsValue>;
 }
+
+impl core::fmt::Debug for DurableObjectState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DurableObjectState")
+            .field("id", &self.id())
+            .finish()
+    }
+}

--- a/worker-sys/src/types/durable_object/transaction.rs
+++ b/worker-sys/src/types/durable_object/transaction.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(extends=js_sys::Object)]
+    #[derive(Debug)]
     pub type DurableObjectTransaction;
 
     #[wasm_bindgen(method, catch)]

--- a/worker-sys/src/types/hyperdrive.rs
+++ b/worker-sys/src/types/hyperdrive.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(extends=js_sys::Object)]
-    #[derive(Clone, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub type Hyperdrive;
 
     #[wasm_bindgen(method, getter, js_name=connectionString)]

--- a/worker-sys/src/types/rate_limit.rs
+++ b/worker-sys/src/types/rate_limit.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::JsValue;
 #[wasm_bindgen::prelude::wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(extends=js_sys::Object)]
-    #[derive(Clone, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub type RateLimiter;
 
     #[wasm_bindgen(method, catch)]

--- a/worker-sys/src/types/version.rs
+++ b/worker-sys/src/types/version.rs
@@ -16,3 +16,13 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name=timestamp)]
     pub fn timestamp(this: &CfVersionMetadata) -> String;
 }
+
+impl core::fmt::Debug for CfVersionMetadata {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CfVersionMetadata")
+            .field("id", &self.id())
+            .field("tag", &self.tag())
+            .field("timestamp", &self.timestamp())
+            .finish()
+    }
+}

--- a/worker/src/ai.rs
+++ b/worker/src/ai.rs
@@ -6,6 +6,7 @@ use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use worker_sys::Ai as AiSys;
 
+#[derive(Debug)]
 pub struct Ai(AiSys);
 
 impl Ai {

--- a/worker/src/analytics_engine.rs
+++ b/worker/src/analytics_engine.rs
@@ -5,7 +5,7 @@ use js_sys::{Array, Uint8Array};
 use wasm_bindgen::{JsCast, JsValue};
 use worker_sys::AnalyticsEngineDataset as AnalyticsEngineSys;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct AnalyticsEngineDataset(AnalyticsEngineSys);
 
 unsafe impl Send for AnalyticsEngineDataset {}
@@ -59,10 +59,12 @@ impl AnalyticsEngineDataset {
     }
 }
 
+#[derive(Debug)]
 pub enum BlobType {
     String(String),
     Blob(Vec<u8>),
 }
+
 impl From<BlobType> for JsValue {
     fn from(val: BlobType) -> Self {
         match val {
@@ -105,13 +107,14 @@ impl<const COUNT: usize> From<&[u8; COUNT]> for BlobType {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct AnalyticsEngineDataPoint {
     indexes: Array,
     doubles: Array,
     blobs: Array,
 }
 
+#[derive(Debug)]
 pub struct AnalyticsEngineDataPointBuilder {
     indexes: Array,
     doubles: Array,

--- a/worker/src/cache.rs
+++ b/worker/src/cache.rs
@@ -160,6 +160,7 @@ impl Cache {
 }
 
 /// The `String` or `Request` object used as the lookup key. `String`s are interpreted as the URL for a new `Request` object.
+#[derive(Debug)]
 pub enum CacheKey<'a> {
     Url(String),
     Request(&'a Request),
@@ -190,7 +191,7 @@ impl<'a> From<&'a Request> for CacheKey<'a> {
 }
 
 /// Successful outcomes when attempting to delete a `Response` from the cache
-#[derive(Serialize)]
+#[derive(Serialize, Debug, Clone)]
 pub enum CacheDeletionOutcome {
     /// The response was cached but is now deleted
     Success,

--- a/worker/src/cf.rs
+++ b/worker/src/cf.rs
@@ -274,7 +274,7 @@ impl From<worker_sys::TlsClientAuth> for TlsClientAuth {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CfResponseProperties(pub(crate) js_sys::Object);
 
 impl CfResponseProperties {

--- a/worker/src/crypto.rs
+++ b/worker/src/crypto.rs
@@ -23,6 +23,7 @@ use crate::send::SendFuture;
 ///
 /// let bytes:Vec<u8> = digest_stream.digest().await.unwrap().to_vec();
 /// ```
+#[derive(Debug)]
 pub struct DigestStream {
     inner: worker_sys::DigestStream,
 }

--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -25,6 +25,7 @@ pub use serde_wasm_bindgen;
 pub mod macros;
 
 // A D1 Database.
+#[derive(Debug)]
 pub struct D1Database(D1DatabaseSys);
 
 unsafe impl Sync for D1Database {}
@@ -134,6 +135,7 @@ impl From<D1DatabaseSys> for D1Database {
 
 /// Possible argument types that can be bound to [`D1PreparedStatement`]
 /// See https://developers.cloudflare.com/d1/build-with-d1/d1-client-api/#type-conversion
+#[derive(Debug)]
 pub enum D1Type<'a> {
     Null,
     Real(f64),
@@ -151,6 +153,7 @@ pub enum D1Type<'a> {
 /// Arguments must be converted to `JsValue` when bound. If you plan to
 /// re-use the same argument multiple times, consider using a `D1PreparedArgument`
 /// which does this once on construction.
+#[derive(Debug)]
 pub struct D1PreparedArgument<'a> {
     value: &'a D1Type<'a>,
     js_value: JsValue,
@@ -220,7 +223,7 @@ impl D1Argument for D1PreparedArgument<'_> {
 }
 
 // A D1 prepared query statement.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct D1PreparedStatement(D1PreparedStatementSys);
 
 impl D1PreparedStatement {
@@ -341,6 +344,7 @@ impl From<D1PreparedStatementSys> for D1PreparedStatement {
 }
 
 // The result of a D1 query execution.
+#[derive(Debug)]
 pub struct D1Result(D1ResultSys);
 
 // The meta object of D1 result.

--- a/worker/src/delay.rs
+++ b/worker/src/delay.rs
@@ -21,6 +21,7 @@ use wasm_bindgen::{prelude::Closure, JsCast};
 /// // Waits a second
 /// Delay::from(duration).await;
 /// ```
+#[derive(Debug)]
 #[pin_project::pin_project(PinnedDrop)]
 pub struct Delay {
     inner: Duration,

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -35,6 +35,7 @@ use worker_sys::{
 use wasm_bindgen_futures::{future_to_promise, JsFuture};
 
 /// A Durable Object stub is a client object used to send requests to a remote Durable Object.
+#[derive(Debug)]
 pub struct Stub {
     inner: EdgeDurableObject,
 }
@@ -65,7 +66,7 @@ impl Stub {
 /// Use an ObjectNamespace to get access to Stubs for communication with a Durable Object instance.
 /// A given namespace can support essentially unlimited Durable Objects, with each Object having
 /// access to a transactional, key-value storage API.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ObjectNamespace {
     inner: EdgeObjectNamespace,
 }
@@ -141,6 +142,7 @@ impl ObjectNamespace {
 
 /// An ObjectId is used to identify, locate, and access a Durable Object via interaction with its
 /// Stub.
+#[derive(Debug)]
 pub struct ObjectId<'a> {
     inner: DurableObjectId,
     namespace: Option<&'a ObjectNamespace>,
@@ -205,6 +207,7 @@ impl Display for ObjectId<'_> {
 
 /// Passed from the runtime to provide access to the Durable Object's storage as well as various
 /// metadata about the Object.
+#[derive(Debug)]
 pub struct State {
     inner: DurableObjectState,
 }
@@ -299,6 +302,12 @@ impl From<DurableObjectState> for State {
 /// accessing multiple key-value pairs.
 pub struct Storage {
     inner: DurableObjectStorage,
+}
+
+impl std::fmt::Debug for Storage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Storage").finish()
+    }
 }
 
 impl Storage {
@@ -530,6 +539,7 @@ impl Storage {
     }
 }
 
+#[derive(Debug)]
 pub struct Transaction {
     inner: DurableObjectTransaction,
 }
@@ -632,7 +642,7 @@ impl Transaction {
     }
 }
 
-#[derive(Default, Serialize)]
+#[derive(Default, Serialize, Debug)]
 pub struct ListOptions<'a> {
     /// Key at which the list results should start, inclusive.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -689,7 +699,7 @@ impl<'a> ListOptions<'a> {
         self
     }
 }
-
+#[derive(Debug)]
 enum ScheduledTimeInit {
     Date(js_sys::Date),
     Offset(f64),
@@ -704,6 +714,7 @@ enum ScheduledTimeInit {
 ///
 /// When an offset is used, the time at which `set_alarm()` or `set_alarm_with_options()` is called
 /// is used to compute the scheduled time. [`Date::now`] is used as the current time.
+#[derive(Debug)]
 pub struct ScheduledTime {
     init: ScheduledTimeInit,
 }
@@ -796,6 +807,7 @@ impl AsRef<JsValue> for ObjectNamespace {
     }
 }
 
+#[derive(Debug)]
 pub enum WebSocketIncomingMessage {
     String(String),
     Binary(Vec<u8>),

--- a/worker/src/env.rs
+++ b/worker/src/env.rs
@@ -18,7 +18,7 @@ use worker_kv::KvStore;
 #[wasm_bindgen]
 extern "C" {
     /// Env contains any bindings you have associated with the Worker when you uploaded it.
-    #[derive(Clone)]
+    #[derive(Debug, Clone)]
     pub type Env;
 }
 
@@ -139,6 +139,7 @@ pub trait EnvBinding: Sized + JsCast {
 }
 
 #[repr(transparent)]
+#[derive(Debug)]
 pub struct StringBinding(JsValue);
 
 impl EnvBinding for StringBinding {

--- a/worker/src/fetcher.rs
+++ b/worker/src/fetcher.rs
@@ -8,7 +8,7 @@ use wasm_bindgen_futures::JsFuture;
 use crate::{HttpRequest, HttpResponse};
 use crate::{Request, Response};
 /// A struct for invoking fetch events to other Workers.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Fetcher(worker_sys::Fetcher);
 
 #[cfg(not(feature = "http"))]

--- a/worker/src/formdata.rs
+++ b/worker/src/formdata.rs
@@ -12,6 +12,7 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 
 /// Representing the options any FormData value can be, a field or a file.
+#[derive(Debug)]
 pub enum FormEntry {
     Field(String),
     File(File),
@@ -136,6 +137,7 @@ impl From<FormData> for wasm_bindgen::JsValue {
 
 /// A [File](https://developer.mozilla.org/en-US/docs/Web/API/File) representation used with
 /// `FormData`.
+#[derive(Debug)]
 pub struct File(web_sys::File);
 
 impl File {

--- a/worker/src/global.rs
+++ b/worker/src/global.rs
@@ -7,6 +7,7 @@ use crate::{request::Request, response::Response, AbortSignal, Result};
 
 /// Construct a Fetch call from a URL string or a Request object. Call its `send` method to execute
 /// the request.
+#[derive(Debug)]
 pub enum Fetch {
     Url(url::Url),
     Request(Request),

--- a/worker/src/hyperdrive.rs
+++ b/worker/src/hyperdrive.rs
@@ -3,6 +3,7 @@ use worker_sys::types::Hyperdrive as HyperdriveSys;
 
 use crate::EnvBinding;
 
+#[derive(Debug)]
 pub struct Hyperdrive(HyperdriveSys);
 
 unsafe impl Send for Hyperdrive {}

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::new_without_default)]
 #![allow(clippy::or_fun_call)]
+#![warn(missing_debug_implementations)]
 //! # Features
 //! ## `d1`
 //!

--- a/worker/src/queue.rs
+++ b/worker/src/queue.rs
@@ -11,6 +11,7 @@ use wasm_bindgen_futures::JsFuture;
 use worker_sys::{Message as MessageSys, MessageBatch as MessageBatchSys, Queue as EdgeQueue};
 
 /// A batch of messages that are sent to a consumer Worker.
+#[derive(Debug)]
 pub struct MessageBatch<T> {
     inner: MessageBatchSys,
     phantom: PhantomData<T>,
@@ -77,6 +78,7 @@ impl<T> From<MessageBatchSys> for MessageBatch<T> {
 }
 
 /// A message that is sent to a consumer Worker.
+#[derive(Debug)]
 pub struct Message<T> {
     inner: MessageSys,
     body: T,
@@ -115,6 +117,7 @@ where
 }
 
 /// A message that is sent to a consumer Worker.
+#[derive(Debug)]
 pub struct RawMessage {
     inner: MessageSys,
 }
@@ -150,11 +153,13 @@ impl<T> MessageSysInner for Message<T> {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 /// Optional configuration when marking a message or a batch of messages for retry.
 pub struct QueueRetryOptions {
     delay_seconds: Option<u32>,
 }
 
+#[derive(Debug)]
 pub struct QueueRetryOptionsBuilder {
     delay_seconds: Option<u32>,
 }
@@ -229,6 +234,7 @@ impl<T: MessageSysInner> MessageExt for T {
     }
 }
 
+#[derive(Debug)]
 pub struct MessageIter<T> {
     range: std::ops::Range<u32>,
     array: Array,
@@ -270,6 +276,7 @@ impl<T> std::iter::FusedIterator for MessageIter<T> where T: DeserializeOwned {}
 
 impl<T> std::iter::ExactSizeIterator for MessageIter<T> where T: DeserializeOwned {}
 
+#[derive(Debug)]
 pub struct RawMessageIter {
     range: std::ops::Range<u32>,
     array: Array,
@@ -302,7 +309,7 @@ impl std::iter::FusedIterator for RawMessageIter {}
 
 impl std::iter::ExactSizeIterator for RawMessageIter {}
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Queue(EdgeQueue);
 
 unsafe impl Send for Queue {}
@@ -361,13 +368,14 @@ impl Serialize for QueueContentType {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueueSendOptions {
     content_type: Option<QueueContentType>,
     delay_seconds: Option<u32>,
 }
 
+#[derive(Debug)]
 pub struct MessageBuilder<T> {
     message: T,
     delay_seconds: Option<u32>,
@@ -411,6 +419,7 @@ impl<T: Serialize> MessageBuilder<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct RawMessageBuilder {
     message: JsValue,
     delay_seconds: Option<u32>,
@@ -449,6 +458,7 @@ impl RawMessageBuilder {
 /// This type can't be constructed directly.
 ///
 /// It should be constructed using the `MessageBuilder`, `RawMessageBuilder` or by calling `.into()` on a struct that is `serializable`.
+#[derive(Debug)]
 pub struct SendMessage<T> {
     /// The body of the message.
     ///
@@ -480,17 +490,19 @@ impl<T: Serialize> From<T> for SendMessage<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct BatchSendMessage<T> {
     body: Vec<SendMessage<T>>,
     options: Option<QueueSendBatchOptions>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueueSendBatchOptions {
     delay_seconds: Option<u32>,
 }
 
+#[derive(Debug)]
 pub struct BatchMessageBuilder<T> {
     messages: Vec<SendMessage<T>>,
     delay_seconds: Option<u32>,

--- a/worker/src/r2/builder.rs
+++ b/worker/src/r2/builder.rs
@@ -13,6 +13,7 @@ use crate::{Date, Error, MultipartUpload, ObjectInner, Objects, Result};
 use super::{Data, Object};
 
 /// Options for configuring the [get](crate::r2::Bucket::get) operation.
+#[derive(Debug)]
 pub struct GetOptionsBuilder<'bucket> {
     pub(crate) edge_bucket: &'bucket EdgeR2Bucket,
     pub(crate) key: String,
@@ -164,6 +165,7 @@ impl TryFrom<R2RangeSys> for Range {
 }
 
 /// Options for configuring the [put](crate::r2::Bucket::put) operation.
+#[derive(Debug)]
 pub struct PutOptionsBuilder<'bucket> {
     pub(crate) edge_bucket: &'bucket EdgeR2Bucket,
     pub(crate) key: String,
@@ -258,6 +260,7 @@ impl PutOptionsBuilder<'_> {
 }
 
 /// Options for configuring the [create_multipart_upload](crate::r2::Bucket::create_multipart_upload) operation.
+#[derive(Debug)]
 pub struct CreateMultipartUploadOptionsBuilder<'bucket> {
     pub(crate) edge_bucket: &'bucket EdgeR2Bucket,
     pub(crate) key: String,
@@ -353,6 +356,7 @@ impl From<R2HttpMetadataSys> for HttpMetadata {
 }
 
 /// Options for configuring the [list](crate::r2::Bucket::list) operation.
+#[derive(Debug)]
 pub struct ListOptionsBuilder<'bucket> {
     pub(crate) edge_bucket: &'bucket EdgeR2Bucket,
     pub(crate) limit: Option<u32>,

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 mod builder;
 
 /// An instance of the R2 bucket binding.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Bucket {
     inner: EdgeR2Bucket,
 }
@@ -161,6 +161,7 @@ impl AsRef<JsValue> for Bucket {
 /// [Object] is created when you [put](Bucket::put) an object into a [Bucket]. [Object] represents
 /// the metadata of an object based on the information provided by the uploader. Every object that
 /// you [put](Bucket::put) into a [Bucket] will have an [Object] created.
+#[derive(Debug)]
 pub struct Object {
     inner: ObjectInner,
 }
@@ -277,6 +278,7 @@ impl Object {
 }
 
 /// The data contained within an [Object].
+#[derive(Debug)]
 pub struct ObjectBody<'body> {
     inner: &'body EdgeR2ObjectBody,
 }
@@ -325,6 +327,7 @@ impl ObjectBody<'_> {
 /// [UploadedPart] represents a part that has been uploaded.
 /// [UploadedPart] objects are returned from [upload_part](MultipartUpload::upload_part) operations
 /// and must be passed to the [complete](MultipartUpload::complete) operation.
+#[derive(Debug)]
 pub struct UploadedPart {
     inner: EdgeR2UploadedPart,
 }
@@ -353,6 +356,7 @@ impl UploadedPart {
     }
 }
 
+#[derive(Debug)]
 pub struct MultipartUpload {
     inner: EdgeR2MultipartUpload,
 }
@@ -415,6 +419,7 @@ impl MultipartUpload {
 }
 
 /// A series of [Object]s returned by [list](Bucket::list).
+#[derive(Debug)]
 pub struct Objects {
     inner: EdgeR2Objects,
 }
@@ -460,12 +465,13 @@ impl Objects {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) enum ObjectInner {
     NoBody(EdgeR2Object),
     Body(EdgeR2ObjectBody),
 }
 
+#[derive(Debug)]
 pub enum Data {
     ReadableStream(web_sys::ReadableStream),
     Stream(FixedLengthStream),

--- a/worker/src/rate_limit.rs
+++ b/worker/src/rate_limit.rs
@@ -4,6 +4,7 @@ use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use worker_sys::RateLimiter as RateLimiterSys;
 
+#[derive(Debug)]
 pub struct RateLimiter(RateLimiterSys);
 
 #[derive(Serialize, Deserialize)]
@@ -11,7 +12,7 @@ struct RateLimitOptions {
     key: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RateLimitOutcome {
     pub success: bool,
 }

--- a/worker/src/request_init.rs
+++ b/worker/src/request_init.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use wasm_bindgen::{prelude::*, JsValue};
 
 /// Optional options struct that contains settings to apply to the `Request`.
+#[derive(Debug)]
 pub struct RequestInit {
     /// Currently requires a manual conversion from your data into a [`wasm_bindgen::JsValue`].
     pub body: Option<JsValue>,
@@ -94,6 +95,7 @@ impl Default for RequestInit {
 }
 
 /// <https://developers.cloudflare.com/workers/runtime-apis/request#requestinitcfproperties>
+#[derive(Debug)]
 pub struct CfProperties {
     /// Whether Cloudflare Apps should be enabled for this request. Defaults to `true`.
     pub apps: Option<bool>,
@@ -276,7 +278,7 @@ impl Default for CfProperties {
 /// Configuration options for Cloudflare's minification features:
 /// <https://www.cloudflare.com/website-optimization/>
 #[wasm_bindgen]
-#[derive(Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct MinifyConfig {
     pub js: bool,
     pub html: bool,
@@ -286,7 +288,7 @@ pub struct MinifyConfig {
 /// Configuration options for Cloudflare's image optimization feature:
 /// <https://blog.cloudflare.com/introducing-polish-automatic-image-optimizati/>
 #[wasm_bindgen]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum PolishConfig {
     Off,
     Lossy,
@@ -310,7 +312,7 @@ impl From<PolishConfig> for &str {
 }
 
 #[wasm_bindgen]
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum RequestRedirect {
     Error,
     #[default]

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -19,6 +19,7 @@ type AsyncHandlerFn<'a, D> =
 
 /// Represents the URL parameters parsed from the path, e.g. a route with "/user/:id" pattern would
 /// contain a single "id" key.
+#[derive(Debug)]
 pub struct RouteParams(HashMap<String, String>);
 
 impl RouteParams {
@@ -48,8 +49,15 @@ pub struct Router<'a, D> {
     data: D,
 }
 
+impl core::fmt::Debug for Router<'_, ()> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Router").finish()
+    }
+}
+
 /// Container for a route's parsed parameters, data, and environment bindings from the Runtime (such
 /// as KV Stores, Durable Objects, Variables, and Secrets).
+#[derive(Debug)]
 pub struct RouteContext<D> {
     pub data: D,
     pub env: Env,

--- a/worker/src/schedule.rs
+++ b/worker/src/schedule.rs
@@ -38,7 +38,7 @@ impl ScheduledEvent {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ScheduleContext {
     edge: EdgeScheduleContext,
 }

--- a/worker/src/send.rs
+++ b/worker/src/send.rs
@@ -11,6 +11,7 @@ use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 
+#[derive(Debug)]
 #[pin_project]
 /// Wrap any future to make it `Send`.
 ///

--- a/worker/src/socket.rs
+++ b/worker/src/socket.rs
@@ -40,7 +40,7 @@ impl TryFrom<JsValue> for SocketInfo {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 enum Reading {
     #[default]
     None,
@@ -48,14 +48,14 @@ enum Reading {
     Ready(Vec<u8>),
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 enum Writing {
     Pending(JsFuture, WritableStreamDefaultWriter, usize),
     #[default]
     None,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 enum Closing {
     Pending(JsFuture),
     #[default]
@@ -63,6 +63,7 @@ enum Closing {
 }
 
 /// Represents an outbound TCP connection from your Worker.
+#[derive(Debug)]
 pub struct Socket {
     inner: worker_sys::Socket,
     writable: WritableStream,
@@ -283,6 +284,7 @@ impl AsyncWrite for Socket {
 }
 
 /// Secure transport options for outbound TCP connections.
+#[derive(Debug, Clone)]
 pub enum SecureTransport {
     /// Do not use TLS.
     Off,
@@ -294,6 +296,7 @@ pub enum SecureTransport {
 }
 
 /// Used to configure outbound TCP connections.
+#[derive(Debug, Clone)]
 pub struct SocketOptions {
     /// Specifies whether or not to use TLS when creating the TCP socket.
     pub secure_transport: SecureTransport,
@@ -314,6 +317,7 @@ impl Default for SocketOptions {
 }
 
 /// The host and port that you wish to connect to.
+#[derive(Debug, Clone)]
 pub struct SocketAddress {
     /// The hostname to connect to. Example: `cloudflare.com`.
     pub hostname: String,
@@ -321,7 +325,7 @@ pub struct SocketAddress {
     pub port: u16,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 pub struct ConnectionBuilder {
     options: SocketOptions,
 }
@@ -403,6 +407,7 @@ pub mod postgres_tls {
     ///     .connect("database_url", 5432)?;
     /// let _ = config.connect_raw(socket, PassthroughTls).await?;
     /// ```
+    #[derive(Debug, Clone, Default)]
     pub struct PassthroughTls;
 
     #[derive(Debug)]

--- a/worker/src/sql.rs
+++ b/worker/src/sql.rs
@@ -240,6 +240,7 @@ unsafe impl Sync for SqlCursor {}
 ///
 /// This iterator yields deserialized rows of type `T`, providing a type-safe
 /// way to iterate over SQL query results with automatic conversion to Rust types.
+#[derive(Debug)]
 pub struct SqlCursorIterator<T> {
     cursor: SqlCursor,
     _phantom: std::marker::PhantomData<T>,
@@ -275,6 +276,7 @@ where
 /// This iterator yields raw values as `Vec<SqlStorageValue>`, providing efficient
 /// access to SQL data without deserialization overhead. Useful when you need
 /// direct access to the underlying SQL values without column names.
+#[derive(Debug)]
 pub struct SqlCursorRawIterator {
     inner: js_sys::Iterator,
 }

--- a/worker/src/streams.rs
+++ b/worker/src/streams.rs
@@ -47,6 +47,15 @@ pub struct FixedLengthStream {
     inner: Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + 'static>>,
 }
 
+impl core::fmt::Debug for FixedLengthStream {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FixedLengthStream")
+            .field("length", &self.length)
+            .field("bytes_read", &self.bytes_read)
+            .finish()
+    }
+}
+
 impl FixedLengthStream {
     pub fn wrap(stream: impl Stream<Item = Result<Vec<u8>>> + 'static, length: u64) -> Self {
         Self {

--- a/worker/src/version.rs
+++ b/worker/src/version.rs
@@ -2,6 +2,7 @@ use crate::EnvBinding;
 use wasm_bindgen::{JsCast, JsValue};
 use worker_sys::types::CfVersionMetadata;
 
+#[derive(Debug)]
 pub struct WorkerVersionMetadata(CfVersionMetadata);
 
 unsafe impl Send for WorkerVersionMetadata {}

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -287,6 +287,7 @@ type EvCallback<T> = Closure<dyn FnMut(T)>;
 /// });
 /// ```
 #[pin_project::pin_project(PinnedDrop)]
+#[derive(Debug)]
 pub struct EventStream<'ws> {
     ws: &'ws WebSocket,
     #[pin]


### PR DESCRIPTION
`worker` crate does not implement `Debug` trait for all types (#773) . It blocks downstream user to derive `Debug` trait for their types containing these types, such as `D1Database `. In this pull request, i implement `Debug` trait for various types. Basically, I derive `Debug` trait for basic types. Some types exported from Javascript would have a reasonable manual implementation. For instance:

```rust
impl core::fmt::Debug for DurableObjectState {
    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
        f.debug_struct("DurableObjectState")
            .field("id", &self.id())
            .finish()
    }
}
```