### PR TITLE
Added initial image binding support

### DIFF
--- a/worker-sys/src/images/mod.rs
+++ b/worker-sys/src/images/mod.rs
@@ -1,0 +1,10 @@
+use js_sys::Promise;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    pub type Images;
+
+    #[wasm_bindgen(method, js_name = fetch)]
+    pub fn fetch(this: &Images, input: JsValue, options: JsValue) -> Promise;
+}

--- a/worker-sys/src/lib.rs
+++ b/worker-sys/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::manual_non_exhaustive, clippy::empty_docs)]
 
 pub mod ext;
+pub mod images;
 pub mod types;
 
 pub use types::*;

--- a/worker/src/env.rs
+++ b/worker/src/env.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use crate::analytics_engine::AnalyticsEngineDataset;
 #[cfg(feature = "d1")]
 use crate::d1::D1Database;
+use crate::images::Images;
 use crate::kv::KvStore;
 use crate::rate_limit::RateLimiter;
 use crate::Ai;
@@ -101,6 +102,10 @@ impl Env {
 
     /// Access an R2 Bucket by the binding name configured in your wrangler.toml file.
     pub fn bucket(&self, binding: &str) -> Result<Bucket> {
+        self.get_binding(binding)
+    }
+
+    pub fn images(&self, binding: &str) -> Result<Images> {
         self.get_binding(binding)
     }
 

--- a/worker/src/images/mod.rs
+++ b/worker/src/images/mod.rs
@@ -1,0 +1,62 @@
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+
+use crate::env::EnvBinding;
+use crate::{Response, Result};
+use worker_sys::images::Images as SysImages;
+
+pub struct Images {
+    inner: SysImages,
+}
+
+impl Images {
+    pub(crate) fn new(inner: SysImages) -> Self {
+        Self { inner }
+    }
+
+    pub async fn fetch(
+        &self,
+        input: impl Into<JsValue>,
+        options: Option<JsValue>,
+    ) -> Result<Response> {
+        let input = input.into();
+        let options = options.unwrap_or(JsValue::UNDEFINED);
+
+        let promise = self.inner.fetch(input, options);
+        let js_value = JsFuture::from(promise).await?;
+        let response: web_sys::Response = js_value.dyn_into()?;
+        Ok(Response::from(response))
+    }
+}
+
+impl JsCast for Images {
+    fn instanceof(val: &JsValue) -> bool {
+        SysImages::instanceof(val)
+    }
+
+    fn unchecked_from_js(val: JsValue) -> Self {
+        Self {
+            inner: SysImages::unchecked_from_js(val),
+        }
+    }
+
+    fn unchecked_from_js_ref(val: &JsValue) -> &Self {
+        unsafe { &*(val as *const JsValue as *const Images) }
+    }
+}
+
+impl AsRef<JsValue> for Images {
+    fn as_ref(&self) -> &JsValue {
+        self.inner.as_ref()
+    }
+}
+
+impl From<Images> for JsValue {
+    fn from(images: Images) -> JsValue {
+        images.inner.into()
+    }
+}
+
+impl EnvBinding for Images {
+    const TYPE_NAME: &'static str = "Images";
+}

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -223,6 +223,7 @@ mod global;
 mod headers;
 mod http;
 mod hyperdrive;
+pub mod images;
 pub mod kv;
 #[cfg(feature = "queue")]
 mod queue;


### PR DESCRIPTION
Initial design for #864 

This PR adds initial support for the Cloudflare Images binding to workers-rs.

It exposes `Env::images(...)` and `Images::fetch(...)`. This is a minimal first step to establish the binding and API shape.

Happy to iterate based on feedback.