### PR TITLE
fix(d1): use Function.apply for bind() to fix WASM crash (#893)

### DIFF
--- a/test/src/router.rs
+++ b/test/src/router.rs
@@ -194,6 +194,7 @@ macro_rules! add_routes (
     add_route!($obj, get, "/d1/retrieve_optional_none", d1::retrieve_optional_none);
     add_route!($obj, get, "/d1/retrieve_optional_some", d1::retrieve_optional_some);
     add_route!($obj, get, "/d1/retrive_first_none", d1::retrive_first_none);
+    add_route!($obj, get, "/d1/insert_with_raw_bind", d1::insert_with_raw_bind);
     add_route!($obj, get, "/kv/get", kv::get);
     add_route!($obj, get, "/kv/get-not-found", kv::get_not_found);
     add_route!($obj, get, "/kv/list-keys", kv::list_keys);

--- a/test/tests/d1.spec.ts
+++ b/test/tests/d1.spec.ts
@@ -131,4 +131,11 @@ describe("d1", () => {
     expect(await resp.text()).toBe("ok");
     expect(resp.status).toBe(200);
   });
+
+  // Test for GitHub issue #893: D1 .bind() WASM crash with INSERT statements
+  test("insert_with_raw_bind", async () => {
+    const resp = await mf.dispatchFetch(`${mfUrl}d1/insert_with_raw_bind`);
+    expect(await resp.text()).toBe("ok");
+    expect(resp.status).toBe(200);
+  });
 });


### PR DESCRIPTION
The wasm-bindgen `variadic` attribute wasn't properly spreading array arguments when calling D1's bind method, causing WASM initialization errors for INSERT/UPDATE/DELETE operations.

This fix uses JavaScript's native Function.apply() to properly spread the arguments, bypassing the problematic variadic handling.

- Modified bind() and bind_refs() to use js_sys::Reflect and Function.apply
- Added test case for INSERT/UPDATE/DELETE with raw bind()

Fixes #893