### PR TITLE
wasm bindgen submodule support

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -42,6 +44,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -79,6 +83,9 @@ jobs:
       - name: Install wasmpack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
+      - name: Build wasm-bindgen
+        run: cd wasm-bindgen && cargo build --release --package wasm-bindgen-cli --bin wasm-bindgen
+
       - name: Build local worker-build
         run: cargo install --path ./worker-build --force --debug
 
@@ -86,7 +93,7 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm run test
+        run: WASM_BINDGEN_PATH=./wasm-bindgen/target/release/wasm-bindgen npm run test
 
       - name: Run tests (http)
-        run: npm run test-http
+        run: WASM_BINDGEN_PATH=./wasm-bindgen/target/release/wasm-bindgen npm run test-http

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "wasm-bindgen"]
+	path = wasm-bindgen
+	url = git@github.com:wasm-bindgen/wasm-bindgen

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,8 +1436,6 @@ dependencies = [
 [[package]]
 name = "js-sys"
 version = "0.3.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3364,8 +3362,6 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 [[package]]
 name = "wasm-bindgen"
 version = "0.2.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3377,8 +3373,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-backend"
 version = "0.2.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -3391,8 +3385,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-cli-support"
 version = "0.2.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861a035764c5019d0f7452ebe8bf4b291930200f78393476f72c45d5c427e8be"
 dependencies = [
  "anyhow",
  "base64",
@@ -3409,8 +3401,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-futures"
 version = "0.4.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3422,8 +3412,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3432,8 +3420,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro-support"
 version = "0.2.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3445,8 +3431,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
@@ -3454,8 +3438,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-test"
 version = "0.3.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80cc7f8a4114fdaa0c58383caf973fc126cf004eba25c9dc639bccd3880d55ad"
 dependencies = [
  "js-sys",
  "minicov",
@@ -3467,8 +3449,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-test-macro"
 version = "0.3.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ada2ab788d46d4bda04c9d567702a79c8ced14f51f221646a16ed39d0e6a5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3525,8 +3505,6 @@ dependencies = [
 [[package]]
 name = "web-sys"
 version = "0.3.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "worker-kv",
     "examples/*",
 ]
-exclude = ["examples/coredump", "examples/axum", "templates/*"]
+exclude = ["examples/coredump", "examples/axum", "templates/*", "wasm-bindgen"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -19,15 +19,17 @@ chrono = { version = "0.4.41", default-features = false, features = [
 futures-channel = "0.3.31"
 futures-util = { version = "0.3.31", default-features = false }
 http = "1.3"
-js-sys = "0.3.77"
+js-sys = { version = "0.3.78", path = "./wasm-bindgen/crates/js-sys" }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.140"
 serde-wasm-bindgen = "0.6.5"
-wasm-bindgen = "0.2.101"
-wasm-bindgen-cli-support = "0.2.101"
-wasm-bindgen-futures = "0.4.51"
-wasm-bindgen-macro-support = "0.2.101"
-wasm-bindgen-test = "0.3.51"
+wasm-bindgen = { version = "0.2.101", path = "./wasm-bindgen" }
+wasm-bindgen-cli-support = { version = "0.2.101", path = "./wasm-bindgen/crates/cli-support" }
+wasm-bindgen-futures = { version = "0.4.51", path = "./wasm-bindgen/crates/futures" }
+wasm-bindgen-macro-support = { version = "0.2.101", path = "./wasm-bindgen/crates/macro-support" }
+wasm-bindgen-shared = { version = "0.2.101", path = "./wasm-bindgen/crates/shared" }
+wasm-bindgen-test = { version = "0.3.51", path = "./wasm-bindgen/crates/test" }
+web-sys = { version = "0.3.78", path = "./wasm-bindgen/crates/web-sys" }
 worker = { path = "worker", version = "0.6.1", features = ["queue", "d1", "axum", "timezone"] }
 worker-build = { path = "worker-build", version = "0.1.4" }
 worker-codegen = { path = "worker-codegen", version = "0.2.0" }
@@ -57,3 +59,13 @@ lto = true
 [profile.release.package."*"]
 codegen-units = 1
 opt-level = "z"
+
+[patch.crates-io]
+js-sys = { version = "0.3.78", path = './wasm-bindgen/crates/js-sys' }
+wasm-bindgen = { version = "0.2.101", path = './wasm-bindgen' }
+wasm-bindgen-cli-support = { version = "0.2.101", path = "./wasm-bindgen/crates/cli-support" }
+wasm-bindgen-futures = { version = "0.4.51", path = './wasm-bindgen/crates/futures' }
+wasm-bindgen-macro-support = { version = "0.2.101", path = "./wasm-bindgen/crates/macro-support" }
+wasm-bindgen-shared = { version = "0.2.101", path = "./wasm-bindgen/crates/shared" }
+wasm-bindgen-test = { version = "0.3.51", path = "./wasm-bindgen/crates/test" }
+web-sys = { version = "0.3.78", path = './wasm-bindgen/crates/web-sys' }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "vitest": "^3.2.4"
   },
   "scripts": {
-    "install": "cargo install --path ./worker-build --force --debug",
-    "test": "cd worker-sandbox && NO_MINIFY=1 worker-build --dev && NODE_OPTIONS=--experimental-vm-modules npx vitest run",
-    "test-http": "cd worker-sandbox && NO_MINIFY=1 worker-build --dev --features http && NODE_OPTIONS=--experimental-vm-modules npx vitest run",
+    "install": "cd wasm-bindgen && cargo build --release --package wasm-bindgen-cli --bin wasm-bindgen && cd .. && cargo install --path ./worker-build --force --debug",
+    "test": "cd worker-sandbox && NO_MINIFY=1 WASM_BINDGEN_PATH=../wasm-bindgen/target/release/wasm-bindgen worker-build --dev && NODE_OPTIONS=--experimental-vm-modules npx vitest run",
+    "test-http": "cd worker-sandbox && NO_MINIFY=1 WASM_BINDGEN_PATH=../wasm-bindgen/target/release/wasm-bindgen worker-build --dev --features http && NODE_OPTIONS=--experimental-vm-modules npx vitest run",
     "lint": "cargo clippy --features d1,queue --all-targets --workspace -- -D warnings",
     "lint:fix": "cargo fmt && cargo clippy --features d1,queue --all-targets --workspace --fix -- -D warnings"
   }

--- a/worker-build/src/wasm_pack/install/mod.rs
+++ b/worker-build/src/wasm_pack/install/mod.rs
@@ -57,15 +57,21 @@ pub fn download_prebuilt_or_cargo_install(
         if let Ok(custom_path) = env::var("WASM_BINDGEN_PATH") {
             let path = Path::new(&custom_path);
             if path.exists() {
-                info!("Using custom wasm-bindgen from WASM_BINDGEN_PATH: {}", custom_path);
+                info!(
+                    "Using custom wasm-bindgen from WASM_BINDGEN_PATH: {}",
+                    custom_path
+                );
                 let download = Download::at(path.parent().unwrap_or(path));
                 return Ok(Status::Found(download));
             } else {
-                warn!("WASM_BINDGEN_PATH set but path doesn't exist: {}", custom_path);
+                warn!(
+                    "WASM_BINDGEN_PATH set but path doesn't exist: {}",
+                    custom_path
+                );
             }
         }
     }
-    
+
     // If the tool is installed globally and it has the right version, use
     // that. Assume that other tools are installed next to it.
     //

--- a/worker-build/src/wasm_pack/install/mod.rs
+++ b/worker-build/src/wasm_pack/install/mod.rs
@@ -52,6 +52,20 @@ pub fn download_prebuilt_or_cargo_install(
     version: &str,
     install_permitted: bool,
 ) -> Result<Status> {
+    // Check for custom wasm-bindgen path via environment variable
+    if matches!(tool, Tool::WasmBindgen) {
+        if let Ok(custom_path) = env::var("WASM_BINDGEN_PATH") {
+            let path = Path::new(&custom_path);
+            if path.exists() {
+                info!("Using custom wasm-bindgen from WASM_BINDGEN_PATH: {}", custom_path);
+                let download = Download::at(path.parent().unwrap_or(path));
+                return Ok(Status::Found(download));
+            } else {
+                warn!("WASM_BINDGEN_PATH set but path doesn't exist: {}", custom_path);
+            }
+        }
+    }
+    
     // If the tool is installed globally and it has the right version, use
     // that. Assume that other tools are installed next to it.
     //


### PR DESCRIPTION
This includes wasm-bindgen as a submodule in workers-rs, and updates the build calls to correctly reference it.

This allows us to easily test new wasm-bindgen releases and PRs ahead of time.