### PR TITLE
fix: Update leptos template so that it works OOTB

### DIFF
--- a/templates/leptos/Cargo.toml
+++ b/templates/leptos/Cargo.toml
@@ -23,7 +23,7 @@ leptos_meta = { version = "0.8" }
 leptos_router = { version = "0.8"{% if use_nightly %}, features = ["nightly"]{% endif %} }
 tower-service = "0.3"
 wasm-bindgen = "0.2"
-worker = { version = "0.5", features = ["http", "axum", "d1"], optional = true }
+worker = { version = "0.6", features = ["http", "axum", "d1"], optional = true }
 
 [features]
 hydrate = ["leptos/hydrate"]
@@ -34,6 +34,12 @@ ssr = [
   "leptos/ssr",
   "leptos_router/ssr",
 ]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
+[package.metadata.wasm-pack.profile.dev]
+wasm-opt = false
 
 [package.metadata.leptos]
 wasm-validation = false

--- a/templates/leptos/src/lib.rs
+++ b/templates/leptos/src/lib.rs
@@ -6,6 +6,26 @@ use crate::app::*;
 pub mod app;
 mod components;
 
+
+#[cfg(feature = "ssr")]
+#[cfg(target_family = "wasm")]
+mod wasm_workaround {
+    unsafe extern "C" {
+        pub(super) fn __wasm_call_ctors();
+    }
+}
+
+#[cfg(feature = "ssr")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+fn start() {
+    // Fix for 'Read a negative address value from the stack. Did we run out of memory?'.
+    // See: https://github.com/cloudflare/workers-rs/issues/772
+    #[cfg(target_family = "wasm")]
+    unsafe {
+        wasm_workaround::__wasm_call_ctors()
+    };
+}
+
 #[cfg(feature = "ssr")]
 pub fn register_server_functions() {
     use leptos::server_fn::axum::register_explicit;


### PR DESCRIPTION
The current leptos template does not work out of the box due to an issue with wasm-bindgen. This PR returns it to a working state via a workaround discussed in the below linked issue by:

- Bumping workers-rs to 0.6 in Cargo.toml
- Disabling wasm-opt
- Adding a call to `pub(super) fn __wasm_call_ctors();`
- Adding a `start` fn to lib.rs

Resolves #772