### PR TITLE
feat: implement DurableObjectNamespace getByName and getByName with o…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
       "dependencies": {
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.29.4",
-        "@cloudflare/workers-types": "^4.20250724.0"
+        "@cloudflare/workers-types": "4.20250826.0"
       },
       "devDependencies": {
         "@types/node": "^24.0.1",
-        "miniflare": "^4.20250712.2",
+        "miniflare": "4.20250823.0",
         "typescript": "^5.8.3",
         "undici": "^7.12.0",
         "uuid": "^11.1.0",
@@ -349,9 +349,9 @@
       "license": "MIT"
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20250712.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250712.0.tgz",
-      "integrity": "sha512-M6S6a/LQ0Jb0R+g0XhlYi1adGifvYmxA5mD/i9TuZZgjs2bIm5ELuka/n3SCnI98ltvlx3HahRaHagAtOilsFg==",
+      "version": "1.20250823.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250823.0.tgz",
+      "integrity": "sha512-yRLJc1cQNqQYcDViOk7kpTXnR5XuBP7B/Ms5KBdlQ6eTr2Vsg9mfKqWKInjzY8/Cx+p+Sic2Tbld42gcYkiM2A==",
       "cpu": [
         "x64"
       ],
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20250712.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250712.0.tgz",
-      "integrity": "sha512-7sFzn6rvAcnLy7MktFL42dYtzL0Idw/kiUmNf2P3TvsBRoShhLK5ZKhbw+NAhvU8e4pXWm5lkE0XmpieA0zNjw==",
+      "version": "1.20250823.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250823.0.tgz",
+      "integrity": "sha512-KJnikUe6J29Ga1QMPKNCc8eHD56DdBlu5XE5LoBH/AYRrbS5UI1d5F844hUWoFKJb8KRaPIH9F849HZWfNa1vw==",
       "cpu": [
         "arm64"
       ],
@@ -383,9 +383,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20250712.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250712.0.tgz",
-      "integrity": "sha512-EFRrGe/bqK7NHtht7vNlbrDpfvH3eRvtJOgsTpEQEysDjVmlK6pVJxSnLy9Hg1zlLY15IfhfGC+K2qisseHGJQ==",
+      "version": "1.20250823.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250823.0.tgz",
+      "integrity": "sha512-4QFXq4eDWEAK5QjGxRe0XUTBax1Fgarc08HETL6q0y/KPZp2nOTLfjLjklTn/qEiztafNFoJEIwhkiknHeOi/g==",
       "cpu": [
         "x64"
       ],
@@ -400,9 +400,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20250712.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250712.0.tgz",
-      "integrity": "sha512-rG8JUleddhUHQVwpXOYv0VbL0S9kOtR9PNKecgVhFpxEhC8aTeg2HNBBjo8st7IfcUvY8WaW3pD3qdAMZ05UwQ==",
+      "version": "1.20250823.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250823.0.tgz",
+      "integrity": "sha512-sODSrSVe4W/maoBu76qb0sJGBhxhSM2Q2tg/+G7q1IPgRZSzArMKIPrW6nBnmBrrG1O0X6aoAdID6w5hfuEM4g==",
       "cpu": [
         "arm64"
       ],
@@ -417,9 +417,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20250712.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250712.0.tgz",
-      "integrity": "sha512-qS8H5RCYwE21Om9wo5/F807ClBJIfknhuLBj16eYxvJcj9JqgAKWi12BGgjyGxHuJJjeoQ63lr4wHAdbFntDDg==",
+      "version": "1.20250823.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250823.0.tgz",
+      "integrity": "sha512-WaNqUOXUnrcEI+i2NI4+okA9CrJMI9n2XTfVtDg/pLvcA/ZPTz23MEFMZU1splr4SslS1th1NBO38RMPnDB4rA==",
       "cpu": [
         "x64"
       ],
@@ -434,9 +434,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20250724.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250724.0.tgz",
-      "integrity": "sha512-TRuz+kMArBpW3lR7xoPR7Ek+/ymvukE5JC7RITlaRyHbs6vWPfwpH9TWQ1dfztYFmSQl5ZiAbLcK8UDRjgiW7g==",
+      "version": "4.20250826.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250826.0.tgz",
+      "integrity": "sha512-nAbTVI81wFSxbESRbfGRlfL4WYNvq8T46yr1ukypHL8O2xnbZfQnQhC7ftSBmDqov8HqQSdqcz9jCgLjVh61SQ==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2626,9 +2626,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20250712.2",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250712.2.tgz",
-      "integrity": "sha512-cZ8WyQBwqfjYLjd61fDR4/j0nAVbjB3Wxbun/brL9S5FAi4RlTR0LyMTKsIVA0s+nL4Pg9VjVMki4M/Jk2cz+Q==",
+      "version": "4.20250823.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250823.0.tgz",
+      "integrity": "sha512-ofQRQ6rb/5P4nsz/J+xptdrN4zvYUm0wuezbKfaxbAGiIVTsM1vd+Pta5MtZwdQ6BKLM9tKMtU0rnbTzy3wntQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2640,7 +2640,7 @@
         "sharp": "^0.33.5",
         "stoppable": "1.1.0",
         "undici": "^7.10.0",
-        "workerd": "1.20250712.0",
+        "workerd": "1.20250823.0",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10",
         "zod": "3.22.3"
@@ -3695,9 +3695,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20250712.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250712.0.tgz",
-      "integrity": "sha512-7h+k1OxREpiZW0849g0uQNexRWMcs5i5gUGhJzCY8nIx6Tv4D/ndlXJ47lEFj7/LQdp165IL9dM2D5uDiedZrg==",
+      "version": "1.20250823.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250823.0.tgz",
+      "integrity": "sha512-95lToK9zeaC7bX5ZmlP/wz6zqoUPBk3hhec1JjEMGZrxsXY9cPRkjWNCcjDctQ17U97vjMcY/ymchgx7w8Cfmg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3708,11 +3708,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20250712.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20250712.0",
-        "@cloudflare/workerd-linux-64": "1.20250712.0",
-        "@cloudflare/workerd-linux-arm64": "1.20250712.0",
-        "@cloudflare/workerd-windows-64": "1.20250712.0"
+        "@cloudflare/workerd-darwin-64": "1.20250823.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250823.0",
+        "@cloudflare/workerd-linux-64": "1.20250823.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250823.0",
+        "@cloudflare/workerd-windows-64": "1.20250823.0"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.29.4",
-    "@cloudflare/workers-types": "^4.20250724.0"
+    "@cloudflare/workers-types": "4.20250826.0"
   },
   "name": "workers-rs",
   "version": "0.0.12",
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/cloudflare/workers-rs#readme",
   "devDependencies": {
     "@types/node": "^24.0.1",
-    "miniflare": "^4.20250712.2",
+    "miniflare": "4.20250823.0",
     "typescript": "^5.8.3",
     "undici": "^7.12.0",
     "uuid": "^11.1.0",

--- a/worker-sandbox/src/durable.rs
+++ b/worker-sandbox/src/durable.rs
@@ -277,3 +277,37 @@ pub async fn handle_basic_test(
 
     Response::ok("ok")
 }
+
+#[worker::send]
+pub async fn handle_get_by_name(
+    _req: Request,
+    env: Env,
+    _data: crate::SomeSharedData,
+) -> Result<Response> {
+    let namespace = env.durable_object("MY_CLASS")?;
+    let name = "my-durable-object";
+    
+    // Using the new get_by_name method - this is equivalent to:
+    // let id = namespace.id_from_name(name)?;
+    // let stub = id.get_stub()?;
+    let stub = namespace.get_by_name(name)?;
+    
+    stub.fetch_with_str(&format!("https://fake-host/hello?name={name}"))
+        .await
+}
+
+#[worker::send]
+pub async fn handle_get_by_name_with_location_hint(
+    _req: Request,
+    env: Env,
+    _data: crate::SomeSharedData,
+) -> Result<Response> {
+    let namespace = env.durable_object("MY_CLASS")?;
+    let name = "my-durable-object";
+    
+    // Using the new get_by_name_with_location_hint method
+    let stub = namespace.get_by_name_with_location_hint(name, "enam")?;
+    
+    stub.fetch_with_str(&format!("https://fake-host/hello?name={name}"))
+        .await
+}

--- a/worker-sandbox/src/router.rs
+++ b/worker-sandbox/src/router.rs
@@ -216,6 +216,8 @@ macro_rules! add_routes (
     add_route!($obj, get, "/durable/hello-unique", durable::handle_hello_unique);
     add_route!($obj, get, "/durable/storage", durable::handle_storage);
     add_route!($obj, get, "/durable/handle-basic-test", durable::handle_basic_test);
+    add_route!($obj, get, "/durable/get-by-name", durable::handle_get_by_name);
+    add_route!($obj, get, "/durable/get-by-name-with-location-hint", durable::handle_get_by_name_with_location_hint);
     add_route!($obj, get, "/js_snippets/now", js_snippets::performance_now);
     add_route!($obj, get, "/js_snippets/log", js_snippets::console_log);
     add_route!($obj, get, format_route!("/sql-counter/{}", "*path"), sql_counter::handle_sql_counter);

--- a/worker-sandbox/tests/durable.spec.ts
+++ b/worker-sandbox/tests/durable.spec.ts
@@ -43,4 +43,18 @@ describe("durable", () => {
     // await new Promise(resolve => setTimeout(resolve, 1000));
     // expect(calledClose).toBe(true);
   });
+
+  test("get-by-name", async () => {
+    const resp = await mf.dispatchFetch(`${mfUrl}durable/get-by-name`);
+    expect(resp.status).toBe(200);
+    const text = await resp.text();
+    expect(text).toBe("Hello from my-durable-object!");
+  });
+
+  test("get-by-name-with-location-hint", async () => {
+    const resp = await mf.dispatchFetch(`${mfUrl}durable/get-by-name-with-location-hint`);
+    expect(resp.status).toBe(200);
+    const text = await resp.text();
+    expect(text).toBe("Hello from my-durable-object!");
+  });
 });

