### PR TITLE
Change wasm-bindgen modules to https url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wasm-bindgen"]
 	path = wasm-bindgen
-	url = git@github.com:wasm-bindgen/wasm-bindgen
+	url = https://github.com/wasm-bindgen/wasm-bindgen


### PR DESCRIPTION
Switch the submodule's protocol to http so it can be used and built on machines without Git authentication