### PR TITLE
Add client_accept_encoding method to Cf struct

### DIFF
--- a/worker-sys/src/types/incoming_request_cf_properties.rs
+++ b/worker-sys/src/types/incoming_request_cf_properties.rs
@@ -69,4 +69,7 @@ extern "C" {
 
     #[wasm_bindgen(method, catch, getter, js_name=isEUCountry)]
     pub fn is_eu_country(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
+
+    #[wasm_bindgen(method, catch, getter, js_name=clientAcceptEncoding)]
+    pub fn client_accept_encoding(this: &IncomingRequestCfProperties) -> Result<Option<String>, JsValue>;
 }

--- a/worker/src/cf.rs
+++ b/worker/src/cf.rs
@@ -184,6 +184,11 @@ impl Cf {
         }
         .map_err(crate::Error::from)
     }
+
+    /// The client's accepted encoding preferences
+    pub fn client_accept_encoding(&self) -> Option<String> {
+        self.inner.client_accept_encoding().unwrap()
+    }
 }
 
 /// Browser-requested prioritization information.


### PR DESCRIPTION
This PR adds a wasm-bindgen getter to expose Cloudflare's clientAcceptEncoding property from the request cf object to Rust/WASM via IncomingRequestCfProperties::client_accept_encoding.

Reference: https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties