### PR TITLE
fix: better macro hygiene for durable objects

### DIFF
--- a/worker-macros/src/durable_object.rs
+++ b/worker-macros/src/durable_object.rs
@@ -25,7 +25,7 @@ mod bindgen_methods {
 
     pub fn core() -> TokenStream {
         quote! {
-            #[wasm_bindgen(constructor, wasm_bindgen=wasm_bindgen)]
+            #[wasm_bindgen(constructor, wasm_bindgen=::worker::wasm_bindgen)]
             pub fn new(
                 state: ::worker::worker_sys::DurableObjectState,
                 env:   ::worker::Env
@@ -36,7 +36,7 @@ mod bindgen_methods {
                 )
             }
 
-            #[wasm_bindgen(js_name = fetch, wasm_bindgen=wasm_bindgen)]
+            #[wasm_bindgen(js_name = fetch, wasm_bindgen=::worker::wasm_bindgen)]
             pub fn fetch(
                 &self,
                 req: ::worker::worker_sys::web_sys::Request
@@ -59,7 +59,7 @@ mod bindgen_methods {
 
     pub fn alarm() -> TokenStream {
         quote! {
-            #[wasm_bindgen(js_name = alarm, wasm_bindgen=wasm_bindgen)]
+            #[wasm_bindgen(js_name = alarm, wasm_bindgen=::worker::wasm_bindgen)]
             pub fn alarm(&self) -> ::worker::js_sys::Promise {
                 // SAFETY:
                 // Durable Object will never be destroyed while there is still
@@ -79,7 +79,7 @@ mod bindgen_methods {
 
     pub fn websocket() -> TokenStream {
         quote! {
-            #[wasm_bindgen(js_name = webSocketMessage, wasm_bindgen=wasm_bindgen)]
+            #[wasm_bindgen(js_name = webSocketMessage, wasm_bindgen=::worker::wasm_bindgen)]
             pub fn websocket_message(
                 &self,
                 ws: ::worker::worker_sys::web_sys::WebSocket,
@@ -105,7 +105,7 @@ mod bindgen_methods {
                 })
             }
 
-            #[wasm_bindgen(js_name = webSocketClose, wasm_bindgen=wasm_bindgen)]
+            #[wasm_bindgen(js_name = webSocketClose, wasm_bindgen=::worker::wasm_bindgen)]
             pub fn websocket_close(
                 &self,
                 ws: ::worker::worker_sys::web_sys::WebSocket,
@@ -126,7 +126,7 @@ mod bindgen_methods {
                 })
             }
 
-            #[wasm_bindgen(js_name = webSocketError, wasm_bindgen=wasm_bindgen)]
+            #[wasm_bindgen(js_name = webSocketError, wasm_bindgen=::worker::wasm_bindgen)]
             pub fn websocket_error(
                 &self,
                 ws: ::worker::worker_sys::web_sys::WebSocket,
@@ -192,11 +192,11 @@ pub fn expand_macro(attr: TokenStream, tokens: TokenStream) -> syn::Result<Token
         const _: () = {
             use ::worker::wasm_bindgen::prelude::*;
 
-            #[wasm_bindgen(wasm_bindgen=wasm_bindgen)]
+            #[wasm_bindgen(wasm_bindgen=::worker::wasm_bindgen)]
             #[::worker::consume]
             #target
 
-            #[wasm_bindgen(wasm_bindgen=wasm_bindgen)]
+            #[wasm_bindgen(wasm_bindgen=::worker::wasm_bindgen)]
             impl #target_name {
                 #(#bindgen_methods)*
             }


### PR DESCRIPTION
As a follow-on to https://github.com/cloudflare/workers-rs/pull/816, this fixes the macro hygiene to instead use the `worker::wasm_bindgen` reference directly, which should resolve the recursive macro bugs we've been seeing.