### PR TITLE
[Draft] Idea: add tokio-workers compatibility shim crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,6 +2503,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-workers"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "pin-project",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio-workers-demo"
+version = "0.1.0"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "tokio-workers",
+ "worker 0.7.2",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "worker-macros",
     "test",
     "worker-sys",
+    "tokio-workers",
     "examples/*",
     "test/container-echo",
 ]

--- a/examples/tokio-workers-demo/Cargo.toml
+++ b/examples/tokio-workers-demo/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tokio-workers-demo"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.release]
+release = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+worker.workspace = true
+tokio-workers = { path = "../../tokio-workers", features = ["spawn-blocking-sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+js-sys.workspace = true

--- a/examples/tokio-workers-demo/package.json
+++ b/examples/tokio-workers-demo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "tokio-workers-demo",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4"
+  }
+}

--- a/examples/tokio-workers-demo/src/lib.rs
+++ b/examples/tokio-workers-demo/src/lib.rs
@@ -1,0 +1,371 @@
+//! # Tokio-Workers Demo
+//!
+//! This example demonstrates how `tokio-workers` provides a drop-in replacement
+//! for common tokio APIs in Cloudflare Workers.
+//!
+//! ## The Problem
+//!
+//! Standard tokio code like this won't work on Workers:
+//!
+//! ```rust,ignore
+//! use tokio::{spawn, time::sleep, sync::mpsc};
+//!
+//! #[tokio::main]  // <-- tokio runtime can't run in WASM
+//! async fn main() {
+//!     let handle = spawn(async { 42 });  // <-- needs tokio runtime
+//!     sleep(Duration::from_secs(1)).await;  // <-- needs tokio timer
+//!     // ...
+//! }
+//! ```
+//!
+//! ## The Solution
+//!
+//! Replace `use tokio::*` with `use tokio_workers::*`:
+//!
+//! ```rust,ignore
+//! use tokio_workers::{spawn, time::sleep, sync::mpsc};
+//! // Now the same code works on Workers!
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::Duration;
+use worker::*;
+
+// =============================================================================
+// THE KEY CHANGE: Instead of importing from tokio, import from tokio_workers
+// =============================================================================
+//
+// BEFORE (standard tokio - won't work on Workers):
+//   use tokio::{spawn, time::{sleep, timeout}, sync::{mpsc, Mutex}, join};
+//
+// AFTER (tokio-workers - works on Workers!):
+use tokio_workers::{
+    join, spawn,
+    sync::{mpsc, Mutex},
+    task::spawn_blocking,
+    time::{sleep, timeout},
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DemoResponse {
+    endpoint: String,
+    description: String,
+    result: String,
+    elapsed_ms: f64,
+}
+
+fn now() -> f64 {
+    js_sys::Date::now()
+}
+
+#[event(fetch)]
+async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
+    Router::new()
+        .get("/", index)
+        .get_async("/spawn", demo_spawn)
+        .get_async("/sleep", demo_sleep)
+        .get_async("/timeout", demo_timeout)
+        .get_async("/channels", demo_channels)
+        .get_async("/mutex", demo_mutex)
+        .get_async("/concurrent", demo_concurrent)
+        .get_async("/spawn-blocking", demo_spawn_blocking)
+        .run(req, env)
+        .await
+}
+
+fn index(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    Response::ok(
+        r#"Tokio-Workers Demo
+
+This Worker demonstrates tokio-workers as a drop-in replacement for tokio.
+
+Endpoints:
+  GET /spawn          - Spawn async tasks and await results
+  GET /sleep?ms=100   - Sleep for specified milliseconds  
+  GET /timeout        - Demonstrate timeout behavior
+  GET /channels       - Use mpsc channels for communication
+  GET /mutex          - Use async Mutex for shared state
+  GET /concurrent     - Run multiple operations with join!
+  GET /spawn-blocking - Run blocking code (sync mode)
+
+All endpoints return JSON with timing information.
+"#,
+    )
+}
+
+/// Demonstrates: tokio::spawn -> tokio_workers::spawn
+///
+/// In standard tokio:
+/// ```rust,ignore
+/// let handle = tokio::spawn(async { compute() });
+/// let result = handle.await?;
+/// ```
+async fn demo_spawn(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    let start = now();
+
+    // Spawn multiple concurrent tasks
+    let h1 = spawn(async {
+        sleep(Duration::from_millis(10)).await;
+        1 + 1
+    });
+    let h2 = spawn(async {
+        sleep(Duration::from_millis(10)).await;
+        2 * 2
+    });
+    let h3 = spawn(async {
+        sleep(Duration::from_millis(10)).await;
+        3 + 3
+    });
+
+    // Await all handles
+    let r1 = h1.await.map_err(|e| Error::RustError(e.to_string()))?;
+    let r2 = h2.await.map_err(|e| Error::RustError(e.to_string()))?;
+    let r3 = h3.await.map_err(|e| Error::RustError(e.to_string()))?;
+
+    let elapsed = now() - start;
+
+    Response::from_json(&DemoResponse {
+        endpoint: "/spawn".into(),
+        description: "Spawned 3 tasks with 10ms sleep each, ran concurrently".into(),
+        result: format!("Results: {}, {}, {} (sum={})", r1, r2, r3, r1 + r2 + r3),
+        elapsed_ms: elapsed,
+    })
+}
+
+/// Demonstrates: tokio::time::sleep -> tokio_workers::time::sleep
+///
+/// In standard tokio:
+/// ```rust,ignore
+/// tokio::time::sleep(Duration::from_millis(100)).await;
+/// ```
+async fn demo_sleep(req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    let ms: u64 = req
+        .url()?
+        .query_pairs()
+        .find(|(k, _)| k == "ms")
+        .map(|(_, v)| v.parse().unwrap_or(100))
+        .unwrap_or(100);
+
+    let start = now();
+    sleep(Duration::from_millis(ms)).await;
+    let elapsed = now() - start;
+
+    Response::from_json(&DemoResponse {
+        endpoint: "/sleep".into(),
+        description: format!("Slept for {}ms using tokio_workers::time::sleep", ms),
+        result: format!("Requested: {}ms, Actual: {:.1}ms", ms, elapsed),
+        elapsed_ms: elapsed,
+    })
+}
+
+/// Demonstrates: tokio::time::timeout -> tokio_workers::time::timeout
+///
+/// In standard tokio:
+/// ```rust,ignore
+/// match tokio::time::timeout(Duration::from_millis(50), slow_operation()).await {
+///     Ok(result) => println!("Completed: {}", result),
+///     Err(_) => println!("Timed out!"),
+/// }
+/// ```
+async fn demo_timeout(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    let start = now();
+
+    // This should complete (50ms timeout, 10ms operation)
+    let fast_result = timeout(Duration::from_millis(50), async {
+        sleep(Duration::from_millis(10)).await;
+        "fast operation completed"
+    })
+    .await;
+
+    // This should timeout (20ms timeout, 100ms operation)
+    let slow_result = timeout(Duration::from_millis(20), async {
+        sleep(Duration::from_millis(100)).await;
+        "slow operation completed"
+    })
+    .await;
+
+    let elapsed = now() - start;
+
+    let result = format!(
+        "Fast (50ms timeout, 10ms op): {:?}\nSlow (20ms timeout, 100ms op): {:?}",
+        fast_result
+            .map(|s| s.to_string())
+            .map_err(|e| e.to_string()),
+        slow_result
+            .map(|s| s.to_string())
+            .map_err(|e| e.to_string()),
+    );
+
+    Response::from_json(&DemoResponse {
+        endpoint: "/timeout".into(),
+        description: "Demonstrated timeout with fast (succeeds) and slow (times out) operations"
+            .into(),
+        result,
+        elapsed_ms: elapsed,
+    })
+}
+
+/// Demonstrates: tokio::sync::mpsc -> tokio_workers::sync::mpsc
+///
+/// In standard tokio:
+/// ```rust,ignore
+/// let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+/// tokio::spawn(async move { tx.send(42).await });
+/// let value = rx.recv().await;
+/// ```
+async fn demo_channels(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    let start = now();
+
+    let (tx, mut rx) = mpsc::channel::<i32>(10);
+
+    // Spawn a producer task
+    let tx1 = tx.clone();
+    spawn(async move {
+        for i in 1..=5 {
+            sleep(Duration::from_millis(5)).await;
+            let _ = tx1.send(i).await;
+        }
+    });
+
+    // Spawn another producer
+    let tx2 = tx.clone();
+    spawn(async move {
+        for i in 6..=10 {
+            sleep(Duration::from_millis(5)).await;
+            let _ = tx2.send(i).await;
+        }
+    });
+
+    // Drop original tx so channel closes when producers finish
+    drop(tx);
+
+    // Collect all values
+    let mut values = Vec::new();
+    while let Some(v) = rx.recv().await {
+        values.push(v);
+    }
+
+    let elapsed = now() - start;
+
+    Response::from_json(&DemoResponse {
+        endpoint: "/channels".into(),
+        description: "Two producers sent values 1-5 and 6-10 through mpsc channel".into(),
+        result: format!("Received {} values: {:?}", values.len(), values),
+        elapsed_ms: elapsed,
+    })
+}
+
+/// Demonstrates: tokio::sync::Mutex -> tokio_workers::sync::Mutex
+///
+/// In standard tokio:
+/// ```rust,ignore
+/// let counter = Arc::new(tokio::sync::Mutex::new(0));
+/// let c = counter.clone();
+/// tokio::spawn(async move { *c.lock().await += 1; });
+/// ```
+async fn demo_mutex(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    let start = now();
+
+    let counter = Arc::new(Mutex::new(0));
+
+    // Spawn multiple tasks that increment the counter
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let c = counter.clone();
+        handles.push(spawn(async move {
+            let mut lock = c.lock().await;
+            *lock += 1;
+        }));
+    }
+
+    // Wait for all tasks to complete
+    for h in handles {
+        h.await.map_err(|e| Error::RustError(e.to_string()))?;
+    }
+
+    let final_value = *counter.lock().await;
+    let elapsed = now() - start;
+
+    Response::from_json(&DemoResponse {
+        endpoint: "/mutex".into(),
+        description: "10 concurrent tasks each incremented a shared counter".into(),
+        result: format!("Final counter value: {} (expected: 10)", final_value),
+        elapsed_ms: elapsed,
+    })
+}
+
+/// Demonstrates: tokio::join! -> tokio_workers::join!
+///
+/// In standard tokio:
+/// ```rust,ignore
+/// let (a, b, c) = tokio::join!(
+///     async { 1 },
+///     async { 2 },
+///     async { 3 },
+/// );
+/// ```
+async fn demo_concurrent(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    let start = now();
+
+    // Run multiple async operations concurrently
+    let (a, b, c) = join!(
+        async {
+            sleep(Duration::from_millis(30)).await;
+            "operation A"
+        },
+        async {
+            sleep(Duration::from_millis(30)).await;
+            "operation B"
+        },
+        async {
+            sleep(Duration::from_millis(30)).await;
+            "operation C"
+        },
+    );
+
+    let elapsed = now() - start;
+
+    Response::from_json(&DemoResponse {
+        endpoint: "/concurrent".into(),
+        description: "Three 30ms operations ran concurrently with join!".into(),
+        result: format!("Results: {}, {}, {} (should take ~30ms, not 90ms)", a, b, c),
+        elapsed_ms: elapsed,
+    })
+}
+
+/// Demonstrates: tokio::task::spawn_blocking -> tokio_workers::task::spawn_blocking
+///
+/// Note: In WASM, true blocking isn't possible. With `spawn-blocking-sync` feature,
+/// the closure runs synchronously (blocking the event loop).
+///
+/// In standard tokio:
+/// ```rust,ignore
+/// let result = tokio::task::spawn_blocking(|| {
+///     expensive_computation()
+/// }).await?;
+/// ```
+async fn demo_spawn_blocking(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    let start = now();
+
+    // This runs synchronously in WASM (with spawn-blocking-sync feature)
+    let handle = spawn_blocking(|| {
+        // Simulate some "blocking" computation
+        let mut sum = 0u64;
+        for i in 0..1000 {
+            sum += i;
+        }
+        sum
+    });
+
+    let result = handle.await.map_err(|e| Error::RustError(e.to_string()))?;
+    let elapsed = now() - start;
+
+    Response::from_json(&DemoResponse {
+        endpoint: "/spawn-blocking".into(),
+        description: "Ran 'blocking' computation (sync in WASM with spawn-blocking-sync feature)"
+            .into(),
+        result: format!("Sum of 0..1000 = {}", result),
+        elapsed_ms: elapsed,
+    })
+}

