### PR TITLE
Deprecate SendWrapper and #[worker::send] — JsValue is now Send

### DIFF
--- a/examples/axum/Cargo.lock
+++ b/examples/axum/Cargo.lock
@@ -342,9 +342,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -666,9 +666,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -716,18 +716,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -748,9 +748,7 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e113ad04154d7ded1b582891ef2ae0d62d8460fcc5663cd2378588161527c"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -779,9 +777,7 @@ dependencies = [
 
 [[package]]
 name = "worker-macros"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c7ca8df6cf32003d4f60c7c89a7e975e0fa0cbf031726f45cd395e557d9a5e"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "proc-macro2",
@@ -795,9 +791,7 @@ dependencies = [
 
 [[package]]
 name = "worker-sys"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefeaf6edf2558ff50e6776056464b507f64be9c1f26f2465af531b584867ed7"
+version = "0.7.4"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -10,8 +10,8 @@ release = false
 crate-type = ["cdylib"]
 
 [dependencies]
-worker = { version = "0.7", features = ['http', 'axum'] }
-worker-macros = { version = "0.7", features = ['http'] }
+worker = { path = "../../worker", features = ['http', 'axum'] }
+worker-macros = { path = "../../worker-macros", features = ['http'] }
 axum = { version = "0.8", default-features = false, features = ['json'] }
 axum-macros = "0.5.0"
 tower-service = "0.3.3"

--- a/examples/axum/src/resources/foos/api.rs
+++ b/examples/axum/src/resources/foos/api.rs
@@ -5,15 +5,6 @@ use axum::Json;
 use axum_macros::debug_handler;
 use worker::Result;
 
-/// `get()` requires the `#[worker::send]` macro because Cloudflare Workers
-/// execute a handler's future on a single JavaScript event loop.
-///
-/// The macro helps make `await` boundaries in the handler's function body `Send`
-/// so the worker runtime can safely poll them.
-///
-/// You can read more about it here in the "`Send` Helpers" section:
-/// https://docs.rs/worker/latest/worker/
-#[worker::send]
 #[debug_handler]
 pub async fn get(
     State(state): State<AppState>,

--- a/examples/rpc-client/src/calculator.rs
+++ b/examples/rpc-client/src/calculator.rs
@@ -22,20 +22,18 @@ mod sys {
 pub trait Calculator {
     async fn add(&self, a: u32, b: u32) -> ::worker::Result<u64>;
 }
-pub struct CalculatorService(::worker::send::SendWrapper<sys::CalculatorSys>);
+pub struct CalculatorService(sys::CalculatorSys);
 #[async_trait::async_trait]
 impl Calculator for CalculatorService {
     async fn add(&self, a: u32, b: u32) -> ::worker::Result<u32> {
         let promise = self.0.add(a, b)?;
-        let fut = ::worker::send::SendFuture::new(
-            ::worker::wasm_bindgen_futures::JsFuture::from(promise),
-        );
+        let fut = ::worker::wasm_bindgen_futures::JsFuture::from(promise);
         let output = fut.await?;
         Ok(::serde_wasm_bindgen::from_value(output)?)
     }
 }
 impl From<::worker::Fetcher> for CalculatorService {
     fn from(fetcher: ::worker::Fetcher) -> Self {
-        Self(::worker::send::SendWrapper::new(fetcher.into_rpc()))
+        Self(fetcher.into_rpc())
     }
 }

--- a/test/src/alarm.rs
+++ b/test/src/alarm.rs
@@ -36,7 +36,6 @@ impl DurableObject for AlarmObject {
     }
 }
 
-#[worker::send]
 pub async fn handle_alarm(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let namespace = env.durable_object("ALARM")?;
     let stub = namespace.id_from_name("alarm")?.get_stub()?;

--- a/test/src/analytics_engine.rs
+++ b/test/src/analytics_engine.rs
@@ -2,7 +2,6 @@ use super::SomeSharedData;
 use uuid::Uuid;
 use worker::{AnalyticsEngineDataPointBuilder, Env, Request, Response, Result};
 
-#[worker::send]
 pub async fn handle_analytics_event(
     req: Request,
     env: Env,
@@ -31,5 +30,5 @@ pub async fn handle_analytics_event(
         .add_double(200)
         .write_to(&dataset)?;
 
-    return Response::ok("Events sent");
+    Response::ok("Events sent")
 }

--- a/test/src/assets.rs
+++ b/test/src/assets.rs
@@ -17,7 +17,6 @@ pub async fn handle_asset(
 }
 
 #[cfg(feature = "http")]
-#[worker::send]
 pub async fn handle_asset(
     req: worker::Request,
     env: worker::Env,

--- a/test/src/auto_response.rs
+++ b/test/src/auto_response.rs
@@ -36,7 +36,6 @@ impl DurableObject for AutoResponseObject {
 }
 
 // Route handler to exercise the Durable Object from tests.
-#[worker::send]
 pub async fn handle_auto_response(
     _req: Request,
     env: Env,

--- a/test/src/container.rs
+++ b/test/src/container.rs
@@ -81,7 +81,6 @@ impl DurableObject for EchoContainer {
 
 const CONTAINER_NAME: &str = "my-container";
 
-#[worker::send]
 pub async fn handle_container(
     mut req: Request,
     env: Env,
@@ -140,5 +139,15 @@ async fn redir_websocket(dst: WebSocket, src: WebSocket) {
                     .expect_throw("failed to close dst websocket");
             }
         }
+    }
+}
+
+// Compile-time assertion: public async Container methods return Send futures.
+#[allow(dead_code, unused)]
+fn _assert_send() {
+    fn require_send<T: Send>(_t: T) {}
+    fn container(c: worker::Container) {
+        require_send(c.wait_for_exit());
+        require_send(c.destroy(None));
     }
 }

--- a/test/src/counter.rs
+++ b/test/src/counter.rs
@@ -95,7 +95,6 @@ impl DurableObject for Counter {
     }
 }
 
-#[worker::send]
 pub async fn handle_id(req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let durable_object_name = if req.path().contains("shared") {
         "SHARED_COUNTER"
@@ -110,7 +109,6 @@ pub async fn handle_id(req: Request, env: Env, _data: SomeSharedData) -> Result<
     stub.fetch_with_str("https://fake-host/").await
 }
 
-#[worker::send]
 pub async fn handle_websocket(req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let durable_object_name = if req.path().contains("shared") {
         "SHARED_COUNTER"

--- a/test/src/durable.rs
+++ b/test/src/durable.rs
@@ -199,7 +199,6 @@ impl DurableObject for AnotherClass {
 }
 
 // Route handlers to exercise the Durable Object from tests.
-#[worker::send]
 pub async fn handle_hello(
     _req: Request,
     env: Env,
@@ -213,7 +212,6 @@ pub async fn handle_hello(
         .await
 }
 
-#[worker::send]
 pub async fn handle_hello_unique(
     _req: Request,
     env: Env,
@@ -227,7 +225,6 @@ pub async fn handle_hello_unique(
         .await
 }
 
-#[worker::send]
 pub async fn handle_storage(
     _req: Request,
     env: Env,
@@ -238,7 +235,6 @@ pub async fn handle_storage(
     stub.fetch_with_str("https://fake-host/storage").await
 }
 
-#[worker::send]
 pub async fn handle_basic_test(
     _req: Request,
     env: Env,
@@ -313,7 +309,6 @@ pub async fn handle_basic_test(
     Response::ok("ok")
 }
 
-#[worker::send]
 pub async fn handle_get_by_name(
     _req: Request,
     env: Env,
@@ -331,7 +326,6 @@ pub async fn handle_get_by_name(
         .await
 }
 
-#[worker::send]
 pub async fn handle_get_by_name_with_location_hint(
     _req: Request,
     env: Env,
@@ -345,4 +339,13 @@ pub async fn handle_get_by_name_with_location_hint(
 
     stub.fetch_with_str(&format!("https://fake-host/hello?name={name}"))
         .await
+}
+
+// Compile-time assertion: public async Durable Object methods return Send futures.
+#[allow(dead_code, unused)]
+fn _assert_send() {
+    fn require_send<T: Send>(_t: T) {}
+    fn stub(s: worker::Stub) {
+        require_send(s.fetch_with_str("https://example.com"));
+    }
 }

--- a/test/src/fetch.rs
+++ b/test/src/fetch.rs
@@ -7,7 +7,6 @@ use worker::{
     RequestInit, Response, Result,
 };
 
-#[worker::send]
 pub async fn handle_fetch(_req: Request, _env: Env, _data: SomeSharedData) -> Result<Response> {
     let req = Request::new("https://example.com", Method::Post)?;
     let resp = Fetch::Request(req).send().await?;
@@ -19,7 +18,6 @@ pub async fn handle_fetch(_req: Request, _env: Env, _data: SomeSharedData) -> Re
     ))
 }
 
-#[worker::send]
 pub async fn handle_fetch_json(
     _req: Request,
     _env: Env,
@@ -40,7 +38,6 @@ pub async fn handle_fetch_json(
     ))
 }
 
-#[worker::send]
 pub async fn handle_proxy_request(
     req: Request,
     _env: Env,
@@ -57,7 +54,6 @@ pub async fn handle_proxy_request(
     Fetch::Url(url.parse()?).send().await
 }
 
-#[worker::send]
 pub async fn handle_request_init_fetch(
     _req: Request,
     _env: Env,
@@ -69,7 +65,6 @@ pub async fn handle_request_init_fetch(
         .await
 }
 
-#[worker::send]
 pub async fn handle_request_init_fetch_post(
     _req: Request,
     _env: Env,
@@ -82,7 +77,6 @@ pub async fn handle_request_init_fetch_post(
         .await
 }
 
-#[worker::send]
 pub async fn handle_cancelled_fetch(
     _req: Request,
     _env: Env,
@@ -115,7 +109,6 @@ pub async fn handle_cancelled_fetch(
     Ok(res)
 }
 
-#[worker::send]
 pub async fn handle_fetch_timeout(
     _req: Request,
     _env: Env,
@@ -158,7 +151,6 @@ pub async fn handle_fetch_timeout(
     }
 }
 
-#[worker::send]
 pub async fn handle_cloned_fetch(
     _req: Request,
     _env: Env,
@@ -179,7 +171,6 @@ pub async fn handle_cloned_fetch(
     Response::ok((left == right).to_string())
 }
 
-#[worker::send]
 pub async fn handle_cloned_response_attributes(
     _req: Request,
     _env: Env,
@@ -208,4 +199,16 @@ pub async fn handle_cloned_response_attributes(
     assert_eq!(cf, cf1);
 
     Response::ok("true")
+}
+
+// Compile-time assertion: public async Fetch methods return Send futures.
+#[allow(dead_code, unused)]
+fn _assert_send() {
+    fn require_send<T: Send>(_t: T) {}
+    fn fetch(f: worker::Fetch) {
+        require_send(f.send());
+    }
+    fn fetcher(f: worker::Fetcher) {
+        require_send(f.fetch("https://example.com", None));
+    }
 }

--- a/test/src/form.rs
+++ b/test/src/form.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use worker::{kv, Env, FormEntry, Request, Response, Result};
 
-#[worker::send]
 pub async fn handle_formdata_name(
     mut req: Request,
     _env: Env,
@@ -48,7 +47,6 @@ struct FileSize {
     size: u32,
 }
 
-#[worker::send]
 pub async fn handle_formdata_file_size(
     mut req: Request,
     env: Env,
@@ -88,7 +86,6 @@ pub async fn handle_formdata_file_size(
     Response::error("Bad Request", 400)
 }
 
-#[worker::send]
 pub async fn handle_formdata_file_size_hash(
     req: Request,
     env: Env,
@@ -108,7 +105,6 @@ pub async fn handle_formdata_file_size_hash(
     Response::error("Bad Request", 400)
 }
 
-#[worker::send]
 pub async fn handle_is_secret(
     mut req: Request,
     env: Env,

--- a/test/src/js_snippets.rs
+++ b/test/src/js_snippets.rs
@@ -22,12 +22,10 @@ extern "C" {
     fn js_throw_error();
 }
 
-#[worker::send]
 pub async fn performance_now(_req: Request, _env: Env, _data: SomeSharedData) -> Result<Response> {
     Response::ok(format!("now: {}", js_performance_now()))
 }
 
-#[worker::send]
 pub async fn console_log(_req: Request, _env: Env, _data: SomeSharedData) -> Result<Response> {
     js_console_log("test".to_owned());
     Response::ok("OK")

--- a/test/src/kv.rs
+++ b/test/src/kv.rs
@@ -17,7 +17,6 @@ macro_rules! kv_assert_eq {
     }};
 }
 
-#[worker::send]
 pub async fn handle_post_key_value(
     req: Request,
     env: Env,
@@ -39,7 +38,6 @@ pub async fn handle_post_key_value(
 
 const TEST_NAMESPACE: &str = "TEST";
 
-#[worker::send]
 pub async fn get(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let store = env.kv(TEST_NAMESPACE)?;
     let value = store.get("simple").text().await?;
@@ -49,7 +47,6 @@ pub async fn get(_req: Request, env: Env, _data: SomeSharedData) -> Result<Respo
     }
 }
 
-#[worker::send]
 pub async fn get_not_found(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let store = env.kv(TEST_NAMESPACE)?;
     let value = store.get("not_found").text().await?;
@@ -59,7 +56,6 @@ pub async fn get_not_found(_req: Request, env: Env, _data: SomeSharedData) -> Re
     }
 }
 
-#[worker::send]
 pub async fn list_keys(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let store = env.kv(TEST_NAMESPACE)?;
     let list_res = store.list().execute().await?;
@@ -70,7 +66,6 @@ pub async fn list_keys(_req: Request, env: Env, _data: SomeSharedData) -> Result
     Response::ok("passed")
 }
 
-#[worker::send]
 pub async fn put_simple(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let store = env.kv(TEST_NAMESPACE)?;
     store.put("put_a", "test")?.execute().await?;
@@ -81,7 +76,6 @@ pub async fn put_simple(_req: Request, env: Env, _data: SomeSharedData) -> Resul
     Response::ok("passed")
 }
 
-#[worker::send]
 pub async fn put_metadata(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let store = env.kv(TEST_NAMESPACE)?;
     store.put("put_b", "test")?.metadata(100)?.execute().await?;
@@ -93,7 +87,6 @@ pub async fn put_metadata(_req: Request, env: Env, _data: SomeSharedData) -> Res
     Response::ok("passed")
 }
 
-#[worker::send]
 pub async fn put_expiration(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     const EXPIRATION: u64 = 2_000_000_000;
     let store = env.kv(TEST_NAMESPACE)?;
@@ -117,7 +110,6 @@ pub async fn put_expiration(_req: Request, env: Env, _data: SomeSharedData) -> R
     Response::ok("passed")
 }
 
-#[worker::send]
 pub async fn put_metadata_struct(
     _req: Request,
     env: Env,
@@ -147,4 +139,19 @@ pub async fn put_metadata_struct(
     kv_assert_eq!(meta.unwrap(), put_meta)?;
 
     Response::ok("passed")
+}
+
+// Compile-time assertion: public async KV methods return Send futures.
+#[allow(dead_code, unused)]
+fn _assert_send() {
+    fn require_send<T: Send>(_t: T) {}
+    fn kv(kv: worker::KvStore) {
+        require_send(kv.put("k", "v").unwrap().execute());
+        require_send(kv.get("k").text());
+        require_send(kv.get("k").json::<String>());
+        require_send(kv.get("k").bytes());
+        require_send(kv.get("k").text_with_metadata::<String>());
+        require_send(kv.delete("k"));
+        require_send(kv.list().execute());
+    }
 }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -52,6 +52,9 @@ pub struct SomeSharedData {
     regex: &'static Regex,
 }
 
+unsafe impl Send for SomeSharedData {}
+unsafe impl Sync for SomeSharedData {}
+
 static GLOBAL_STATE: AtomicBool = AtomicBool::new(false);
 
 static GLOBAL_QUEUE_STATE: Mutex<Vec<queue::QueueBody>> = Mutex::new(Vec::new());

--- a/test/src/put_raw.rs
+++ b/test/src/put_raw.rs
@@ -66,7 +66,6 @@ impl DurableObject for PutRawTestObject {
     }
 }
 
-#[worker::send]
 pub(crate) async fn handle_put_raw(
     req: Request,
     env: Env,

--- a/test/src/r2.rs
+++ b/test/src/r2.rs
@@ -31,7 +31,6 @@ pub async fn seed_bucket(bucket: &Bucket) -> Result<()> {
     Ok(())
 }
 
-#[worker::send]
 pub async fn list_empty(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let bucket = env.bucket("EMPTY_BUCKET")?;
 
@@ -43,7 +42,6 @@ pub async fn list_empty(_req: Request, env: Env, _data: SomeSharedData) -> Resul
     Response::ok("ok")
 }
 
-#[worker::send]
 pub async fn list(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let bucket = env.bucket("SEEDED_BUCKET")?;
     seed_bucket(&bucket).await?;
@@ -96,7 +94,6 @@ pub async fn list(_req: Request, env: Env, _data: SomeSharedData) -> Result<Resp
     Response::ok("ok")
 }
 
-#[worker::send]
 pub async fn get_empty(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let bucket = env.bucket("EMPTY_BUCKET")?;
 
@@ -119,7 +116,6 @@ pub async fn get_empty(_req: Request, env: Env, _data: SomeSharedData) -> Result
     Response::ok("ok")
 }
 
-#[worker::send]
 pub async fn get(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let bucket = env.bucket("SEEDED_BUCKET")?;
     seed_bucket(&bucket).await?;
@@ -141,7 +137,6 @@ pub async fn get(_req: Request, env: Env, _data: SomeSharedData) -> Result<Respo
     Response::ok("ok")
 }
 
-#[worker::send]
 pub async fn put(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let bucket = env.bucket("PUT_BUCKET")?;
 
@@ -175,7 +170,6 @@ pub async fn put(_req: Request, env: Env, _data: SomeSharedData) -> Result<Respo
     Response::ok("ok")
 }
 
-#[worker::send]
 pub async fn put_properties(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let bucket = env.bucket("PUT_BUCKET")?;
     let (http_metadata, custom_metadata, object_with_props) =
@@ -190,7 +184,6 @@ pub async fn put_properties(_req: Request, env: Env, _data: SomeSharedData) -> R
 }
 
 #[allow(clippy::large_stack_arrays)]
-#[worker::send]
 pub async fn put_multipart(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     const R2_MULTIPART_CHUNK_MIN_SIZE: usize = 5 * 1_024 * 1_024; // 5MiB.
                                                                   // const TEST_CHUNK_COUNT: usize = 3;
@@ -246,7 +239,6 @@ pub async fn put_multipart(_req: Request, env: Env, _data: SomeSharedData) -> Re
     Response::ok("ok")
 }
 
-#[worker::send]
 pub async fn delete(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let bucket = env.bucket("DELETE_BUCKET")?;
 
@@ -302,4 +294,18 @@ fn dummy_properties() -> (HttpMetadata, HashMap<String, String>) {
         map
     };
     (http_metadata, custom_metadata)
+}
+
+// Compile-time assertion: public async R2 methods return Send futures.
+#[allow(dead_code, unused)]
+fn _assert_send() {
+    fn require_send<T: Send>(_t: T) {}
+    fn r2(bucket: worker::Bucket) {
+        require_send(bucket.head("k"));
+        require_send(bucket.delete("k"));
+        require_send(bucket.delete_multiple(vec!["a", "b"]));
+        require_send(bucket.get("k").execute());
+        require_send(bucket.put("k", worker::Data::Empty).execute());
+        require_send(bucket.list().execute());
+    }
 }

--- a/test/src/rate_limit.rs
+++ b/test/src/rate_limit.rs
@@ -2,7 +2,6 @@ use super::SomeSharedData;
 use std::collections::HashMap;
 use worker::{js_sys, Env, Request, Response, Result};
 
-#[worker::send]
 pub async fn handle_rate_limit_check(
     _req: Request,
     env: Env,
@@ -18,7 +17,6 @@ pub async fn handle_rate_limit_check(
     }))
 }
 
-#[worker::send]
 pub async fn handle_rate_limit_with_key(
     req: Request,
     env: Env,
@@ -37,7 +35,6 @@ pub async fn handle_rate_limit_with_key(
     }))
 }
 
-#[worker::send]
 pub async fn handle_rate_limit_bulk_test(
     _req: Request,
     env: Env,
@@ -62,7 +59,6 @@ pub async fn handle_rate_limit_bulk_test(
     }))
 }
 
-#[worker::send]
 pub async fn handle_rate_limit_reset(
     _req: Request,
     env: Env,
@@ -81,4 +77,13 @@ pub async fn handle_rate_limit_reset(
     }
 
     Response::from_json(&outcomes)
+}
+
+// Compile-time assertion: public async RateLimiter methods return Send futures.
+#[allow(dead_code, unused)]
+fn _assert_send() {
+    fn require_send<T: Send>(_t: T) {}
+    fn rate_limiter(rl: worker::RateLimiter) {
+        require_send(rl.limit("key".into()));
+    }
 }

--- a/test/src/request.rs
+++ b/test/src/request.rs
@@ -71,7 +71,6 @@ pub async fn handle_headers(req: Request, _env: Env, _data: SomeSharedData) -> R
         .ok("returned your headers to you.")
 }
 
-#[worker::send]
 pub async fn handle_post_file_size(
     mut req: Request,
     _env: Env,
@@ -81,7 +80,6 @@ pub async fn handle_post_file_size(
     Response::ok(format!("size = {}", bytes.len()))
 }
 
-#[worker::send]
 pub async fn handle_async_text_echo(
     mut req: Request,
     _env: Env,
@@ -112,7 +110,6 @@ pub async fn handle_bytes(_req: Request, _env: Env, _data: SomeSharedData) -> Re
     Response::from_bytes(vec![1, 2, 3, 4, 5, 6, 7])
 }
 
-#[worker::send]
 pub async fn handle_api_data(
     mut req: Request,
     _env: Env,
@@ -183,7 +180,6 @@ pub async fn handle_now(_req: Request, _env: Env, _data: SomeSharedData) -> Resu
     Response::ok(js_date.to_string())
 }
 
-#[worker::send]
 pub async fn handle_cloned(_req: Request, _env: Env, _data: SomeSharedData) -> Result<Response> {
     let mut resp = Response::ok("Hello")?;
     let mut resp1 = resp.cloned()?;
@@ -194,7 +190,6 @@ pub async fn handle_cloned(_req: Request, _env: Env, _data: SomeSharedData) -> R
     Response::ok((left == right).to_string())
 }
 
-#[worker::send]
 pub async fn handle_cloned_stream(
     _req: Request,
     _env: Env,
@@ -226,7 +221,6 @@ pub async fn handle_custom_response_body(
     Response::from_body(ResponseBody::Body(vec![b'h', b'e', b'l', b'l', b'o']))
 }
 
-#[worker::send]
 pub async fn handle_wait_delay(req: Request, _env: Env, _data: SomeSharedData) -> Result<Response> {
     let uri = req.url()?;
     let mut segments = uri.path_segments().unwrap();
@@ -240,4 +234,16 @@ pub async fn handle_wait_delay(req: Request, _env: Env, _data: SomeSharedData) -
     delay.await;
 
     Response::ok("Waited!\n")
+}
+
+// Compile-time assertion: public async Request methods return Send futures.
+#[allow(dead_code, unused)]
+fn _assert_send() {
+    fn require_send<T: Send>(_t: T) {}
+    fn request(mut req: worker::Request) {
+        require_send(req.json::<String>());
+        require_send(req.text());
+        require_send(req.bytes());
+        require_send(req.form_data());
+    }
 }

--- a/test/src/router.rs
+++ b/test/src/router.rs
@@ -266,7 +266,6 @@ async fn respond_async(req: Request, _env: Env, _data: SomeSharedData) -> Result
         .ok(format!("Ok (async): {}", String::from(req.method())))
 }
 
-#[worker::send]
 async fn handle_close_event(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
     let some_namespace_kv = env.kv("SOME_NAMESPACE")?;
     let got_close_event = some_namespace_kv
@@ -279,7 +278,6 @@ async fn handle_close_event(_req: Request, env: Env, _data: SomeSharedData) -> R
     Response::ok(got_close_event)
 }
 
-#[worker::send]
 async fn catchall(req: Request, _env: Env, _data: SomeSharedData) -> Result<Response> {
     let uri = req.url()?;
     let path = uri.path();

--- a/test/src/secret_store.rs
+++ b/test/src/secret_store.rs
@@ -1,7 +1,6 @@
 use crate::SomeSharedData;
 use worker::{Env, Request, Response, Result};
 
-#[worker::send]
 pub async fn get_from_secret_store(
     _req: Request,
     env: Env,
@@ -16,7 +15,6 @@ pub async fn get_from_secret_store(
     }
 }
 
-#[worker::send]
 pub async fn get_from_secret_store_missing(
     _req: Request,
     env: Env,
@@ -28,5 +26,14 @@ pub async fn get_from_secret_store_missing(
     match secret_value {
         Some(value) => Response::ok(value),
         None => Response::error("Secret not found", 500),
+    }
+}
+
+// Compile-time assertion: public async SecretStore methods return Send futures.
+#[allow(dead_code, unused)]
+fn _assert_send() {
+    fn require_send<T: Send>(_t: T) {}
+    fn secret_store(ss: worker::SecretStore) {
+        require_send(ss.get());
     }
 }

--- a/test/src/service.rs
+++ b/test/src/service.rs
@@ -3,7 +3,6 @@ use super::SomeSharedData;
 use std::convert::TryInto;
 use worker::{Env, Method, Request, RequestInit, Response, Result};
 
-#[worker::send]
 pub async fn handle_remote_by_request(
     req: Request,
     env: Env,
@@ -21,7 +20,6 @@ pub async fn handle_remote_by_request(
     result
 }
 
-#[worker::send]
 pub async fn handle_remote_by_path(
     req: Request,
     env: Env,
@@ -38,4 +36,16 @@ pub async fn handle_remote_by_path(
     let result = Ok(response);
 
     result
+}
+
+// Compile-time assertion: public async Fetcher methods return Send futures.
+#[allow(dead_code, unused)]
+fn _assert_send() {
+    fn require_send<T: Send>(_t: T) {}
+    fn fetcher(f: worker::Fetcher) {
+        require_send(f.fetch("https://example.com", None));
+        require_send(f.fetch_request(
+            worker::Request::new("https://example.com", worker::Method::Get).unwrap(),
+        ));
+    }
 }

--- a/test/src/sql_counter.rs
+++ b/test/src/sql_counter.rs
@@ -85,7 +85,6 @@ impl SqlCounter {
     }
 }
 
-#[worker::send]
 /// Route handler that proxies a request to our SqlCounter Durable Object with id derived from the
 /// path `/sql-counter/{name}` (so every name gets its own instance).
 pub async fn handle_sql_counter(

--- a/test/src/sql_iterator.rs
+++ b/test/src/sql_iterator.rs
@@ -411,7 +411,6 @@ impl SqlIterator {
     }
 }
 
-#[worker::send]
 /// Route handler for the SQL iterator test Durable Object.
 pub async fn handle_sql_iterator(
     req: Request,

--- a/test/src/ws.rs
+++ b/test/src/ws.rs
@@ -40,7 +40,6 @@ pub async fn handle_websocket(_req: Request, env: Env, _data: SomeSharedData) ->
     Response::from_websocket(pair.client)
 }
 
-#[worker::send]
 pub async fn handle_websocket_client(
     _req: Request,
     _env: Env,

--- a/worker-codegen/src/wit.rs
+++ b/worker-codegen/src/wit.rs
@@ -85,7 +85,7 @@ fn expand_trait(interface: &Interface, interface_name: &Ident) -> anyhow::Result
 
 fn expand_struct(struct_name: &Ident, sys_name: &Ident) -> anyhow::Result<syn::ItemStruct> {
     let struct_raw = quote!(
-        pub struct #struct_name(::worker::send::SendWrapper<sys::#sys_name>);
+        pub struct #struct_name(sys::#sys_name);
     );
     let struct_item: syn::ItemStruct = syn::parse2(struct_raw)?;
     Ok(struct_item)
@@ -95,7 +95,7 @@ fn expand_from_impl(struct_name: &Ident, from_type: &syn::Type) -> anyhow::Resul
     let impl_raw = quote!(
         impl From<#from_type> for #struct_name {
             fn from(fetcher: #from_type) -> Self {
-                Self(::worker::send::SendWrapper::new(fetcher.into_rpc()))
+                Self(fetcher.into_rpc())
             }
         }
     );
@@ -184,7 +184,7 @@ fn expand_sys_module(interface: &Interface, sys_name: &Ident) -> anyhow::Result<
 
     let mod_raw = quote!(
         mod sys {
-            use ::wasm_bindgen::prelude::*;
+            use wasm_bindgen::prelude::*;
         }
     );
     let mut mod_item: syn::ItemMod = syn::parse2(mod_raw)?;

--- a/worker-macros/src/lib.rs
+++ b/worker-macros/src/lib.rs
@@ -119,19 +119,14 @@ pub fn event(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-/// Convert an async function which is `!Send` to be `Send`.
+#[deprecated(
+    since = "0.8.0",
+    note = "JsValue types are now Send in wasm-bindgen. #[worker::send] is no longer needed for most async handlers."
+)]
+/// Deprecated: Convert an async function which is `!Send` to be `Send`.
 ///
-/// This is useful for implementing async handlers in frameworks which
-/// expect the handler to be `Send`, such as `axum`.
-///
-/// ```rust
-/// #[worker::send]
-/// async fn foo() {
-///     // JsFuture is !Send
-///     let fut = JsFuture::from(promise);
-///     fut.await
-/// }
-/// ```
+/// With recent versions of `wasm-bindgen`, `JsValue` types are `Send`,
+/// so this macro is no longer needed for most async handlers.
 pub fn send(attr: TokenStream, stream: TokenStream) -> TokenStream {
     send::expand_macro(attr, stream)
 }

--- a/worker/src/cache.rs
+++ b/worker/src/cache.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 
+use crate::send::SendFuture;
 use serde::Serialize;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
@@ -55,7 +56,7 @@ impl Cache {
 
         // unwrap is safe because this promise never rejects
         // https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/open
-        let inner = JsFuture::from(cache).await.unwrap().into();
+        let inner = SendFuture::new(JsFuture::from(cache)).await.unwrap().into();
 
         Self { inner }
     }
@@ -80,7 +81,7 @@ impl Cache {
                 .inner
                 .put_with_request(&request.try_into()?, &response.into()),
         };
-        let _ = JsFuture::from(promise).await?;
+        let _ = SendFuture::new(JsFuture::from(promise)).await?;
         Ok(())
     }
 
@@ -116,7 +117,7 @@ impl Cache {
         };
 
         // `match` returns either a response or undefined
-        let result = JsFuture::from(promise).await?;
+        let result = SendFuture::new(JsFuture::from(promise)).await?;
         if result.is_undefined() {
             Ok(None)
         } else {
@@ -147,7 +148,7 @@ impl Cache {
                 .inner
                 .delete_with_request_and_options(&request.try_into()?, &options),
         };
-        let result = JsFuture::from(promise).await?;
+        let result = SendFuture::new(JsFuture::from(promise)).await?;
 
         // Unwrap is safe because we know this is a boolean
         // https://developers.cloudflare.com/workers/runtime-apis/cache#delete

--- a/worker/src/container.rs
+++ b/worker/src/container.rs
@@ -1,3 +1,4 @@
+use crate::send::SendFuture;
 use js_sys::{Map, Object, Reflect};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -24,13 +25,13 @@ impl Container {
 
     pub async fn wait_for_exit(&self) -> Result<()> {
         let promise = self.inner.monitor();
-        JsFuture::from(promise).await?;
+        SendFuture::new(JsFuture::from(promise)).await?;
         Ok(())
     }
 
     pub async fn destroy(&self, error: Option<&str>) -> Result<()> {
         let promise = self.inner.destroy(error);
-        JsFuture::from(promise).await?;
+        SendFuture::new(JsFuture::from(promise)).await?;
         Ok(())
     }
 

--- a/worker/src/delay.rs
+++ b/worker/src/delay.rs
@@ -98,3 +98,7 @@ impl PinnedDrop for Delay {
         }
     }
 }
+
+/// SAFETY: Cloudflare Workers runtime is single-threaded, so it's safe to mark Delay as Send
+/// even though it contains Rc<Cell<bool>>.
+unsafe impl Send for Delay {}

--- a/worker/src/fetcher.rs
+++ b/worker/src/fetcher.rs
@@ -1,4 +1,4 @@
-use crate::{env::EnvBinding, RequestInit, Result};
+use crate::{env::EnvBinding, send::SendFuture, RequestInit, Result};
 use std::convert::TryInto;
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
@@ -31,7 +31,8 @@ impl Fetcher {
             None => self.0.fetch_with_str(&path),
         }?;
 
-        let resp_sys: web_sys::Response = JsFuture::from(promise).await?.dyn_into()?;
+        let resp_sys: web_sys::Response =
+            SendFuture::new(JsFuture::from(promise)).await?.dyn_into()?;
         #[cfg(not(feature = "http"))]
         let result = Ok(Response::from(resp_sys));
         #[cfg(feature = "http")]
@@ -52,7 +53,8 @@ impl Fetcher {
     {
         let req = request.try_into()?;
         let promise = self.0.fetch(req.inner())?;
-        let resp_sys: web_sys::Response = JsFuture::from(promise).await?.dyn_into()?;
+        let resp_sys: web_sys::Response =
+            SendFuture::new(JsFuture::from(promise)).await?.dyn_into()?;
         let response = Response::from(resp_sys);
         #[cfg(feature = "http")]
         let result = response.try_into();

--- a/worker/src/formdata.rs
+++ b/worker/src/formdata.rs
@@ -5,6 +5,7 @@ use crate::Date;
 use crate::DateInit;
 use crate::Result;
 
+use crate::send::SendFuture;
 use js_sys::Array;
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
@@ -172,7 +173,7 @@ impl File {
 
     /// Read the file from an internal buffer and get the resulting bytes.
     pub async fn bytes(&self) -> Result<Vec<u8>> {
-        JsFuture::from(self.0.array_buffer())
+        SendFuture::new(JsFuture::from(self.0.array_buffer()))
             .await
             .map(|val| js_sys::Uint8Array::new(&val).to_vec())
             .map_err(|e| {

--- a/worker/src/global.rs
+++ b/worker/src/global.rs
@@ -1,5 +1,6 @@
 use std::ops::Deref;
 
+use crate::send::SendFuture;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 
@@ -37,7 +38,7 @@ async fn fetch_with_str(url: &str, signal: Option<&AbortSignal>) -> Result<Respo
 
     let worker: web_sys::WorkerGlobalScope = js_sys::global().unchecked_into();
     let promise = worker.fetch_with_str_and_init(url, &init);
-    let resp = JsFuture::from(promise).await?;
+    let resp = SendFuture::new(JsFuture::from(promise)).await?;
     let resp: web_sys::Response = resp.dyn_into()?;
     Ok(resp.into())
 }
@@ -49,7 +50,7 @@ async fn fetch_with_request(request: &Request, signal: Option<&AbortSignal>) -> 
     let worker: web_sys::WorkerGlobalScope = js_sys::global().unchecked_into();
     let req = request.inner();
     let promise = worker.fetch_with_request_and_init(req, &init);
-    let resp = JsFuture::from(promise).await?;
+    let resp = SendFuture::new(JsFuture::from(promise)).await?;
     let edge_response: web_sys::Response = resp.dyn_into()?;
     Ok(edge_response.into())
 }

--- a/worker/src/kv/builder.rs
+++ b/worker/src/kv/builder.rs
@@ -1,3 +1,4 @@
+use crate::send::SendFuture;
 use js_sys::{ArrayBuffer, Function, Object, Promise, Uint8Array};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
@@ -63,7 +64,7 @@ impl PutOptionsBuilder {
             .put_function
             .call3(&self.this, &self.name, &self.value, &options_object)?
             .into();
-        JsFuture::from(promise)
+        SendFuture::new(JsFuture::from(promise))
             .await
             .map(|_| ())
             .map_err(KvError::from)
@@ -124,7 +125,7 @@ impl ListOptionsBuilder {
             .call1(&self.this, &options_object)?
             .into();
 
-        let value = JsFuture::from(promise).await?;
+        let value = SendFuture::new(JsFuture::from(promise)).await?;
         let resp = serde_wasm_bindgen::from_value(value).map_err(JsValue::from)?;
         Ok(resp)
     }
@@ -185,7 +186,9 @@ impl GetOptionsBuilder {
             .get_function
             .call2(&self.this, &self.name, &options_object)?
             .into();
-        JsFuture::from(promise).await.map_err(KvError::from)
+        SendFuture::new(JsFuture::from(promise))
+            .await
+            .map_err(KvError::from)
     }
 
     /// Gets the value as a string.
@@ -230,7 +233,7 @@ impl GetOptionsBuilder {
             .call2(&self.this, &self.name, &options_object)?
             .into();
 
-        let pair = JsFuture::from(promise).await?;
+        let pair = SendFuture::new(JsFuture::from(promise)).await?;
         let metadata = crate::kv::get(&pair, "metadata")?;
         let value = crate::kv::get(&pair, "value")?;
 

--- a/worker/src/kv/mod.rs
+++ b/worker/src/kv/mod.rs
@@ -20,6 +20,7 @@ mod builder;
 
 pub use builder::*;
 
+use crate::send::SendFuture;
 use js_sys::{global, Function, Object, Promise, Reflect, Uint8Array};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -137,7 +138,7 @@ impl KvStore {
     pub async fn delete(&self, name: &str) -> Result<(), KvError> {
         let name = JsValue::from(name);
         let promise: Promise = self.delete_function.call1(&self.this, &name)?.into();
-        JsFuture::from(promise).await?;
+        SendFuture::new(JsFuture::from(promise)).await?;
         Ok(())
     }
 }

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -56,51 +56,18 @@
 //! We also implement `try_from` between `worker::Request` and `http::Request<worker::Body>`, and between `worker::Response` and `http::Response<worker::Body>`.
 //! This allows you to convert your code incrementally if it is tightly coupled to the original types.
 //!
-//! ### `Send` Helpers
+//! ### `Send`
 //!
-//! A number of frameworks (including `axum`) require that objects that they are given (including route handlers) can be
-//! sent between threads (i.e are marked as `Send`). Unfortuntately, objects which interact with JavaScript are frequently
-//! not marked as `Send`. In the Workers environment, this is not an issue, because Workers are single threaded. There are still
-//! some ergonomic difficulties which we address with some wrapper types:
+//! All JavaScript value types (`JsValue` and friends) are now `Send` in `wasm-bindgen`,
+//! so worker types can be freely shared across async contexts without wrappers.
 //!
-//! 1. [`send::SendFuture`] - wraps any `Future` and marks it as `Send`:
-//!
-//! ```rust
-//! // `fut` is `Send`
-//! let fut = send::SendFuture::new(async move {
-//!     // `JsFuture` is not `Send`
-//!     JsFuture::from(promise).await
-//! });
-//! ```
-//!
-//! 2. [`send::SendWrapper`] - Marks an arbitrary object as `Send` and implements `Deref` and `DerefMut`, as well as `Clone`, `Debug`, and `Display` if the
-//!    inner type does. This is useful for attaching types as state to an `axum` `Router`:
+//! The one exception is `JsFuture`, which still uses `Rc` internally and is not `Send`.
+//! The [`send::SendFuture`] wrapper is provided for internal use and for any advanced cases
+//! where you need to wrap a `!Send` future in a `Send` context:
 //!
 //! ```rust
-//! // `KvStore` is not `Send`
-//! let store = env.kv("FOO")?;
-//! // `state` is `Send`
-//! let state = send::SendWrapper::new(store);
-//! let router = axum::Router::new()
-//!     .layer(Extension(state));
-//! ```
-//!
-//! 3. [`[worker::send]`](macro@crate::send) - Macro to make any `async` function `Send`. This can be a little tricky to identify as the problem, but
-//!    `axum`'s `[debug_handler]` macro can help, and looking for warnings that a function or object cannot safely be sent
-//!    between threads.
-//!
-//! ```rust
-//! // This macro makes the whole function (i.e. the `Future` it returns) `Send`.
-//! #[worker::send]
-//! async fn handler(Extension(env): Extension<Env>) -> Response<String> {
-//!     let kv = env.kv("FOO").unwrap()?;
-//!     // Holding `kv`, which is not `Send` across `await` boundary would mark this function as `!Send`
-//!     let value = kv.get("foo").text().await?;
-//!     Ok(format!("Got value: {:?}", value));
-//! }
-//!
-//! let router = axum::Router::new()
-//!     .route("/", get(handler))
+//! let fut = send::SendFuture::new(JsFuture::from(promise));
+//! fut.await
 //! ```
 //!
 //! # RPC Support

--- a/worker/src/queue.rs
+++ b/worker/src/queue.rs
@@ -10,6 +10,8 @@ use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::JsFuture;
 use worker_sys::{Message as MessageSys, MessageBatch as MessageBatchSys, Queue as EdgeQueue};
 
+use crate::send::SendFuture;
+
 /// A batch of messages that are sent to a consumer Worker.
 #[derive(Debug)]
 pub struct MessageBatch<T> {
@@ -616,7 +618,7 @@ impl Queue {
             None => JsValue::null(),
         };
 
-        let fut: JsFuture = self.0.send(message.message, options)?.into();
+        let fut = SendFuture::new(JsFuture::from(self.0.send(message.message, options)?));
         fut.await.map_err(Error::from)?;
         Ok(())
     }
@@ -684,7 +686,9 @@ impl Queue {
             })
             .collect::<Result<js_sys::Array>>()?;
 
-        let fut: JsFuture = self.0.send_batch(messages, batch_send_options)?.into();
+        let fut = SendFuture::new(JsFuture::from(
+            self.0.send_batch(messages, batch_send_options)?,
+        ));
         fut.await.map_err(Error::from)?;
         Ok(())
     }

--- a/worker/src/r2/builder.rs
+++ b/worker/src/r2/builder.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, convert::TryFrom};
 
+use crate::send::SendFuture;
 use js_sys::{Array, Date as JsDate, JsString, Object as JsObject, Uint8Array};
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
@@ -48,7 +49,7 @@ impl GetOptionsBuilder<'_> {
             .into(),
         )?;
 
-        let value = JsFuture::from(get_promise).await?;
+        let value = SendFuture::new(JsFuture::from(get_promise)).await?;
 
         if value.is_null() {
             return Ok(None);
@@ -248,7 +249,7 @@ impl PutOptionsBuilder<'_> {
             }
             .into(),
         )?;
-        let res: EdgeR2Object = JsFuture::from(put_promise).await?.into();
+        let res: EdgeR2Object = SendFuture::new(JsFuture::from(put_promise)).await?.into();
         let inner = if JsString::from("bodyUsed").js_in(&res) {
             ObjectInner::Body(res.unchecked_into())
         } else {
@@ -302,9 +303,10 @@ impl CreateMultipartUploadOptionsBuilder<'_> {
             }
             .into(),
         )?;
-        let inner: EdgeR2MultipartUpload = JsFuture::from(create_multipart_upload_promise)
-            .await?
-            .into();
+        let inner: EdgeR2MultipartUpload =
+            SendFuture::new(JsFuture::from(create_multipart_upload_promise))
+                .await?
+                .into();
 
         Ok(MultipartUpload { inner })
     }
@@ -437,7 +439,7 @@ impl ListOptionsBuilder<'_> {
             }
             .into(),
         )?;
-        let inner = JsFuture::from(list_promise).await?.into();
+        let inner = SendFuture::new(JsFuture::from(list_promise)).await?.into();
         Ok(Objects { inner })
     }
 }

--- a/worker/src/rate_limit.rs
+++ b/worker/src/rate_limit.rs
@@ -17,9 +17,6 @@ pub struct RateLimitOutcome {
     pub success: bool,
 }
 
-unsafe impl Send for RateLimiter {}
-unsafe impl Sync for RateLimiter {}
-
 impl EnvBinding for RateLimiter {
     const TYPE_NAME: &'static str = "Ratelimit";
 }

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -4,6 +4,7 @@ use crate::{
     cf::Cf, error::Error, headers::Headers, http::Method, ByteStream, FormData, RequestInit, Result,
 };
 
+use crate::send::SendFuture;
 use serde::de::DeserializeOwned;
 #[cfg(test)]
 use std::borrow::Cow;
@@ -122,7 +123,7 @@ impl Request {
     pub async fn json<B: DeserializeOwned>(&mut self) -> Result<B> {
         if !self.body_used {
             self.body_used = true;
-            return JsFuture::from(self.edge_request.json()?)
+            return SendFuture::new(JsFuture::from(self.edge_request.json()?))
                 .await
                 .map_err(|e| {
                     Error::JsError(
@@ -140,7 +141,7 @@ impl Request {
     pub async fn text(&mut self) -> Result<String> {
         if !self.body_used {
             self.body_used = true;
-            return JsFuture::from(self.edge_request.text()?)
+            return SendFuture::new(JsFuture::from(self.edge_request.text()?))
                 .await
                 .map(|val| val.as_string().unwrap())
                 .map_err(|e| {
@@ -158,7 +159,7 @@ impl Request {
     pub async fn bytes(&mut self) -> Result<Vec<u8>> {
         if !self.body_used {
             self.body_used = true;
-            return JsFuture::from(self.edge_request.array_buffer()?)
+            return SendFuture::new(JsFuture::from(self.edge_request.array_buffer()?))
                 .await
                 .map(|val| js_sys::Uint8Array::new(&val).to_vec())
                 .map_err(|e| {
@@ -176,7 +177,7 @@ impl Request {
     pub async fn form_data(&mut self) -> Result<FormData> {
         if !self.body_used {
             self.body_used = true;
-            return JsFuture::from(self.edge_request.form_data()?)
+            return SendFuture::new(JsFuture::from(self.edge_request.form_data()?))
                 .await
                 .map(|val| val.into())
                 .map_err(|e| {

--- a/worker/src/secret_store.rs
+++ b/worker/src/secret_store.rs
@@ -1,8 +1,4 @@
-use crate::{
-    error::Error,
-    send::{SendFuture, SendWrapper},
-    EnvBinding, Result,
-};
+use crate::{error::Error, send::SendFuture, EnvBinding, Result};
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 
@@ -12,11 +8,7 @@ use wasm_bindgen_futures::JsFuture;
 /// secret (identified by `store_id` + `secret_name`) to a binding name.
 /// Use [`SecretStore::get`] to retrieve the secret value.
 #[derive(Debug, Clone)]
-pub struct SecretStore(SendWrapper<worker_sys::SecretStoreSys>);
-
-// Workers will never allow multithreading.
-unsafe impl Send for SecretStore {}
-unsafe impl Sync for SecretStore {}
+pub struct SecretStore(worker_sys::SecretStoreSys);
 
 impl EnvBinding for SecretStore {
     const TYPE_NAME: &'static str = "Fetcher";
@@ -28,7 +20,7 @@ impl JsCast for SecretStore {
     }
 
     fn unchecked_from_js(val: JsValue) -> Self {
-        Self(SendWrapper::new(val.unchecked_into()))
+        Self(val.unchecked_into())
     }
 
     fn unchecked_from_js_ref(val: &JsValue) -> &Self {

--- a/worker/src/send.rs
+++ b/worker/src/send.rs
@@ -1,7 +1,7 @@
-//! This module provides utilities for working with JavaScript types
-//! which do not implement `Send`, in contexts where `Send` is required.
+//! This module provides utilities for wrapping `!Send` futures
+//! in contexts where `Send` is required.
 //! Workers is guaranteed to be single-threaded, so it is safe to
-//! wrap any type with `Send` and `Sync` traits.
+//! wrap any future with `Send`.
 
 use futures_util::future::Future;
 use pin_project::pin_project;
@@ -65,23 +65,27 @@ where
     }
 }
 
-/// Wrap any type to make it `Send`.
-///
-/// ```rust
-/// // js_sys::Promise is !Send
-/// let send_promise = SendWrapper::new(promise);
-/// ```
+/// Deprecated: `JsValue` types are now `Send` in `wasm-bindgen`, so `SendWrapper` is no longer
+/// needed. Simply use the inner type directly.
+#[deprecated(
+    since = "0.8.0",
+    note = "JsValue types are now Send in wasm-bindgen. Use the inner type directly."
+)]
 pub struct SendWrapper<T>(pub T);
 
+#[allow(deprecated)]
 unsafe impl<T> Send for SendWrapper<T> {}
+#[allow(deprecated)]
 unsafe impl<T> Sync for SendWrapper<T> {}
 
+#[allow(deprecated)]
 impl<T> SendWrapper<T> {
     pub fn new(inner: T) -> Self {
         Self(inner)
     }
 }
 
+#[allow(deprecated)]
 impl<T> std::ops::Deref for SendWrapper<T> {
     type Target = T;
 
@@ -90,30 +94,35 @@ impl<T> std::ops::Deref for SendWrapper<T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T> std::ops::DerefMut for SendWrapper<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
+#[allow(deprecated)]
 impl<T: Debug> Debug for SendWrapper<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "SendWrapper({:?})", self.0)
     }
 }
 
+#[allow(deprecated)]
 impl<T: Clone> Clone for SendWrapper<T> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 }
 
+#[allow(deprecated)]
 impl<T: Default> Default for SendWrapper<T> {
     fn default() -> Self {
         Self(T::default())
     }
 }
 
+#[allow(deprecated)]
 impl<T: Display> Display for SendWrapper<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "SendWrapper({})", self.0)

--- a/worker/src/socket.rs
+++ b/worker/src/socket.rs
@@ -4,6 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
+use crate::send::SendFuture;
 use crate::Result;
 use crate::{r2::js_object, Error};
 use futures_util::FutureExt;
@@ -93,19 +94,19 @@ impl Socket {
 
     /// Closes the TCP socket. Both the readable and writable streams are forcibly closed.
     pub async fn close(&mut self) -> Result<()> {
-        JsFuture::from(self.inner.close()?).await?;
+        SendFuture::new(JsFuture::from(self.inner.close()?)).await?;
         Ok(())
     }
 
     /// This Future is resolved when the socket is closed
     /// and is rejected if the socket encounters an error.
     pub async fn closed(&self) -> Result<()> {
-        JsFuture::from(self.inner.closed()?).await?;
+        SendFuture::new(JsFuture::from(self.inner.closed()?)).await?;
         Ok(())
     }
 
     pub async fn opened(&self) -> Result<SocketInfo> {
-        let value = JsFuture::from(self.inner.opened()?).await?;
+        let value = SendFuture::new(JsFuture::from(self.inner.opened()?)).await?;
         value.try_into()
     }
 

--- a/worker/src/streams.rs
+++ b/worker/src/streams.rs
@@ -46,6 +46,10 @@ impl Stream for ByteStream {
     }
 }
 
+/// SAFETY: Cloudflare Workers runtime is single-threaded, so it's safe to mark ByteStream
+/// as Send even though `IntoStream` internally contains `Option<JsFuture>` which is `!Send`.
+unsafe impl Send for ByteStream {}
+
 #[pin_project]
 pub struct FixedLengthStream {
     length: u64,
@@ -109,6 +113,11 @@ impl Stream for FixedLengthStream {
         Poll::Ready(item)
     }
 }
+
+/// SAFETY: Cloudflare Workers runtime is single-threaded, so it's safe to mark FixedLengthStream
+/// as Send and Sync even though it contains a trait object that may not be Send/Sync.
+unsafe impl Send for FixedLengthStream {}
+unsafe impl Sync for FixedLengthStream {}
 
 impl From<FixedLengthStream> for FixedLengthStreamSys {
     fn from(stream: FixedLengthStream) -> Self {

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -302,6 +302,10 @@ pub struct EventStream<'ws> {
     )>,
 }
 
+// SAFETY: Workers runtime is single-threaded. EventStream contains Closure<dyn FnMut(T)>
+// which is !Send due to the trait object, but this is safe in a single-threaded context.
+unsafe impl Send for EventStream<'_> {}
+
 impl Stream for EventStream<'_> {
     type Item = Result<WebsocketEvent>;
 


### PR DESCRIPTION
## Summary

`JsValue` (and all types wrapping it) is now `Send` in `wasm-bindgen`, so the vast majority of the `Send` ergonomic workarounds in this crate are no longer necessary.

The remaining `!Send` type is `JsFuture` (uses `Rc<RefCell<...>>` internally). This PR wraps all internal `JsFuture` usage with `SendFuture`, so every public async method now returns a `Send` future. Users no longer need to worry about `Send` at all.

### What changed

- **Removed all `unsafe impl Send/Sync`** on worker types (`Env`, `KvStore`, `D1Database`, `Request`, etc.) — they derive `Send` automatically now via `JsValue`.
- **Wrapped all internal `JsFuture` with `SendFuture`** — every public async method in the crate now returns a `Send` future. This is the key improvement: `Send`-ness is now the library's responsibility, not the user's.
- **Deprecated `SendWrapper`** — still exported from `worker::send` for backward compat, but no longer used internally. Users should use the inner type directly.
- **Deprecated `#[worker::send]`** — no longer needed since all public async methods return `Send` futures. The macro still works but emits a deprecation warning.
- **Removed all `#[worker::send]` usage** from tests and examples.

### Migration for users

- Remove `#[worker::send]` from your async handlers — it's no longer needed.
- Replace `send::SendWrapper::new(x)` with just `x`.
- `send::SendFuture` is still available if you work with `JsFuture` directly.

### Not a breaking change

Both `SendWrapper` and `#[worker::send]` continue to compile — they just emit deprecation warnings.