### PR TITLE
Fix "hiding a lifetime that's elided elsewhere is confusing" warnings on the Nightly compiler

### DIFF
--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -77,7 +77,7 @@ unsafe impl Sync for ObjectNamespace {}
 impl ObjectNamespace {
     /// This method derives a unique object ID from the given name string. It will always return the
     /// same ID when given the same name as input.
-    pub fn id_from_name(&self, name: &str) -> Result<ObjectId> {
+    pub fn id_from_name(&self, name: &str) -> Result<ObjectId<'_>> {
         self.inner
             .id_from_name(name)
             .map_err(Error::from)
@@ -95,7 +95,7 @@ impl ObjectNamespace {
     /// numbers are valid IDs. This method will throw if it is passed an ID that was not originally
     /// created by newUniqueId() or idFromName(). It will also throw if the ID was originally
     /// created for a different namespace.
-    pub fn id_from_string(&self, hex_id: &str) -> Result<ObjectId> {
+    pub fn id_from_string(&self, hex_id: &str) -> Result<ObjectId<'_>> {
         self.inner
             .id_from_string(hex_id)
             .map_err(Error::from)
@@ -108,7 +108,7 @@ impl ObjectNamespace {
     /// Creates a new object ID randomly. This method will never return the same ID twice, and thus
     /// it is guaranteed that the object does not yet exist and has never existed at the time the
     /// method returns.
-    pub fn unique_id(&self) -> Result<ObjectId> {
+    pub fn unique_id(&self) -> Result<ObjectId<'_>> {
         self.inner
             .new_unique_id()
             .map_err(Error::from)
@@ -127,7 +127,7 @@ impl ObjectNamespace {
     ///
     /// See supported jurisdictions and more documentation at:
     /// <https://developers.cloudflare.com/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction>
-    pub fn unique_id_with_jurisdiction(&self, jd: &str) -> Result<ObjectId> {
+    pub fn unique_id_with_jurisdiction(&self, jd: &str) -> Result<ObjectId<'_>> {
         let options = Object::new();
         js_sys::Reflect::set(&options, &JsValue::from("jurisdiction"), &jd.into())?;
         self.inner

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -42,7 +42,7 @@ impl Bucket {
     /// Retrieves the [Object] for the given key containing object metadata and the object body if
     /// the key exists. In the event that a precondition specified in options fails, get() returns
     /// an [Object] with no body.
-    pub fn get(&self, key: impl Into<String>) -> GetOptionsBuilder {
+    pub fn get(&self, key: impl Into<String>) -> GetOptionsBuilder<'_> {
         GetOptionsBuilder {
             edge_bucket: &self.inner,
             key: key.into(),
@@ -56,7 +56,7 @@ impl Bucket {
     ///
     /// R2 writes are strongly consistent. Once the future resolves, all subsequent read operations
     /// will see this key value pair globally.
-    pub fn put(&self, key: impl Into<String>, value: impl Into<Data>) -> PutOptionsBuilder {
+    pub fn put(&self, key: impl Into<String>, value: impl Into<Data>) -> PutOptionsBuilder<'_> {
         PutOptionsBuilder {
             edge_bucket: &self.inner,
             key: key.into(),
@@ -98,7 +98,7 @@ impl Bucket {
 
     /// Returns an [Objects] containing a list of [Objects]s contained within the bucket. By
     /// default, returns the first 1000 entries.
-    pub fn list(&self) -> ListOptionsBuilder {
+    pub fn list(&self) -> ListOptionsBuilder<'_> {
         ListOptionsBuilder {
             edge_bucket: &self.inner,
             limit: None,
@@ -117,7 +117,7 @@ impl Bucket {
     pub fn create_multipart_upload(
         &self,
         key: impl Into<String>,
-    ) -> CreateMultipartUploadOptionsBuilder {
+    ) -> CreateMultipartUploadOptionsBuilder<'_> {
         CreateMultipartUploadOptionsBuilder {
             edge_bucket: &self.inner,
             key: key.into(),
@@ -270,7 +270,7 @@ impl Object {
         .try_into()
     }
 
-    pub fn body(&self) -> Option<ObjectBody> {
+    pub fn body(&self) -> Option<ObjectBody<'_>> {
         match &self.inner {
             ObjectInner::NoBody(_) => None,
             ObjectInner::Body(body) => Some(ObjectBody { inner: body }),

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -208,7 +208,7 @@ impl WebSocket {
 
     /// Gets an implementation [`Stream`](futures::Stream) that yields events from the inner
     /// WebSocket.
-    pub fn events(&self) -> Result<EventStream> {
+    pub fn events(&self) -> Result<EventStream<'_>> {
         let (tx, rx) = futures_channel::mpsc::unbounded::<Result<WebsocketEvent>>();
         let tx = Rc::new(tx);
 


### PR DESCRIPTION
The warnings in question:

```
warning: hiding a lifetime that's elided elsewhere is confusing
  --> worker/src/durable.rs:80:25
   |
80 |     pub fn id_from_name(&self, name: &str) -> Result<ObjectId> {
   |                         ^^^^^                        ^^^^^^^^ the same lifetime is hidden here
   |                         |
   |                         the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: use `'_` for type paths
   |
80 |     pub fn id_from_name(&self, name: &str) -> Result<ObjectId<'_>> {
   |                                                              ++++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> worker/src/durable.rs:98:27
   |
98 |     pub fn id_from_string(&self, hex_id: &str) -> Result<ObjectId> {
   |                           ^^^^^                          ^^^^^^^^ the same lifetime is hidden here
   |                           |
   |                           the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
98 |     pub fn id_from_string(&self, hex_id: &str) -> Result<ObjectId<'_>> {
   |                                                                  ++++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> worker/src/durable.rs:111:22
    |
111 |     pub fn unique_id(&self) -> Result<ObjectId> {
    |                      ^^^^^            ^^^^^^^^ the same lifetime is hidden here
    |                      |
    |                      the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
111 |     pub fn unique_id(&self) -> Result<ObjectId<'_>> {
    |                                               ++++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> worker/src/durable.rs:130:40
    |
130 |     pub fn unique_id_with_jurisdiction(&self, jd: &str) -> Result<ObjectId> {
    |                                        ^^^^^                      ^^^^^^^^ the same lifetime is hidden here
    |                                        |
    |                                        the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
130 |     pub fn unique_id_with_jurisdiction(&self, jd: &str) -> Result<ObjectId<'_>> {
    |                                                                           ++++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> worker/src/r2/mod.rs:45:16
   |
45 |     pub fn get(&self, key: impl Into<String>) -> GetOptionsBuilder {
   |                ^^^^^ the lifetime is elided here ^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
45 |     pub fn get(&self, key: impl Into<String>) -> GetOptionsBuilder<'_> {
   |                                                                   ++++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> worker/src/r2/mod.rs:59:16
   |
59 |     pub fn put(&self, key: impl Into<String>, value: impl Into<Data>) -> PutOptionsBuilder {
   |                ^^^^^ the lifetime is elided here                         ^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
59 |     pub fn put(&self, key: impl Into<String>, value: impl Into<Data>) -> PutOptionsBuilder<'_> {
   |                                                                                           ++++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> worker/src/r2/mod.rs:101:17
    |
101 |     pub fn list(&self) -> ListOptionsBuilder {
    |                 ^^^^^     ^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                 |
    |                 the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
101 |     pub fn list(&self) -> ListOptionsBuilder<'_> {
    |                                             ++++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> worker/src/r2/mod.rs:118:9
    |
118 |         &self,
    |         ^^^^^ the lifetime is elided here
119 |         key: impl Into<String>,
120 |     ) -> CreateMultipartUploadOptionsBuilder {
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
120 |     ) -> CreateMultipartUploadOptionsBuilder<'_> {
    |                                             ++++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> worker/src/r2/mod.rs:273:17
    |
273 |     pub fn body(&self) -> Option<ObjectBody> {
    |                 ^^^^^            ^^^^^^^^^^ the same lifetime is hidden here
    |                 |
    |                 the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
273 |     pub fn body(&self) -> Option<ObjectBody<'_>> {
    |                                            ++++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> worker/src/websocket.rs:211:19
    |
211 |     pub fn events(&self) -> Result<EventStream> {
    |                   ^^^^^            ^^^^^^^^^^^ the same lifetime is hidden here
    |                   |
    |                   the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
211 |     pub fn events(&self) -> Result<EventStream<'_>> {
    |                                               ++++

```