### PR TITLE
fix(build): correct esbuild binary path on Windows

### DIFF
--- a/worker-build/src/binary.rs
+++ b/worker-build/src/binary.rs
@@ -212,7 +212,13 @@ impl BinaryDep for Esbuild {
     }
     fn bin_path(&self, name: Option<&str>) -> Result<String> {
         Ok(match name {
-            None | Some("esbuild") => format!("bin/esbuild{MAYBE_EXE}"),
+            None | Some("esbuild") => {
+                if cfg!(windows) {
+                    format!("esbuild{MAYBE_EXE}")
+                } else {
+                    format!("bin/esbuild{MAYBE_EXE}")
+                }
+            }
             Some(name) => bail!("Unknown binary {name} in {}", self.full_name()),
         })
     }


### PR DESCRIPTION
On Windows, the cache directory is named with .exe suffix (esbuild-win32-x64-<version>.exe), and extraction places esbuild.exe directly in that directory (no \bin subfolder due to package/ prefix stripping).

However, bin_path always returns "bin/esbuild.exe", causing get_binary to look for a non-existent \bin\esbuild.exe and fail with: Error: Unable to locate binary ...esbuild-win32-x64-<version>.exe\bin\esbuild.exe in Esbuild

Use platform-specific bin_path: direct "esbuild.exe" on Windows, "bin/esbuild" on other platforms.

This resolves the common Windows esbuild download/extraction failure in worker-build without needing manual placement or global installs.