### PR TITLE
Support deleting multiple R2 keys, fixes #780

### DIFF
--- a/worker-sandbox/src/r2.rs
+++ b/worker-sandbox/src/r2.rs
@@ -257,6 +257,14 @@ pub async fn delete(_req: Request, env: Env, _data: SomeSharedData) -> Result<Re
 
     bucket.delete("key").await?;
 
+    let keys: Vec<String> = (0..1000).map(|i| format!("key_{i}")).collect();
+    for key in &keys {
+        bucket.put(key, Data::Empty).execute().await?;
+    }
+    let objects = bucket.list().execute().await?;
+    assert_eq!(objects.objects().len(), keys.len());
+
+    bucket.delete_multiple(keys).await?;
     let objects = bucket.list().execute().await?;
     assert_eq!(objects.objects().len(), 0);
 

--- a/worker-sys/src/types/r2/bucket.rs
+++ b/worker-sys/src/types/r2/bucket.rs
@@ -23,6 +23,10 @@ extern "C" {
     #[wasm_bindgen(method, catch)]
     pub fn delete(this: &R2Bucket, key: String) -> Result<js_sys::Promise, JsValue>;
 
+    #[wasm_bindgen(method, catch, js_name=delete)]
+    pub fn delete_multiple(this: &R2Bucket, keys: Vec<JsValue>)
+        -> Result<js_sys::Promise, JsValue>;
+
     #[wasm_bindgen(method, catch)]
     pub fn list(this: &R2Bucket, options: JsValue) -> Result<js_sys::Promise, JsValue>;
 


### PR DESCRIPTION
Add support for deleting multiple R2 keys at once with `delete_multiple` as supported by the Javascript API: https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#bucket-method-definitions.

The implementation is similar to how `delete_multiple` is implemented for DO storage: https://github.com/cloudflare/workers-rs/blob/main/worker-sys/src/types/durable_object/storage.rs#L36.

Local testing with worker-sandbox appears to work fine:
```
cd worker-sandbox
npx wrangler dev

curl -X DELETE http://localhost:8787/r2/delete
ok
```