### PR TITLE
Support eager memory deallocation on hibernation

### DIFF
--- a/worker-build/src/js/shim.js
+++ b/worker-build/src/js/shim.js
@@ -15,14 +15,14 @@ function registerPanicHook() {
 
 registerPanicHook();
 
-let instanceId = 0;
+let reinitId = 0;
 function checkReinitialize() {
   if (panicError) {
     console.log("Reinitializing Wasm application");
     exports.__wbg_reset_state();
     panicError = null;
     registerPanicHook();
-    instanceId++;
+    reinitId++;
   }
 }
 
@@ -30,20 +30,24 @@ export default class Entrypoint extends WorkerEntrypoint {
 $HANDLERS
 }
 
+const instances = new Map();
 const classProxyHooks = {
   construct(ctor, args, newTarget) {
-    const instance = {
-      instance: Reflect.construct(ctor, args, newTarget),
-      instanceId,
+    instances.get(ctor)?.free();
+    const instance = Reflect.construct(ctor, args, newTarget);
+    instances.set(ctor, instance);
+    const target = {
+      instance,
+      reinitId,
       ctor,
       args,
       newTarget
     };
-    return new Proxy(instance, {
+    return new Proxy(target, {
       get(target, prop, receiver) {
-        if (target.instanceId !== instanceId) {
-          target.instance = Reflect.construct(target.ctor, target.args, target.newTarget);
-          target.instanceId = instanceId;
+        if (target.reinitId !== reinitId) {
+          instances.set(target.ctor, target.instance = Reflect.construct(target.ctor, target.args, target.newTarget));
+          target.reinitId = reinitId;
         }
         return Reflect.get(target.instance, prop, receiver);
       }

--- a/worker-build/src/js/shim.js
+++ b/worker-build/src/js/shim.js
@@ -36,14 +36,13 @@ const classProxyHooks = {
     instances.get(ctor)?.free();
     const instance = Reflect.construct(ctor, args, newTarget);
     instances.set(ctor, instance);
-    const target = {
+    return new Proxy({
       instance,
       reinitId,
       ctor,
       args,
       newTarget
-    };
-    return new Proxy(target, {
+    }, {
       get(target, prop, receiver) {
         if (target.reinitId !== reinitId) {
           instances.set(target.ctor, target.instance = Reflect.construct(target.ctor, target.args, target.newTarget));


### PR DESCRIPTION
While formally not a memory leak, this reduces Wasm memory usage for durable objects subject to hibernation by eagerly freeing Wasm memory associated with the stale instance when a new instance is constructed.