--- a/examples/tokio-workers-demo/wrangler.toml
+++ b/examples/tokio-workers-demo/wrangler.toml
@@ -1,0 +1,6 @@
+name = "tokio-workers-demo"
+main = "build/index.js"
+compatibility_date = "2024-01-01"
+
+[build]
+command = "cargo install worker-build@^0.7 && worker-build --release"

--- a/tokio-workers/Cargo.toml
+++ b/tokio-workers/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "tokio-workers"
+version = "0.1.0"
+authors = ["Cloudflare Workers Team <workers@cloudflare.com>"]
+edition = "2021"
+license = "Apache-2.0"
+description = "Tokio compatibility shim for Cloudflare Workers"
+repository = "https://github.com/cloudflare/workers-rs"
+keywords = ["tokio", "wasm", "workers", "cloudflare", "async"]
+rust-version = "1.75"
+
+[dependencies]
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
+js-sys.workspace = true
+web-sys.workspace = true
+futures-util = { version = "0.3.31", default-features = false, features = ["alloc", "async-await", "async-await-macro"] }
+tokio = { version = "1.28", default-features = false, features = ["sync"] }
+pin-project = "1"
+
+[features]
+default = []
+# spawn_blocking behavior - if neither is set, defaults to panic
+spawn-blocking-panic = []
+spawn-blocking-sync = []
+
+[dev-dependencies]
+wasm-bindgen-test.workspace = true

