### PR TITLE
feat: add support for lists in worker-codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3498,17 +3498,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.205.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d457bb52804242e09d55a306e53ddbc65d1d29ed83db6a4eea3ed412ee0cfdf"
-dependencies = [
- "bitflags 2.10.0",
- "indexmap 2.12.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
@@ -3961,9 +3950,9 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wit-parser"
-version = "0.205.0"
+version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3db34c7688c161ed7bd1b2f8055dca9fb2c15201db58754e9c48a0805f32e5f"
+checksum = "9875ea3fa272f57cc1fc50f225a7b94021a7878c484b33792bccad0d93223439"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -3974,7 +3963,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.205.0",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]

--- a/examples/rpc-client/src/lib.rs
+++ b/examples/rpc-client/src/lib.rs
@@ -12,7 +12,7 @@ async fn main(_req: Request, env: Env, _ctx: Context) -> Result<Response> {
 
     let service: rpc::CalculatorService = env.service("SERVER")?.into();
 
-    let num = service.add(1, 2).await?;
+    let num = service.add(vec![1, 2]).await?;
 
     Response::ok(format!("{num:?}"))
 }

--- a/examples/rpc-client/wit/calculator.wit
+++ b/examples/rpc-client/wit/calculator.wit
@@ -2,5 +2,5 @@ package rpc:calculator;
 
 interface calculator {
     // Add two unsigned integers
-    add: func(a: u32, b: u32) -> u32;
+    add: func(a: list<u32>) -> u32;
 }

--- a/examples/rpc-server/src/lib.rs
+++ b/examples/rpc-server/src/lib.rs
@@ -7,6 +7,6 @@ async fn main(_req: Request, _env: Env, _ctx: Context) -> Result<Response> {
 }
 
 #[wasm_bindgen]
-pub async fn add(a: u32, b: u32) -> u32 {
-    a + b
+pub async fn add(a: Vec<u32>) -> u32 {
+    a.iter().sum()
 }

--- a/worker-codegen/Cargo.toml
+++ b/worker-codegen/Cargo.toml
@@ -21,6 +21,6 @@ syn = { version = "2.0.17", features = ['extra-traits'] }
 proc-macro2 = "1.0.60"
 quote = "1.0.28"
 prettyplease = { version = "0.2" }
-wit-parser = { version = "0.205" }
+wit-parser = "0.240.0"
 convert_case = { version = "0.6" }
 anyhow = { version = "1" }


### PR DESCRIPTION
The current wit RPC system is somewhat limited to only being able to handle primitive types. These changes add experimental support for using list types, aka Vec in Rust.

An open question is, should list<u8> be handled as a special case to being a `::worker::js_sys::Uint8Array`.