### PR TITLE
fix keeping support for CUSTOM_SHIM

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -189,6 +189,8 @@ jobs:
           push: false
           load: true
           tags: worker-dev/echocontainer:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run tests
         env:

--- a/worker-build/src/main.rs
+++ b/worker-build/src/main.rs
@@ -72,9 +72,9 @@ pub fn main() -> Result<()> {
 
     wasm_pack_build.init()?;
 
-    let supports_module_and_reset_state =
-        wasm_pack_build.supports_target_module_and_reset_state()?;
-    if supports_module_and_reset_state {
+    let module_target = wasm_pack_build.supports_target_module_and_reset_state()?
+        || env::var("CUSTOM_SHIM").is_ok();
+    if module_target {
         wasm_pack_build
             .extra_args
             .push("--experimental-reset-state-function".to_string());
@@ -91,7 +91,7 @@ pub fn main() -> Result<()> {
         wasm_coredump()?;
     }
 
-    if supports_module_and_reset_state {
+    if module_target {
         let (has_fetch_handler, has_queue_handler, has_scheduled_handler) =
             detect_exported_handlers()?;
 


### PR DESCRIPTION
This was deprecated in the change to the wasm-bindgen module target, but we need to retain support for backwards compat until the official deprecation can be made (and alternative mechanisms for RPC bindings are provided).

Replaces https://github.com/cloudflare/workers-rs/pull/829.