--- a/tokio-workers/src/lib.rs
+++ b/tokio-workers/src/lib.rs
@@ -1,0 +1,69 @@
+//! Tokio compatibility shim for Cloudflare Workers.
+//!
+//! This crate provides tokio-like APIs that work in the Workers WASM environment.
+//! It allows you to run code written for tokio on Cloudflare Workers with minimal
+//! modifications.
+//!
+//! # Usage
+//!
+//! Replace `use tokio::*` with `use tokio_workers::*`:
+//!
+//! ```rust,ignore
+//! // Before
+//! use tokio::{spawn, time::sleep};
+//!
+//! // After
+//! use tokio_workers::{spawn, time::sleep};
+//! use std::time::Duration;
+//!
+//! async fn example() {
+//!     let handle = spawn(async { 42 });
+//!     sleep(Duration::from_secs(1)).await;
+//!     let result = handle.await.unwrap();
+//! }
+//! ```
+//!
+//! # Supported APIs
+//!
+//! ## Task spawning
+//! - [`spawn`] - Spawn a future onto the runtime
+//! - [`spawn_local`] - Same as `spawn` (WASM is single-threaded)
+//! - [`task::spawn_blocking`] - Feature-gated behavior (see below)
+//! - [`task::yield_now`] - Yield execution to other tasks
+//!
+//! ## Time
+//! - [`time::sleep`] - Sleep for a duration
+//! - [`time::timeout`] - Require a future to complete within a duration
+//!
+//! ## Synchronization (re-exported from tokio)
+//! - [`sync::Mutex`], [`sync::RwLock`], [`sync::Semaphore`]
+//! - [`sync::mpsc`], [`sync::oneshot`], [`sync::broadcast`], [`sync::watch`]
+//!
+//! ## Macros (re-exported from futures)
+//! - [`select!`] - Wait on multiple futures
+//! - [`join!`] - Wait for all futures to complete
+//!
+//! # `spawn_blocking` Behavior
+//!
+//! The `spawn_blocking` function has configurable behavior via feature flags:
+//!
+//! - `spawn-blocking-panic` (default if neither set): Panics with an error message
+//! - `spawn-blocking-sync`: Runs the closure synchronously (blocks event loop)
+//!
+//! # Limitations
+//!
+//! - No true multi-threading (WASM is single-threaded)
+//! - `JoinHandle::abort()` cannot interrupt running code
+//! - `spawn_blocking` cannot truly run blocking code in the background
+
+pub mod sync;
+pub mod task;
+pub mod time;
+
+// Re-export common items at crate root (mirrors tokio's API)
+pub use task::{spawn, spawn_local, JoinError, JoinHandle};
+
+// Re-export macros from futures-util (compatible replacements)
+// These are proc-macros that work with any executor
+pub use futures_util::select_biased as select;
+pub use futures_util::{join, try_join};

