### PR TITLE
fix: add additional optional cf properties

### DIFF
--- a/worker-sys/src/types/incoming_request_cf_properties.rs
+++ b/worker-sys/src/types/incoming_request_cf_properties.rs
@@ -62,7 +62,7 @@ extern "C" {
     pub fn region_code(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 
     #[wasm_bindgen(method, catch, getter, js_name=hostMetadata)]
-    pub fn host_metadata(this: &IncomingRequestCfProperties) -> Result<Option<JsValue>, JsValue>;
+    pub fn host_metadata(this: &IncomingRequestCfProperties) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(method, catch, getter)]
     pub fn timezone(this: &IncomingRequestCfProperties) -> Result<String, JsValue>;

--- a/worker/src/cf.rs
+++ b/worker/src/cf.rs
@@ -33,7 +33,7 @@ impl Cf {
     }
 
     /// The Autonomous System Number (ASN) of the request, e.g. `395747`
-    pub fn asn(&self) -> u32 {
+    pub fn asn(&self) -> Option<u32> {
         self.inner.asn().unwrap()
     }
 


### PR DESCRIPTION
Follow-on to https://github.com/cloudflare/workers-rs/pull/776, making `asn` an optional property as well.