### PR TITLE
feat: support --no-panic-recovery flag to disable panic reinitialization

### DIFF
--- a/worker-build/src/wasm_pack/command/build.rs
+++ b/worker-build/src/wasm_pack/command/build.rs
@@ -176,6 +176,10 @@ pub struct BuildOptions {
     /// List of extra options to pass to `cargo build`
     pub extra_options: Vec<String>,
 
+    #[clap(long, hide = true)]
+    /// Pass-through for --no-panic-recovery
+    pub no_panic_recovery: bool,
+
     #[deprecated(note = "runtime-detected")]
     #[allow(dead_code)]
     #[clap(long = "weak-refs", hide = true)]


### PR DESCRIPTION
This allows disabling the panic reinitialization to instead continue executing Wasm code after a panic.

When dealing with say 1000 concurrent requests, an error in one request would cause all other 999 to abort and stall.

Instead, in many cases, despite being invalid state and "undefined behaviour", we are typically lucky and those other 999 requests would still be able to complete despite the panic.

While this is a **unsafe behaviour**, it was the legacy behaviour which can now be reenabled as a workaround. This may be useful at least until we have formal exception handling with recoverable panics.