### PR TITLE
update examples and usage for wasm_bindgen

### DIFF
--- a/templates/axum/Cargo.toml
+++ b/templates/axum/Cargo.toml
@@ -12,3 +12,4 @@ worker = { version = "0.6", features = ['http', 'axum'] }
 worker-macros = { version = "0.6", features = ['http'] }
 axum = { version = "0.8", default-features = false }
 tower-service = "0.3.3"
+wasm-bindgen = "0.2"

--- a/templates/hello-world-http/Cargo.toml
+++ b/templates/hello-world-http/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["cdylib"]
 worker = { version = "0.6", features = ['http'] }
 worker-macros = { version = "0.6", features = ['http'] }
 http = "1.3"
+wasm-bindgen = "0.2"

--- a/templates/hello-world/Cargo.toml
+++ b/templates/hello-world/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = ["cdylib"]
 [dependencies]
 worker = { version = "0.6" }
 worker-macros = { version = "0.6" }
+wasm-bindgen = "0.2"


### PR DESCRIPTION
Issue found when trying to implement an example similar to the one listed in the README. A change in the `durable_object` macro I believe now makes it so that including wasm_bindgen seems to be required. If not included, a confusing error occurs that is difficult to debug, likely from macro expansion. See error attached below.

```
error: the `self` argument is only allowed for functions in `impl` blocks.

       If the function is already in an `impl` block, did you perhaps forget to add `#[wasm_bindgen]` to the `impl` block?
 --> src/lib.rs:3:1
  |
3 | #[durable_object]
  | ^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the attribute macro `durable_object` (in Nightly builds, run with -Z macro-backtrace for more info)

error: recursion limit reached while expanding `#[derive]`
 --> src/lib.rs:3:1
  |
3 | #[durable_object]
  | ^^^^^^^^^^^^^^^^^
  |
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`durable-object-demo`)
  = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `durable-object-demo` (lib) due to 2 previous errors
```