--- a/tokio-workers/src/sync.rs
+++ b/tokio-workers/src/sync.rs
@@ -1,0 +1,145 @@
+//! Synchronization primitives.
+//!
+//! This module re-exports tokio's synchronization primitives, which are
+//! runtime-agnostic and work in any async environment including WASM.
+//!
+//! # Included Primitives
+//!
+//! ## Locks
+//! - [`Mutex`] - An async mutex
+//! - [`RwLock`] - An async read-write lock
+//! - [`Semaphore`] - Limits concurrent access to a resource
+//!
+//! ## Notification
+//! - [`Notify`] - Notifies waiting tasks
+//! - [`Barrier`] - Synchronizes multiple tasks at a barrier point
+//!
+//! ## Channels
+//! - [`mpsc`] - Multi-producer, single-consumer channel
+//! - [`oneshot`] - Single-use channel for one value
+//! - [`broadcast`] - Multi-producer, multi-consumer broadcast channel
+//! - [`watch`] - Single-producer, multi-consumer channel for watching values
+//!
+//! ## Lazy Initialization
+//! - [`OnceCell`] - A cell that can be written to only once
+//!
+//! # Note on `_timeout` Methods
+//!
+//! Some tokio sync primitives have methods ending in `_timeout` (e.g.,
+//! `Mutex::lock_timeout`). These require the tokio timer infrastructure
+//! and will not work in WASM. Use [`crate::time::timeout`] instead:
+//!
+//! ```rust,ignore
+//! use tokio_workers::{sync::Mutex, time::timeout};
+//! use std::time::Duration;
+//!
+//! async fn example(mutex: &Mutex<i32>) {
+//!     // Instead of: mutex.lock_timeout(Duration::from_secs(1))
+//!     // Use:
+//!     let result = timeout(Duration::from_secs(1), mutex.lock()).await;
+//!     match result {
+//!         Ok(guard) => println!("Got lock: {}", *guard),
+//!         Err(_) => println!("Timeout waiting for lock"),
+//!     }
+//! }
+//! ```
+
+// Locks
+pub use tokio::sync::{
+    AcquireError, OwnedSemaphorePermit, Semaphore, SemaphorePermit, TryAcquireError,
+};
+pub use tokio::sync::{Mutex, MutexGuard, OwnedMutexGuard, TryLockError};
+pub use tokio::sync::{
+    OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
+};
+
+// Notification
+pub use tokio::sync::Notify;
+pub use tokio::sync::{Barrier, BarrierWaitResult};
+
+// Lazy initialization
+pub use tokio::sync::OnceCell;
+
+// Channels
+pub use tokio::sync::broadcast;
+pub use tokio::sync::mpsc;
+pub use tokio::sync::oneshot;
+pub use tokio::sync::watch;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use wasm_bindgen_test::*;
+
+    #[wasm_bindgen_test]
+    async fn test_mutex() {
+        let mutex = Arc::new(Mutex::new(0));
+
+        let m1 = mutex.clone();
+        let h1 = crate::spawn(async move {
+            let mut guard = m1.lock().await;
+            *guard += 1;
+        });
+
+        let m2 = mutex.clone();
+        let h2 = crate::spawn(async move {
+            let mut guard = m2.lock().await;
+            *guard += 1;
+        });
+
+        h1.await.unwrap();
+        h2.await.unwrap();
+
+        assert_eq!(*mutex.lock().await, 2);
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_oneshot() {
+        let (tx, rx) = oneshot::channel();
+
+        crate::spawn(async move {
+            tx.send(42).unwrap();
+        });
+
+        let value = rx.await.unwrap();
+        assert_eq!(value, 42);
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_mpsc() {
+        let (tx, mut rx) = mpsc::channel(10);
+
+        crate::spawn(async move {
+            tx.send(1).await.unwrap();
+            tx.send(2).await.unwrap();
+            tx.send(3).await.unwrap();
+        });
+
+        let mut values = vec![];
+        while let Some(v) = rx.recv().await {
+            values.push(v);
+        }
+
+        assert_eq!(values, vec![1, 2, 3]);
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_notify() {
+        let notify = Arc::new(Notify::new());
+        let notify2 = notify.clone();
+
+        let handle = crate::spawn(async move {
+            notify2.notified().await;
+            42
+        });
+
+        // Give the task time to start waiting
+        crate::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        notify.notify_one();
+
+        let result = handle.await.unwrap();
+        assert_eq!(result, 42);
+    }
+}

--- a/tokio-workers/src/task.rs
+++ b/tokio-workers/src/task.rs
@@ -1,0 +1,370 @@
+//! Task spawning and management.
+//!
+//! This module provides tokio-compatible task spawning APIs that work
+//! in the Cloudflare Workers WASM environment.
+
+use std::{
+    cell::RefCell,
+    fmt,
+    future::Future,
+    pin::Pin,
+    rc::Rc,
+    task::{Context, Poll, Waker},
+};
+
+use wasm_bindgen_futures::spawn_local as wasm_spawn_local;
+
+/// Error returned from awaiting a [`JoinHandle`].
+///
+/// In the WASM environment, this error is returned when a task is aborted.
+/// Unlike tokio, panics in spawned tasks will propagate rather than being
+/// captured in a `JoinError`.
+#[derive(Debug)]
+pub struct JoinError {
+    cancelled: bool,
+}
+
+impl JoinError {
+    fn cancelled() -> Self {
+        Self { cancelled: true }
+    }
+
+    /// Returns `true` if the task was cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled
+    }
+
+    /// Returns `true` if the task panicked.
+    ///
+    /// Note: In WASM, panics propagate rather than being captured,
+    /// so this always returns `false`.
+    pub fn is_panic(&self) -> bool {
+        false
+    }
+}
+
+impl fmt::Display for JoinError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.cancelled {
+            write!(f, "task was cancelled")
+        } else {
+            write!(f, "task failed")
+        }
+    }
+}
+
+impl std::error::Error for JoinError {}
+
+/// Internal state shared between the spawned task and its [`JoinHandle`].
+struct JoinState<T> {
+    /// The result of the task, if completed.
+    result: Option<Result<T, JoinError>>,
+    /// Waker to notify when the task completes.
+    waker: Option<Waker>,
+    /// Whether the task has been aborted.
+    aborted: bool,
+}
+
+/// A handle to a spawned task.
+///
+/// This can be awaited to retrieve the task's return value.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tokio_workers::spawn;
+///
+/// let handle = spawn(async {
+///     // do some work
+///     42
+/// });
+///
+/// let result = handle.await.unwrap();
+/// assert_eq!(result, 42);
+/// ```
+pub struct JoinHandle<T> {
+    state: Rc<RefCell<JoinState<T>>>,
+}
+
+impl<T> JoinHandle<T> {
+    /// Abort the task.
+    ///
+    /// Note: In WASM, this sets a cancellation flag but cannot interrupt
+    /// code that is currently executing. The task will be marked as cancelled
+    /// the next time it yields.
+    pub fn abort(&self) {
+        let mut state = self.state.borrow_mut();
+        state.aborted = true;
+        // If we have a result already, mark it as cancelled
+        if state.result.is_none() {
+            state.result = Some(Err(JoinError::cancelled()));
+            if let Some(waker) = state.waker.take() {
+                waker.wake();
+            }
+        }
+    }
+
+    /// Returns `true` if the task has completed.
+    pub fn is_finished(&self) -> bool {
+        self.state.borrow().result.is_some()
+    }
+}
+
+impl<T: 'static> Future for JoinHandle<T> {
+    type Output = Result<T, JoinError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = self.state.borrow_mut();
+        if let Some(result) = state.result.take() {
+            Poll::Ready(result)
+        } else {
+            state.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+/// Spawn a future onto the Workers runtime.
+///
+/// This function spawns the given future and returns a [`JoinHandle`] that
+/// can be awaited to retrieve the result.
+///
+/// # Differences from tokio
+///
+/// - No `Send` bound required (WASM is single-threaded)
+/// - Panics in spawned tasks propagate rather than being captured
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tokio_workers::spawn;
+///
+/// async fn example() {
+///     let handle = spawn(async {
+///         // perform some async work
+///         "hello"
+///     });
+///
+///     let result = handle.await.unwrap();
+///     assert_eq!(result, "hello");
+/// }
+/// ```
+pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
+where
+    F: Future + 'static,
+    F::Output: 'static,
+{
+    let state = Rc::new(RefCell::new(JoinState {
+        result: None,
+        waker: None,
+        aborted: false,
+    }));
+
+    let state_clone = state.clone();
+    wasm_spawn_local(async move {
+        // Check if aborted before starting
+        if state_clone.borrow().aborted {
+            return;
+        }
+
+        let result = future.await;
+
+        let mut s = state_clone.borrow_mut();
+        // Only set result if not already aborted
+        if s.result.is_none() {
+            s.result = Some(Ok(result));
+            if let Some(waker) = s.waker.take() {
+                waker.wake();
+            }
+        }
+    });
+
+    JoinHandle { state }
+}
+
+/// Spawn a `!Send` future onto the Workers runtime.
+///
+/// In WASM, this is identical to [`spawn`] since everything runs on a single thread.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tokio_workers::spawn_local;
+/// use std::rc::Rc;
+///
+/// async fn example() {
+///     // Rc is !Send, but that's fine in WASM
+///     let data = Rc::new(42);
+///     let handle = spawn_local(async move {
+///         *data
+///     });
+///
+///     let result = handle.await.unwrap();
+///     assert_eq!(result, 42);
+/// }
+/// ```
+pub fn spawn_local<F>(future: F) -> JoinHandle<F::Output>
+where
+    F: Future + 'static,
+    F::Output: 'static,
+{
+    spawn(future)
+}
+
+/// Runs a blocking function.
+///
+/// # Behavior
+///
+/// The behavior depends on which feature flag is enabled:
+///
+/// - `spawn-blocking-panic` (default): Panics with an error message explaining
+///   that blocking operations aren't supported in WASM.
+/// - `spawn-blocking-sync`: Runs the closure synchronously. **Warning**: This
+///   blocks the event loop and should only be used for very fast operations.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tokio_workers::task::spawn_blocking;
+///
+/// // With spawn-blocking-sync feature:
+/// let handle = spawn_blocking(|| {
+///     // This runs synchronously
+///     expensive_computation()
+/// });
+///
+/// let result = handle.await.unwrap();
+/// ```
+#[cfg(any(feature = "spawn-blocking-panic", not(feature = "spawn-blocking-sync")))]
+pub fn spawn_blocking<F, R>(_f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + 'static,
+    R: 'static,
+{
+    panic!(
+        "spawn_blocking is not supported in WASM. \
+         Blocking operations cannot run in the background on a single-threaded runtime. \
+         Consider using async alternatives, or enable the 'spawn-blocking-sync' feature \
+         to run the closure synchronously (warning: this blocks the event loop)."
+    );
+}
+
+#[cfg(all(feature = "spawn-blocking-sync", not(feature = "spawn-blocking-panic")))]
+pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + 'static,
+    R: 'static,
+{
+    // Run synchronously - this blocks the event loop
+    let result = f();
+
+    let state = Rc::new(RefCell::new(JoinState {
+        result: Some(Ok(result)),
+        waker: None,
+        aborted: false,
+    }));
+
+    JoinHandle { state }
+}
+
+/// Yields execution back to the runtime.
+///
+/// This allows other tasks to run before continuing. Useful in long-running
+/// computations to avoid blocking the event loop.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tokio_workers::task::yield_now;
+///
+/// async fn long_computation() {
+///     for i in 0..1000 {
+///         // Do some work
+///         process_item(i);
+///
+///         // Periodically yield to let other tasks run
+///         if i % 100 == 0 {
+///             yield_now().await;
+///         }
+///     }
+/// }
+/// ```
+pub async fn yield_now() {
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_futures::JsFuture;
+
+    let promise = js_sys::Promise::resolve(&JsValue::UNDEFINED);
+    let _ = JsFuture::from(promise).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    #[wasm_bindgen_test]
+    async fn test_spawn_returns_value() {
+        let handle = spawn(async { 42 });
+        let result = handle.await.unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_spawn_local_returns_value() {
+        let handle = spawn_local(async { "hello" });
+        let result = handle.await.unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_spawn_with_rc() {
+        use std::rc::Rc;
+
+        let data = Rc::new(42);
+        let handle = spawn_local(async move { *data });
+        let result = handle.await.unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_is_finished() {
+        let handle = spawn(async { 42 });
+
+        // Wait for the task to complete
+        crate::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        assert!(handle.is_finished());
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_abort() {
+        let handle = spawn(async {
+            crate::time::sleep(std::time::Duration::from_millis(100)).await;
+            42
+        });
+
+        handle.abort();
+
+        let result = handle.await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_cancelled());
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_yield_now() {
+        yield_now().await;
+        // Just verify it doesn't panic
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_multiple_spawns() {
+        let h1 = spawn(async { 1 });
+        let h2 = spawn(async { 2 });
+        let h3 = spawn(async { 3 });
+
+        let (r1, r2, r3) = futures_util::join!(h1, h2, h3);
+        assert_eq!(r1.unwrap(), 1);
+        assert_eq!(r2.unwrap(), 2);
+        assert_eq!(r3.unwrap(), 3);
+    }
+}

--- a/tokio-workers/src/time.rs
+++ b/tokio-workers/src/time.rs
@@ -1,0 +1,255 @@
+//! Time-related utilities.
+//!
+//! This module provides tokio-compatible time APIs that work in the
+//! Cloudflare Workers WASM environment using JavaScript's `setTimeout`.
+
+use std::{
+    cell::Cell,
+    future::Future,
+    pin::Pin,
+    rc::Rc,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use pin_project::pin_project;
+use wasm_bindgen::{prelude::Closure, JsCast, JsValue};
+
+/// A future that completes after the specified duration.
+///
+/// Created by the [`sleep`] function.
+#[pin_project(PinnedDrop)]
+pub struct Sleep {
+    duration: Duration,
+    closure: Option<Closure<dyn FnMut()>>,
+    timeout_id: Option<JsValue>,
+    completed: Rc<Cell<bool>>,
+}
+
+impl std::fmt::Debug for Sleep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Sleep")
+            .field("duration", &self.duration)
+            .field("completed", &self.completed.get())
+            .finish()
+    }
+}
+
+// Helper to call setTimeout on any global (works in Node, Browser, and Workers)
+fn set_timeout(callback: &js_sys::Function, delay_ms: i32) -> Result<JsValue, JsValue> {
+    let global = js_sys::global();
+    let set_timeout_fn = js_sys::Reflect::get(&global, &JsValue::from_str("setTimeout"))?;
+    let set_timeout_fn: js_sys::Function = set_timeout_fn.unchecked_into();
+    set_timeout_fn.call2(&global, callback, &JsValue::from(delay_ms))
+}
+
+// Helper to call clearTimeout on any global
+fn clear_timeout(timeout_id: &JsValue) {
+    let global = js_sys::global();
+    if let Ok(clear_timeout_fn) = js_sys::Reflect::get(&global, &JsValue::from_str("clearTimeout"))
+    {
+        let clear_timeout_fn: js_sys::Function = clear_timeout_fn.unchecked_into();
+        let _ = clear_timeout_fn.call1(&global, timeout_id);
+    }
+}
+
+impl Future for Sleep {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        if this.completed.get() {
+            return Poll::Ready(());
+        }
+
+        if this.closure.is_none() {
+            let completed = this.completed.clone();
+            let waker = cx.waker().clone();
+
+            let callback = Closure::wrap(Box::new(move || {
+                completed.set(true);
+                waker.wake_by_ref();
+            }) as Box<dyn FnMut()>);
+
+            let timeout_id = set_timeout(
+                callback.as_ref().unchecked_ref(),
+                this.duration.as_millis() as i32,
+            )
+            .expect("setTimeout failed");
+
+            *this.closure = Some(callback);
+            *this.timeout_id = Some(timeout_id);
+        }
+
+        Poll::Pending
+    }
+}
+
+#[pin_project::pinned_drop]
+impl PinnedDrop for Sleep {
+    fn drop(self: Pin<&mut Self>) {
+        let this = self.project();
+        if !this.completed.get() {
+            if let Some(id) = this.timeout_id {
+                clear_timeout(id);
+            }
+        }
+    }
+}
+
+/// Creates a future that completes after the specified duration.
+///
+/// This is equivalent to `tokio::time::sleep` but uses JavaScript's
+/// `setTimeout` under the hood.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tokio_workers::time::sleep;
+/// use std::time::Duration;
+///
+/// async fn example() {
+///     // Sleep for 1 second
+///     sleep(Duration::from_secs(1)).await;
+///     println!("1 second has passed");
+/// }
+/// ```
+///
+/// # Cancellation
+///
+/// The sleep is cancelled if the future is dropped before completion.
+/// The underlying JavaScript timeout will be cleared.
+pub fn sleep(duration: Duration) -> Sleep {
+    Sleep {
+        duration,
+        closure: None,
+        timeout_id: None,
+        completed: Rc::new(Cell::new(false)),
+    }
+}
+
+/// Error returned when a timeout expires.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Elapsed(());
+
+impl Elapsed {
+    fn new() -> Self {
+        Self(())
+    }
+}
+
+impl std::fmt::Display for Elapsed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "deadline has elapsed")
+    }
+}
+
+impl std::error::Error for Elapsed {}
+
+/// Requires a future to complete before the specified duration has elapsed.
+///
+/// If the future completes before the timeout, its output is returned.
+/// If the timeout elapses first, an [`Elapsed`] error is returned.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tokio_workers::time::{timeout, sleep};
+/// use std::time::Duration;
+///
+/// async fn example() {
+///     // This will succeed
+///     let result = timeout(Duration::from_secs(1), async { 42 }).await;
+///     assert_eq!(result.unwrap(), 42);
+///
+///     // This will timeout
+///     let result = timeout(
+///         Duration::from_millis(10),
+///         sleep(Duration::from_secs(1))
+///     ).await;
+///     assert!(result.is_err());
+/// }
+/// ```
+///
+/// # Cancellation
+///
+/// If the timeout is dropped, both the inner future and the sleep are cancelled.
+pub async fn timeout<F: Future>(duration: Duration, future: F) -> Result<F::Output, Elapsed> {
+    use futures_util::future::{select, Either};
+    use std::pin::pin;
+
+    let sleep_fut = pin!(sleep(duration));
+    let task_fut = pin!(future);
+
+    match select(task_fut, sleep_fut).await {
+        Either::Left((result, _)) => Ok(result),
+        Either::Right((_, _)) => Err(Elapsed::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    #[wasm_bindgen_test]
+    async fn test_sleep_completes() {
+        sleep(Duration::from_millis(10)).await;
+        // Just verify it completes without error
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_sleep_zero_duration() {
+        sleep(Duration::ZERO).await;
+        // Zero duration should complete immediately (or nearly so)
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_timeout_success() {
+        let result = timeout(Duration::from_millis(100), async { 42 }).await;
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_timeout_elapsed() {
+        let result = timeout(Duration::from_millis(10), sleep(Duration::from_millis(100))).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "deadline has elapsed");
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_timeout_with_value() {
+        let result = timeout(Duration::from_millis(100), async {
+            sleep(Duration::from_millis(10)).await;
+            "completed"
+        })
+        .await;
+        assert_eq!(result.unwrap(), "completed");
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_multiple_sleeps() {
+        let start = js_sys::Date::now();
+        sleep(Duration::from_millis(10)).await;
+        sleep(Duration::from_millis(10)).await;
+        let elapsed = js_sys::Date::now() - start;
+        // Should take at least 20ms (but allow some slack for timing)
+        assert!(elapsed >= 15.0);
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_concurrent_sleeps() {
+        use futures_util::join;
+
+        let start = js_sys::Date::now();
+        join!(
+            sleep(Duration::from_millis(20)),
+            sleep(Duration::from_millis(20)),
+            sleep(Duration::from_millis(20)),
+        );
+        let elapsed = js_sys::Date::now() - start;
+        // Concurrent sleeps should complete in ~20ms, not 60ms
+        assert!(elapsed < 50.0);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `tokio-workers` crate providing tokio-compatible APIs that work on Cloudflare Workers
- Users can swap `use tokio::*` with `use tokio_workers::*` to run tokio-based code on Workers
- Add `examples/tokio-workers-demo` demonstrating all supported APIs

## Supported APIs

| Tokio API | tokio-workers Implementation |
|-----------|------------------------------|
| `spawn`, `spawn_local` | `wasm_bindgen_futures::spawn_local` with custom `JoinHandle` |
| `time::sleep` | JavaScript `setTimeout` |
| `time::timeout` | Race sleep against future |
| `sync::*` | Re-exported from tokio (already runtime-agnostic) |
| `join!`, `try_join!`, `select!` | Re-exported from futures-util |
| `spawn_blocking` | Feature-gated: `spawn-blocking-panic` or `spawn-blocking-sync` |

## Example Usage

```rust
// Before (won't work on Workers):
use tokio::{spawn, time::sleep, sync::mpsc};

// After (works on Workers!):
use tokio_workers::{spawn, time::sleep, sync::mpsc};
```

## Testing

All 18 unit tests pass, plus the demo example has 7 endpoints that all work correctly:

- `/spawn` - Concurrent task spawning (~11ms for 3x10ms tasks)
- `/sleep` - Timer works as expected
- `/timeout` - Fast ops succeed, slow ops timeout
- `/channels` - mpsc channels work with multiple producers
- `/mutex` - Async mutex correctly synchronizes
- `/concurrent` - `join!` runs operations in parallel (~30ms not 90ms)
- `/spawn-blocking` - Sync computation works