--- a/worker-sys/src/types/durable_object/namespace.rs
+++ b/worker-sys/src/types/durable_object/namespace.rs
@@ -41,4 +41,17 @@ extern "C" {
         id: &DurableObjectId,
         options: &JsValue,
     ) -> Result<DurableObject, JsValue>;
+
+    #[wasm_bindgen(method, catch, js_name=getByName)]
+    pub fn get_by_name(
+        this: &DurableObjectNamespace,
+        name: &str,
+    ) -> Result<DurableObject, JsValue>;
+
+    #[wasm_bindgen(method, catch, js_name=getByName)]
+    pub fn get_by_name_with_options(
+        this: &DurableObjectNamespace,
+        name: &str,
+        options: &JsValue,
+    ) -> Result<DurableObject, JsValue>;
 }

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -138,6 +138,31 @@ impl ObjectNamespace {
                 namespace: Some(self),
             })
     }
+
+    /// Get a Durable Object stub directly by name. This combines the functionality of
+    /// `id_from_name()` and `get_stub()` into a single method call.
+    pub fn get_by_name(&self, name: &str) -> Result<Stub> {
+        self.inner
+            .get_by_name(name)
+            .map_err(Error::from)
+            .map(|stub| Stub { inner: stub })
+    }
+
+    /// Get a Durable Object stub directly by name with options (such as location hints).
+    /// This combines the functionality of `id_from_name()` and `get_stub_with_location_hint()`
+    /// into a single method call.
+    pub fn get_by_name_with_location_hint(&self, name: &str, location_hint: &str) -> Result<Stub> {
+        let options = Object::new();
+        js_sys::Reflect::set(
+            &options,
+            &JsValue::from("locationHint"),
+            &location_hint.into(),
+        )?;
+        self.inner
+            .get_by_name_with_options(name, &options)
+            .map_err(Error::from)
+            .map(|stub| Stub { inner: stub })
+    }
 }
 
 /// An ObjectId is used to identify, locate, and access a Durable Object via interaction with its


### PR DESCRIPTION
…ptions

Add support for the getByName API to directly obtain DurableObject stubs by name, matching the JavaScript Workers API. This provides a more efficient alternative to the id_from_name() + get_stub() pattern.

Changes:
- Add get_by_name() and get_by_name_with_options() to worker-sys bindings
- Implement get_by_name() and get_by_name_with_location_hint() in worker crate
- Add example handlers in worker-sandbox
- Update dependencies to latest Cloudflare Workers types