### PR TITLE
fix: SecretStore::get() returns None due to Fetcher indirection and error swallowing

### DIFF
--- a/test/src/secret_store.rs
+++ b/test/src/secret_store.rs
@@ -11,7 +11,7 @@ pub async fn get_from_secret_store(
     let secret_value = secrets.get().await?;
 
     match secret_value {
-        Some(_value) => Response::ok("secret value"),
+        Some(value) => Response::ok(value),
         None => Response::error("Secret not found", 404),
     }
 }

--- a/worker/src/secret_store.rs
+++ b/worker/src/secret_store.rs
@@ -1,15 +1,20 @@
 use crate::{
+    error::Error,
     send::{SendFuture, SendWrapper},
-    EnvBinding, Fetcher, Result,
+    EnvBinding, Result,
 };
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 
-/// A binding to a Cloudflare Secret Store.
+/// A binding to a Cloudflare Secret Store secret.
+///
+/// Each `[[secrets_store_secrets]]` entry in your wrangler.toml maps a single
+/// secret (identified by `store_id` + `secret_name`) to a binding name.
+/// Use [`SecretStore::get`] to retrieve the secret value.
 #[derive(Debug, Clone)]
 pub struct SecretStore(SendWrapper<worker_sys::SecretStoreSys>);
 
-// Allows for attachment to axum router, as Workers will never allow multithreading.
+// Workers will never allow multithreading.
 unsafe impl Send for SecretStore {}
 unsafe impl Sync for SecretStore {}
 
@@ -18,39 +23,32 @@ impl EnvBinding for SecretStore {
 }
 
 impl JsCast for SecretStore {
-    fn instanceof(val: &wasm_bindgen::JsValue) -> bool {
-        Fetcher::instanceof(val)
+    fn instanceof(val: &JsValue) -> bool {
+        val.is_instance_of::<worker_sys::SecretStoreSys>()
     }
 
-    fn unchecked_from_js(val: wasm_bindgen::JsValue) -> Self {
-        let fetcher = Fetcher::unchecked_from_js(val);
-        Self::from(fetcher)
+    fn unchecked_from_js(val: JsValue) -> Self {
+        Self(SendWrapper::new(val.unchecked_into()))
     }
 
-    fn unchecked_from_js_ref(val: &wasm_bindgen::JsValue) -> &Self {
-        unsafe { &*(val as *const wasm_bindgen::JsValue as *const Self) }
+    fn unchecked_from_js_ref(val: &JsValue) -> &Self {
+        unsafe { &*(val as *const JsValue as *const Self) }
     }
 }
 
-impl AsRef<wasm_bindgen::JsValue> for SecretStore {
-    fn as_ref(&self) -> &wasm_bindgen::JsValue {
+impl AsRef<JsValue> for SecretStore {
+    fn as_ref(&self) -> &JsValue {
         self.0.as_ref()
     }
 }
 
-impl From<wasm_bindgen::JsValue> for SecretStore {
-    fn from(val: wasm_bindgen::JsValue) -> Self {
+impl From<JsValue> for SecretStore {
+    fn from(val: JsValue) -> Self {
         Self::unchecked_from_js(val)
     }
 }
 
-impl From<Fetcher> for SecretStore {
-    fn from(fetcher: Fetcher) -> Self {
-        Self(SendWrapper::new(fetcher.into_rpc()))
-    }
-}
-
-impl From<SecretStore> for wasm_bindgen::JsValue {
+impl From<SecretStore> for JsValue {
     fn from(secret_store: SecretStore) -> Self {
         let sys_obj: &worker_sys::SecretStoreSys = secret_store.0.as_ref();
         sys_obj.clone().into()
@@ -59,19 +57,15 @@ impl From<SecretStore> for wasm_bindgen::JsValue {
 
 impl SecretStore {
     /// Get a secret value from the secret store.
-    /// Returns None if the secret doesn't exist.
+    ///
+    /// Returns `Ok(None)` if the secret doesn't exist,
+    /// or propagates any JS error that occurs.
     pub async fn get(&self) -> Result<Option<String>> {
-        let promise = match self.0.get() {
-            Ok(p) => p,
-            Err(_) => return Ok(None), // Secret not found
-        };
+        let promise = self.0.get().map_err(Error::from)?;
 
         let fut = SendFuture::new(JsFuture::from(promise));
 
-        let output = match fut.await {
-            Ok(val) => val,
-            Err(_) => return Ok(None), // Promise rejected, secret not found
-        };
+        let output = fut.await.map_err(Error::from)?;
 
         if output.is_null() || output.is_undefined() {
             Ok(None)


### PR DESCRIPTION
## Summary

Fixes #919 — `SecretStore::get()` always returns `None` in production despite correctly configured bindings.

## Root Cause

Two bugs in the `SecretStore` implementation:

1. **Unnecessary `Fetcher`/`into_rpc()` indirection** — `SecretStore` was constructed by casting the JS binding through `Fetcher::unchecked_from_js()` then `fetcher.into_rpc::<SecretStoreSys>()`. A `[[secrets_store_secrets]]` binding is not an RPC-style Fetcher — it is a direct binding with a `.get()` method. This indirection may interfere with method dispatch in the production runtime. Every other non-Fetcher binding in the codebase (`RateLimiter`, `KvStore`, `Bucket`, etc.) constructs directly from the `JsValue`.

2. **Silent error swallowing in `get()`** — Both the synchronous `.get()` call and the promise `.await` had `Err(_) => return Ok(None)` arms that discarded all JS errors, making it impossible to distinguish "secret not found" from "something went wrong."

## Changes

- **`worker/src/secret_store.rs`**: Remove the `Fetcher` dependency. Construct `SecretStore` directly from `JsValue` via `val.unchecked_into()`, matching the pattern used by `RateLimiter` and other bindings. Propagate real JS errors in `get()` instead of swallowing them — `Ok(None)` is now only returned for genuinely null/undefined values.

- **`test/src/secret_store.rs`**: Return the actual secret value from the test handler instead of a hardcoded string, so the test validates end-to-end deserialization.