### PR TITLE
fix snippets handling when not using snippets

### DIFF
--- a/worker-build/src/main.rs
+++ b/worker-build/src/main.rs
@@ -273,7 +273,10 @@ fn bundle(esbuild_path: &Path) -> Result<()> {
 fn remove_unused_files() -> Result<()> {
     std::fs::remove_file(output_path("index_bg.wasm.d.ts"))?;
     std::fs::remove_file(output_path("shim.js"))?;
-    std::fs::remove_dir_all(output_path("snippets"))?;
+    let snippets_path = output_path("snippets");
+    if snippets_path.exists() {
+        std::fs::remove_dir_all(snippets_path)?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Fixes a bug in worker-build where we were trying to remove the `snippets` folder when snippets were not used resulting an an error.