### PR TITLE
Added example: Using serde to populate structures from an API

### DIFF
--- a/examples/serde-rust-structs/.gitignore
+++ b/examples/serde-rust-structs/.gitignore
@@ -1,0 +1,3 @@
+target
+node_modules
+.wrangler

--- a/examples/serde-rust-structs/Cargo.toml
+++ b/examples/serde-rust-structs/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "serde-rust-structs"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.release]
+release = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+worker = { version = "0.7", features = ['http'] }
+worker-macros = { version = "0.7", features = ['http'] }
+http = "1.3"
+serde = "1.0.228"
+serde_json = "1.0.149"

--- a/examples/serde-rust-structs/Cargo.toml
+++ b/examples/serde-rust-structs/Cargo.toml
@@ -14,4 +14,3 @@ worker = { version = "0.7", features = ['http'] }
 worker-macros = { version = "0.7", features = ['http'] }
 http = "1.3"
 serde = "1.0.228"
-serde_json = "1.0.149"

--- a/examples/serde-rust-structs/Readme.md
+++ b/examples/serde-rust-structs/Readme.md
@@ -1,0 +1,2 @@
+# Using Serde to populate Rust structures
+Demo of using ```serde::{Serialize, Deserialize}``` to populate structures from an API, and then return a JSON value from a structure.

--- a/examples/serde-rust-structs/src/lib.rs
+++ b/examples/serde-rust-structs/src/lib.rs
@@ -1,0 +1,66 @@
+use worker::{ Context, Env, Fetch, Request, Response, Result, RouteContext, Router, event };
+use serde::{ Serialize, Deserialize };
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ImageURL {
+    pub image_url: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Images {
+    pub jpg: ImageURL,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Data {
+    pub mal_id: u32,
+    pub url: String,
+    pub title: String,
+    pub date: String,
+    pub author_username: String,
+    pub author_url: String,
+    pub forum_url: String,
+    pub images: Images,
+    pub comments: u32,
+    pub excerpt: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Pagination {
+    pub last_visible_page: u32,
+    pub has_next_page: bool,
+}
+
+// The main struct from the API
+#[derive(Serialize, Deserialize, Clone)]
+pub struct APIResult {
+    pub pagination: Pagination,
+    pub data: Vec<Data>,
+}
+
+// Handle route for /anime/:id
+async fn get_anime_news(_req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let id = ctx.param("id").ok_or_else(|| worker::Error::RustError("Missing 'id' param".into()))?;
+
+    let url = format!("https://api.jikan.moe/v4/anime/{}/news", id); //Ex id: 38524
+
+    let request = http::Request
+        ::builder()
+        .method("GET")
+        .uri(url.as_str())
+        .header("Content-Type", "application/json")
+        .header("Accept", "*/*")
+        .body(String::new())
+        .unwrap();
+
+    let api_res: APIResult = Fetch::Request(worker::Request::try_from(request).unwrap())
+        .send().await?
+        .json().await?;
+
+    Response::from_json(&api_res)
+}
+
+#[event(fetch)]
+async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
+    Router::new().get_async("/anime/:id", get_anime_news).run(req, env).await
+}

--- a/examples/serde-rust-structs/wrangler.toml
+++ b/examples/serde-rust-structs/wrangler.toml
@@ -1,0 +1,6 @@
+name = "serde-rust-structs"
+main = "build/index.js"
+compatibility_date = "2026-02-07"
+
+[build]
+command = "cargo install -q worker-build@^0.7 && worker-build --release"


### PR DESCRIPTION
This is a demo of using serde Serialize and Deserialize to populate structs from JSON from an API and return a response from that struct serialised as JSON. It also uses http:Request instead of worker::Request.
It is useful to get values tied to Rust variables from an API.
This fills a gap in the current examples, where using external APIs to get values and manipulate them.