### PR TITLE
Make `as_organization` optional on `IncomingRequestCfProperties`

### DIFF
--- a/worker-sys/src/types/incoming_request_cf_properties.rs
+++ b/worker-sys/src/types/incoming_request_cf_properties.rs
@@ -15,7 +15,7 @@ extern "C" {
     pub fn asn(this: &IncomingRequestCfProperties) -> Result<u32, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=asOrganization)]
-    pub fn as_organization(this: &IncomingRequestCfProperties) -> Result<String, JsValue>;
+    pub fn as_organization(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
     pub fn country(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;

--- a/worker/src/cf.rs
+++ b/worker/src/cf.rs
@@ -38,7 +38,7 @@ impl Cf {
     }
 
     /// The Autonomous System organization name of the request, e.g. `Cloudflare, Inc.`
-    pub fn as_organization(&self) -> String {
+    pub fn as_organization(&self) -> Option<String> {
         self.inner.as_organization().unwrap()
     }
 


### PR DESCRIPTION
This PR updates the `IncomingRequestCfProperties` to reflect that `as_organization` is optional.

We ran into a case today in production where `cf.asOrganization` was `undefined`.

We're not using `worker` directly, but we are using bindings based on `worker-sys`, which resulted in the Worker panicking when trying to call the `as_organization` method.

I posted a [question](https://discord.com/channels/595317990191398933/1394398763119804528) about this in the Cloudflare Developers Discord and was told that this field can be optional and its presence should not be assumed:

<img width="364" height="79" alt="Screenshot 2025-07-14 at 3 40 25 PM" src="https://github.com/user-attachments/assets/50d61995-b4ee-408d-996e-6dc400eec1da" />
