### PR TITLE
Fix ci

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.87.0"
+profile = "default"


### PR DESCRIPTION
There seem to be some dependencies bumping the MSRV on minors, so we need to now test against 1.87.