### PR TITLE
fix(templates): remove invalid pinned version in generated wrangler.toml build command

### DIFF
--- a/templates/hello-world-http/wrangler.toml
+++ b/templates/hello-world-http/wrangler.toml
@@ -3,4 +3,4 @@ main = "build/index.js"
 compatibility_date = "{{ "now" | date: "%Y-%m-%d" }}"
 
 [build]
-command = "cargo install -q worker-build@^0.7 && worker-build --release"
+command = "cargo install -q worker-build && worker-build --release"


### PR DESCRIPTION
Templates currently generate:
command = "cargo install -q worker-build@^0.7 && worker-build --release"

Modern versions of Cargo reject the incomplete version specifier `@0.7`, causing: error: invalid value 'worker-build@0.7' ... unexpected end of input while parsing minor version number

Change to unpinned install to use the latest compatible worker-build: command = "cargo install -q worker-build && worker-build --release"

This resolves Cargo syntax errors on fresh Windows (and other) projects without affecting existing functionality.