### PR TITLE
Use `impl IntoIterator` consistently

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -18,6 +18,9 @@ jobs:
 
     steps:
       - uses: dtolnay/rust-toolchain@1.87.0
+      - name: Enable symlinks on Windows
+        if: runner.os == 'Windows'
+        run: git config --global core.symlinks true
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -165,6 +168,9 @@ jobs:
 
     steps:
       - uses: dtolnay/rust-toolchain@1.87.0
+      - name: Enable symlinks on Windows
+        if: runner.os == 'Windows'
+        run: git config --global core.symlinks true
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4333,3 +4333,35 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "js-sys"
+version = "0.3.91"
+
+[[patch.unused]]
+name = "wasm-bindgen"
+version = "0.2.114"
+
+[[patch.unused]]
+name = "wasm-bindgen-cli-support"
+version = "0.2.114"
+
+[[patch.unused]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+
+[[patch.unused]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+
+[[patch.unused]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+
+[[patch.unused]]
+name = "wasm-bindgen-test"
+version = "0.3.64"
+
+[[patch.unused]]
+name = "web-sys"
+version = "0.3.91"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-web",
- "worker 0.7.4",
+ "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -611,9 +611,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deflate64"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
 
 [[package]]
 name = "der"
@@ -661,7 +661,7 @@ name = "digest-stream-on-workers"
 version = "0.1.0"
 dependencies = [
  "hex",
- "worker 0.7.4",
+ "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -728,12 +728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
-
-[[package]]
 name = "env_logger"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,9 +748,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
 dependencies = [
  "serde",
  "serde_core",
@@ -797,7 +791,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "worker 0.7.4",
+ "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -964,20 +958,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1301,9 +1295,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -1314,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1336,8 +1330,6 @@ dependencies = [
 [[package]]
 name = "js-sys"
 version = "0.3.90"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1348,7 +1340,7 @@ name = "kv-on-workers"
 version = "0.1.0"
 dependencies = [
  "serde_json",
- "worker 0.7.4",
+ "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1371,9 +1363,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
@@ -1383,13 +1375,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags",
  "libc",
- "redox_syscall 0.7.2",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1753,18 +1746,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1773,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1788,6 +1781,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -1882,14 +1881,14 @@ name = "queue-on-workers"
 version = "0.1.0"
 dependencies = [
  "serde",
- "worker 0.7.4",
+ "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1899,6 +1898,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1960,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
 ]
@@ -2036,7 +2041,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "tokio",
- "worker 0.7.4",
+ "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2147,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2399,12 +2404,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2477,12 +2482,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -2596,9 +2601,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2613,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3077,11 +3082,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3117,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e227b6648df548f43f267aeee20dfd74d3121ccea10f6a73ea5aa319012df20"
+checksum = "643cc295c2bf4c34d36c2bbaddee48c56a15de3a35e7021b95ceb6a936a493ac"
 dependencies = [
  "anyhow",
  "gimli",
@@ -3189,8 +3194,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen"
 version = "0.2.113"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3202,8 +3205,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-cli-support"
 version = "0.2.113"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a855c0fac6939d61ef9c27e1a436edf4ffdfa0bf63862dee3c1555f6d23b009"
 dependencies = [
  "anyhow",
  "base64",
@@ -3220,8 +3221,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-futures"
 version = "0.4.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3234,8 +3233,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.113"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3244,8 +3241,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro-support"
 version = "0.2.113"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3257,8 +3252,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.113"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
 dependencies = [
  "unicode-ident",
 ]
@@ -3266,8 +3259,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-test"
 version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6fc7a6f61926fa909ee570d4ca194e264545ebbbb4ffd63ac07ba921bff447"
 dependencies = [
  "async-trait",
  "cast",
@@ -3288,8 +3279,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-test-macro"
 version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f745a117245c232859f203d6c8d52c72d4cfc42de7e668c147ca6b3e45f1157e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3299,8 +3288,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-test-shared"
 version = "0.2.113"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f88e7ae201cc7c291da857532eb1c8712e89494e76ec3967b9805221388e938"
 
 [[package]]
 name = "wasm-encoder"
@@ -3332,19 +3319,6 @@ dependencies = [
  "indexmap",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -3412,8 +3386,6 @@ dependencies = [
 [[package]]
 name = "web-sys"
 version = "0.3.90"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3448,13 +3420,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
- "env_home",
- "rustix 1.1.4",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -3589,15 +3559,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3629,28 +3590,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3666,12 +3610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,12 +3620,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3702,22 +3634,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3732,12 +3652,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3748,12 +3662,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3768,12 +3676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3786,25 +3688,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
@@ -3914,36 +3804,6 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244647fd7673893058f91f22a0eabd0f45bb50298e995688cb0c4b9837081b19"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "js-sys",
- "matchit 0.7.3",
- "pin-project",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
- "worker-macros 0.7.4",
- "worker-sys 0.7.4",
-]
-
-[[package]]
-name = "worker"
 version = "0.7.5"
 dependencies = [
  "async-trait",
@@ -3968,10 +3828,40 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
  "worker-macros 0.7.5",
  "worker-sys 0.7.5",
+]
+
+[[package]]
+name = "worker"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7267f3baa986254a8dace6f6a7c6ab88aef59f00c03aaad6749e048b5faaf6f6"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "js-sys",
+ "matchit 0.7.3",
+ "pin-project",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "worker-macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "worker-sys 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4023,22 +3913,6 @@ dependencies = [
 
 [[package]]
 name = "worker-macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7e73ffb164183b57bb67d3efb881681fcd93ef5515ba32a4d022c4a6acc2ce"
-dependencies = [
- "async-trait",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-macro-support",
- "worker-sys 0.7.4",
-]
-
-[[package]]
-name = "worker-macros"
 version = "0.7.5"
 dependencies = [
  "async-trait",
@@ -4049,6 +3923,22 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-macro-support",
  "worker-sys 0.7.5",
+]
+
+[[package]]
+name = "worker-macros"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7410081121531ec2fa111ab17b911efc601d7b6d590c0a92b847874ebeff0030"
+dependencies = [
+ "async-trait",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-macro-support",
+ "worker-sys 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4085,9 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "worker-sys"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2b96254fcaa9229fd82d886f04be99c4ee8e59c8d80438724aa70039dca838"
+version = "0.7.5"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4098,6 +3986,8 @@ dependencies = [
 [[package]]
 name = "worker-sys"
 version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4777582bf8a04174a034cb336f3702eb0e5cb444a67fdaa4fd44454ff7e2dd95"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4166,18 +4056,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4333,35 +4223,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "js-sys"
-version = "0.3.91"
-
-[[patch.unused]]
-name = "wasm-bindgen"
-version = "0.2.114"
-
-[[patch.unused]]
-name = "wasm-bindgen-cli-support"
-version = "0.2.114"
-
-[[patch.unused]]
-name = "wasm-bindgen-futures"
-version = "0.4.64"
-
-[[patch.unused]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.114"
-
-[[patch.unused]]
-name = "wasm-bindgen-shared"
-version = "0.2.114"
-
-[[patch.unused]]
-name = "wasm-bindgen-test"
-version = "0.3.64"
-
-[[patch.unused]]
-name = "web-sys"
-version = "0.3.91"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-web",
- "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "worker 0.7.4",
 ]
 
 [[package]]
@@ -611,9 +611,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deflate64"
-version = "0.1.11"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "der"
@@ -661,7 +661,7 @@ name = "digest-stream-on-workers"
 version = "0.1.0"
 dependencies = [
  "hex",
- "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "worker 0.7.4",
 ]
 
 [[package]]
@@ -728,6 +728,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "env_logger"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,9 +754,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.10"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
 dependencies = [
  "serde",
  "serde_core",
@@ -791,7 +797,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "worker 0.7.4",
 ]
 
 [[package]]
@@ -958,20 +964,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "wasip2",
  "wasip3",
 ]
@@ -1295,9 +1301,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
 dependencies = [
  "jiff-static",
  "log",
@@ -1308,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1340,7 +1346,7 @@ name = "kv-on-workers"
 version = "0.1.0"
 dependencies = [
  "serde_json",
- "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "worker 0.7.4",
 ]
 
 [[package]]
@@ -1363,9 +1369,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libm"
@@ -1375,14 +1381,13 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.2",
 ]
 
 [[package]]
@@ -1746,18 +1751,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1766,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1781,12 +1786,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -1881,14 +1880,14 @@ name = "queue-on-workers"
 version = "0.1.0"
 dependencies = [
  "serde",
- "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "worker 0.7.4",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1898,12 +1897,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1965,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
 dependencies = [
  "bitflags",
 ]
@@ -2041,7 +2034,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "tokio",
- "worker 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "worker 0.7.4",
 ]
 
 [[package]]
@@ -2152,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.29"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2404,12 +2397,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2482,12 +2475,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.27.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -2601,9 +2594,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
@@ -2618,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3082,11 +3075,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.1",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3122,9 +3115,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.25.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cc295c2bf4c34d36c2bbaddee48c56a15de3a35e7021b95ceb6a936a493ac"
+checksum = "8e227b6648df548f43f267aeee20dfd74d3121ccea10f6a73ea5aa319012df20"
 dependencies = [
  "anyhow",
  "gimli",
@@ -3323,6 +3316,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -3420,11 +3426,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
- "libc",
+ "env_home",
+ "rustix 1.1.4",
+ "winsafe",
 ]
 
 [[package]]
@@ -3559,6 +3567,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3590,11 +3607,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3610,6 +3644,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,6 +3660,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3634,10 +3680,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3652,6 +3710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3662,6 +3726,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3676,6 +3746,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3688,13 +3764,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.15"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
@@ -3804,6 +3892,36 @@ dependencies = [
 
 [[package]]
 name = "worker"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244647fd7673893058f91f22a0eabd0f45bb50298e995688cb0c4b9837081b19"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "js-sys",
+ "matchit 0.7.3",
+ "pin-project",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "worker-macros 0.7.4",
+ "worker-sys 0.7.4",
+]
+
+[[package]]
+name = "worker"
 version = "0.7.5"
 dependencies = [
  "async-trait",
@@ -3828,40 +3946,10 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
  "worker-macros 0.7.5",
  "worker-sys 0.7.5",
-]
-
-[[package]]
-name = "worker"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7267f3baa986254a8dace6f6a7c6ab88aef59f00c03aaad6749e048b5faaf6f6"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "js-sys",
- "matchit 0.7.3",
- "pin-project",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "worker-macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "worker-sys 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3913,6 +4001,22 @@ dependencies = [
 
 [[package]]
 name = "worker-macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac7e73ffb164183b57bb67d3efb881681fcd93ef5515ba32a4d022c4a6acc2ce"
+dependencies = [
+ "async-trait",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-macro-support",
+ "worker-sys 0.7.4",
+]
+
+[[package]]
+name = "worker-macros"
 version = "0.7.5"
 dependencies = [
  "async-trait",
@@ -3923,22 +4027,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-macro-support",
  "worker-sys 0.7.5",
-]
-
-[[package]]
-name = "worker-macros"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7410081121531ec2fa111ab17b911efc601d7b6d590c0a92b847874ebeff0030"
-dependencies = [
- "async-trait",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-macro-support",
- "worker-sys 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3975,7 +4063,9 @@ dependencies = [
 
 [[package]]
 name = "worker-sys"
-version = "0.7.5"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2b96254fcaa9229fd82d886f04be99c4ee8e59c8d80438724aa70039dca838"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3986,8 +4076,6 @@ dependencies = [
 [[package]]
 name = "worker-sys"
 version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4777582bf8a04174a034cb336f3702eb0e5cb444a67fdaa4fd44454ff7e2dd95"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4056,18 +4144,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/test/src/sql_counter.rs
+++ b/test/src/sql_counter.rs
@@ -15,7 +15,7 @@ impl DurableObject for SqlCounter {
     fn new(state: State, _env: Env) -> Self {
         let sql = state.storage().sql();
         // Create table if it does not exist.  Note: `exec` is synchronous.
-        sql.exec("CREATE TABLE IF NOT EXISTS counter(value INTEGER);", None)
+        sql.exec("CREATE TABLE IF NOT EXISTS counter(value INTEGER);", [])
             .expect("create table");
         Self { sql }
     }
@@ -43,15 +43,15 @@ impl SqlCounter {
 
         let rows: Vec<Row> = self
             .sql
-            .exec("SELECT value FROM counter LIMIT 1;", None)?
+            .exec("SELECT value FROM counter LIMIT 1;", [])?
             .to_array()?;
         let current = rows.first().map_or(0, |r| r.value);
         let next = current + 1;
 
         // Upsert new value – simplest way: delete and insert again.
-        self.sql.exec("DELETE FROM counter;", None)?;
+        self.sql.exec("DELETE FROM counter;", [])?;
         self.sql
-            .exec("INSERT INTO counter(value) VALUES (?);", vec![next.into()])?;
+            .exec("INSERT INTO counter(value) VALUES (?);", [next.into()])?;
 
         Response::ok(format!("SQL counter is now {next}"))
     }
@@ -77,9 +77,9 @@ impl SqlCounter {
         };
 
         // Store the safe value
-        self.sql.exec("DELETE FROM counter;", None)?;
+        self.sql.exec("DELETE FROM counter;", [])?;
         self.sql
-            .exec("INSERT INTO counter(value) VALUES (?);", vec![safe_value])?;
+            .exec("INSERT INTO counter(value) VALUES (?);", [safe_value])?;
 
         Response::ok(format!("Successfully stored large value: {large_value}"))
     }

--- a/test/src/sql_iterator.rs
+++ b/test/src/sql_iterator.rs
@@ -244,9 +244,7 @@ impl SqlIterator {
     }
 
     fn handle_blob_next(&self) -> Result<Response> {
-        let cursor = self
-            .sql
-            .exec("SELECT * FROM blob_data ORDER BY id;", [])?;
+        let cursor = self.sql.exec("SELECT * FROM blob_data ORDER BY id;", [])?;
 
         let mut results = Vec::new();
         let iterator = cursor.raw();
@@ -285,9 +283,7 @@ impl SqlIterator {
     }
 
     fn handle_blob_raw(&self) -> Result<Response> {
-        let cursor = self
-            .sql
-            .exec("SELECT * FROM blob_data ORDER BY id;", [])?;
+        let cursor = self.sql.exec("SELECT * FROM blob_data ORDER BY id;", [])?;
 
         let mut results = Vec::new();
         let column_names = cursor.column_names();
@@ -400,10 +396,8 @@ impl SqlIterator {
         }
 
         // Clean up test data
-        self.sql.exec(
-            "DELETE FROM blob_data WHERE name = ?;",
-            [test_name.into()],
-        )?;
+        self.sql
+            .exec("DELETE FROM blob_data WHERE name = ?;", [test_name.into()])?;
 
         let response_body = format!("blob-roundtrip test results:\n{}", results.join("\n"));
 

--- a/test/src/sql_iterator.rs
+++ b/test/src/sql_iterator.rs
@@ -68,18 +68,18 @@ impl DurableObject for SqlIterator {
         // Create table and seed with test data
         sql.exec(
             "CREATE TABLE IF NOT EXISTS products(id INTEGER PRIMARY KEY, name TEXT, price REAL, in_stock INTEGER);",
-            None,
+            [],
         ).expect("create table");
 
         sql.exec(
             "CREATE TABLE IF NOT EXISTS blob_data(id INTEGER PRIMARY KEY, name TEXT, data BLOB);",
-            None,
+            [],
         )
         .expect("create blob table");
 
         // Check if we need to seed data
         let count: Vec<serde_json::Value> = sql
-            .exec("SELECT COUNT(*) as count FROM products;", None)
+            .exec("SELECT COUNT(*) as count FROM products;", [])
             .expect("count query")
             .to_array()
             .expect("count result");
@@ -103,14 +103,14 @@ impl DurableObject for SqlIterator {
             for (name, price, in_stock) in products {
                 sql.exec(
                     "INSERT INTO products(name, price, in_stock) VALUES (?, ?, ?);",
-                    vec![name.into(), price.into(), i32::from(in_stock).into()],
+                    [name.into(), price.into(), i32::from(in_stock).into()],
                 )
                 .expect("insert product");
             }
         }
 
         let blob_count: Vec<serde_json::Value> = sql
-            .exec("SELECT COUNT(*) as count FROM blob_data;", None)
+            .exec("SELECT COUNT(*) as count FROM blob_data;", [])
             .expect("blob count query")
             .to_array()
             .expect("blob count result");
@@ -135,7 +135,7 @@ impl DurableObject for SqlIterator {
             for (name, data) in blob_test_data {
                 sql.exec(
                     "INSERT INTO blob_data(name, data) VALUES (?, ?);",
-                    vec![name.into(), SqlStorageValue::Blob(data)],
+                    [name.into(), SqlStorageValue::Blob(data)],
                 )
                 .expect("insert blob data");
             }
@@ -162,7 +162,7 @@ impl DurableObject for SqlIterator {
 
 impl SqlIterator {
     fn handle_next(&self) -> Result<Response> {
-        let cursor = self.sql.exec("SELECT * FROM products ORDER BY id;", None)?;
+        let cursor = self.sql.exec("SELECT * FROM products ORDER BY id;", [])?;
 
         let mut results = Vec::new();
         let iterator = cursor.next::<Product>();
@@ -190,7 +190,7 @@ impl SqlIterator {
     }
 
     fn handle_raw(&self) -> Result<Response> {
-        let cursor = self.sql.exec("SELECT * FROM products ORDER BY id;", None)?;
+        let cursor = self.sql.exec("SELECT * FROM products ORDER BY id;", [])?;
 
         let mut results = Vec::new();
         let column_names = cursor.column_names();
@@ -216,7 +216,7 @@ impl SqlIterator {
     }
 
     fn handle_next_invalid(&self) -> Result<Response> {
-        let cursor = self.sql.exec("SELECT * FROM products ORDER BY id;", None)?;
+        let cursor = self.sql.exec("SELECT * FROM products ORDER BY id;", [])?;
 
         let mut results = Vec::new();
         let iterator = cursor.next::<BadProduct>();
@@ -246,7 +246,7 @@ impl SqlIterator {
     fn handle_blob_next(&self) -> Result<Response> {
         let cursor = self
             .sql
-            .exec("SELECT * FROM blob_data ORDER BY id;", None)?;
+            .exec("SELECT * FROM blob_data ORDER BY id;", [])?;
 
         let mut results = Vec::new();
         let iterator = cursor.raw();
@@ -287,7 +287,7 @@ impl SqlIterator {
     fn handle_blob_raw(&self) -> Result<Response> {
         let cursor = self
             .sql
-            .exec("SELECT * FROM blob_data ORDER BY id;", None)?;
+            .exec("SELECT * FROM blob_data ORDER BY id;", [])?;
 
         let mut results = Vec::new();
         let column_names = cursor.column_names();
@@ -341,18 +341,18 @@ impl SqlIterator {
         // Insert test data
         self.sql.exec(
             "INSERT INTO blob_data(name, data) VALUES (?, ?);",
-            vec![test_name.into(), SqlStorageValue::Blob(test_data.clone())],
+            [test_name.into(), SqlStorageValue::Blob(test_data.clone())],
         )?;
 
         // Read it back using both methods (raw iterator approach for both)
         let cursor_next = self.sql.exec(
             "SELECT * FROM blob_data WHERE name = ? ORDER BY id DESC LIMIT 1;",
-            vec![test_name.into()],
+            [test_name.into()],
         )?;
 
         let cursor_raw = self.sql.exec(
             "SELECT * FROM blob_data WHERE name = ? ORDER BY id DESC LIMIT 1;",
-            vec![test_name.into()],
+            [test_name.into()],
         )?;
 
         let mut results = Vec::new();
@@ -402,7 +402,7 @@ impl SqlIterator {
         // Clean up test data
         self.sql.exec(
             "DELETE FROM blob_data WHERE name = ?;",
-            vec![test_name.into()],
+            [test_name.into()],
         )?;
 
         let response_body = format!("blob-roundtrip test results:\n{}", results.join("\n"));

--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -49,7 +49,10 @@ impl D1Database {
     /// Batch execute one or more statements against the database.
     ///
     /// Returns the results in the same order as the provided statements.
-    pub async fn batch(&self, statements: impl IntoIterator<Item = D1PreparedStatement>) -> Result<Vec<D1Result>> {
+    pub async fn batch(
+        &self,
+        statements: impl IntoIterator<Item = D1PreparedStatement>,
+    ) -> Result<Vec<D1Result>> {
         let statements = statements.into_iter().map(|s| s.0).collect::<Array>();
         let results = JsFuture::from(self.0.batch(statements)?).await;
         let results = cast_to_d1_error(results)?;

--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -49,7 +49,7 @@ impl D1Database {
     /// Batch execute one or more statements against the database.
     ///
     /// Returns the results in the same order as the provided statements.
-    pub async fn batch(&self, statements: Vec<D1PreparedStatement>) -> Result<Vec<D1Result>> {
+    pub async fn batch(&self, statements: impl IntoIterator<Item = D1PreparedStatement>) -> Result<Vec<D1Result>> {
         let statements = statements.into_iter().map(|s| s.0).collect::<Array>();
         let results = JsFuture::from(self.0.batch(statements)?).await;
         let results = cast_to_d1_error(results)?;

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -361,7 +361,10 @@ impl Storage {
     }
 
     /// Retrieves the values associated with each of the provided keys.
-    pub async fn get_multiple<S: Deref<Target = str>, I: IntoIterator<Item=S>>(&self, keys: I) -> Result<Map> {
+    pub async fn get_multiple<S: Deref<Target = str>, I: IntoIterator<Item = S>>(
+        &self,
+        keys: I,
+    ) -> Result<Map> {
         let keys = self.inner.get_multiple(
             keys.into_iter()
                 .map(|key| JsValue::from(key.deref()))
@@ -593,7 +596,10 @@ impl Transaction {
             .map_err(Error::from)
     }
 
-    pub async fn get_multiple<I: IntoIterator<Item = D>, D: Deref<Target=str>>(&self, keys: I) -> Result<Map> {
+    pub async fn get_multiple<I: IntoIterator<Item = D>, D: Deref<Target = str>>(
+        &self,
+        keys: I,
+    ) -> Result<Map> {
         let keys = self.inner.get_multiple(
             keys.into_iter()
                 .map(|key| JsValue::from(key.deref()))
@@ -632,7 +638,10 @@ impl Transaction {
             .map_err(Error::from)
     }
 
-    pub async fn delete_multiple<I: IntoIterator<Item = D>, D: Deref<Target=str>>(&self, keys: I) -> Result<usize> {
+    pub async fn delete_multiple<I: IntoIterator<Item = D>, D: Deref<Target = str>>(
+        &self,
+        keys: I,
+    ) -> Result<usize> {
         let fut: JsFuture = self
             .inner
             .delete_multiple(

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -426,7 +426,10 @@ impl Storage {
 
     /// Deletes the provided keys and their associated values. Returns a count of the number of
     /// key-value pairs deleted.
-    pub async fn delete_multiple(&self, keys: Vec<impl Deref<Target = str>>) -> Result<usize> {
+    pub async fn delete_multiple(
+        &self,
+        keys: impl IntoIterator<Item = impl Deref<Target = str>>,
+    ) -> Result<usize> {
         let fut: JsFuture = self
             .inner
             .delete_multiple(

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -361,7 +361,7 @@ impl Storage {
     }
 
     /// Retrieves the values associated with each of the provided keys.
-    pub async fn get_multiple(&self, keys: Vec<impl Deref<Target = str>>) -> Result<Map> {
+    pub async fn get_multiple<S: Deref<Target = str>, I: IntoIterator<Item=S>>(&self, keys: I) -> Result<Map> {
         let keys = self.inner.get_multiple(
             keys.into_iter()
                 .map(|key| JsValue::from(key.deref()))
@@ -590,7 +590,7 @@ impl Transaction {
             .map_err(Error::from)
     }
 
-    pub async fn get_multiple(&self, keys: Vec<impl Deref<Target = str>>) -> Result<Map> {
+    pub async fn get_multiple<I: IntoIterator<Item = D>, D: Deref<Target=str>>(&self, keys: I) -> Result<Map> {
         let keys = self.inner.get_multiple(
             keys.into_iter()
                 .map(|key| JsValue::from(key.deref()))
@@ -629,7 +629,7 @@ impl Transaction {
             .map_err(Error::from)
     }
 
-    pub async fn delete_multiple(&self, keys: Vec<impl Deref<Target = str>>) -> Result<usize> {
+    pub async fn delete_multiple<I: IntoIterator<Item = D>, D: Deref<Target=str>>(&self, keys: I) -> Result<usize> {
         let fut: JsFuture = self
             .inner
             .delete_multiple(

--- a/worker/src/r2/builder.rs
+++ b/worker/src/r2/builder.rs
@@ -408,8 +408,8 @@ impl ListOptionsBuilder<'_> {
     ///         .await?;
     /// }
     /// ```
-    pub fn include(mut self, include: Vec<Include>) -> Self {
-        self.include = Some(include);
+    pub fn include(mut self, include: impl IntoIterator<Item = Include>) -> Self {
+        self.include = Some(include.into_iter().collect());
         self
     }
 

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -87,7 +87,10 @@ impl Bucket {
     /// pairs globally.
     ///
     /// Up to 1000 keys may be deleted per call.
-    pub async fn delete_multiple(&self, keys: Vec<impl Deref<Target = str>>) -> Result<()> {
+    pub async fn delete_multiple(
+        &self,
+        keys: impl IntoIterator<Item = impl Deref<Target = str>>,
+    ) -> Result<()> {
         let fut: JsFuture = self
             .inner
             .delete_multiple(keys.into_iter().map(|key| JsValue::from(&*key)).collect())?

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -357,7 +357,7 @@ impl<'a, D: 'a> Router<'a, D> {
         self
     }
 
-    fn add_handler(&mut self, pattern: &str, func: Handler<'a, D>, methods: Vec<Method>) {
+    fn add_handler(&mut self, pattern: &str, func: Handler<'a, D>, methods: impl IntoIterator<Item = Method>) {
         for method in methods {
             self.handlers
                 .entry(method.clone())

--- a/worker/src/router.rs
+++ b/worker/src/router.rs
@@ -357,7 +357,12 @@ impl<'a, D: 'a> Router<'a, D> {
         self
     }
 
-    fn add_handler(&mut self, pattern: &str, func: Handler<'a, D>, methods: impl IntoIterator<Item = Method>) {
+    fn add_handler(
+        &mut self,
+        pattern: &str,
+        func: Handler<'a, D>,
+        methods: impl IntoIterator<Item = Method>,
+    ) {
         for method in methods {
             self.handlers
                 .entry(method.clone())

--- a/worker/src/sql.rs
+++ b/worker/src/sql.rs
@@ -201,13 +201,11 @@ impl SqlStorage {
     pub fn exec(
         &self,
         query: &str,
-        bindings: impl Into<Option<Vec<SqlStorageValue>>>,
+        bindings: impl IntoIterator<Item = SqlStorageValue>,
     ) -> Result<SqlCursor> {
         let array = Array::new();
-        if let Some(bindings) = bindings.into() {
-            for v in bindings {
-                array.push(&v.into());
-            }
+        for v in bindings {
+            array.push(&v.into());
         }
         let cursor = self.inner.exec(query, array).map_err(Error::from)?;
         Ok(SqlCursor { inner: cursor })
@@ -220,13 +218,11 @@ impl SqlStorage {
     pub fn exec_raw(
         &self,
         query: &str,
-        bindings: impl Into<Option<Vec<JsValue>>>,
+        bindings: impl IntoIterator<Item = JsValue>,
     ) -> Result<SqlCursor> {
         let array = Array::new();
-        if let Some(bindings) = bindings.into() {
-            for v in bindings {
-                array.push(&v);
-            }
+        for v in bindings {
+            array.push(&v);
         }
         let cursor = self.inner.exec(query, array).map_err(Error::from)?;
         Ok(SqlCursor { inner: cursor })

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -76,19 +76,19 @@ impl WebSocket {
     /// Response::error("never got a message echoed back :(", 500)
     /// ```
     pub async fn connect(url: Url) -> Result<WebSocket> {
-        WebSocket::connect_with_protocols(url, None).await
+        WebSocket::connect_with_protocols(url, std::iter::empty::<&str>()).await
     }
 
     /// Attempts to establish a [`WebSocket`] connection to the provided [`Url`] and protocol.
     ///
     /// # Example:
     /// ```rust,ignore
-    /// let ws = WebSocket::connect_with_protocols("wss://echo.zeb.workers.dev/".parse()?, Some(vec!["GiggleBytes"])).await?;
+    /// let ws = WebSocket::connect_with_protocols("wss://echo.zeb.workers.dev/".parse()?, ["GiggleBytes"]).await?;
     ///
     /// ```
     pub async fn connect_with_protocols(
         mut url: Url,
-        protocols: Option<Vec<&str>>,
+        protocols: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Result<WebSocket> {
         let scheme: String = match url.scheme() {
             "ws" => "http".into(),
@@ -103,12 +103,15 @@ impl WebSocket {
         let mut req = Request::new(url.as_str(), Method::Get)?;
         req.headers_mut()?.set("upgrade", "websocket")?;
 
-        match protocols {
-            None => {}
-            Some(v) => {
-                req.headers_mut()?
-                    .set("Sec-WebSocket-Protocol", v.join(",").as_str())?;
-            }
+        let protocols: Vec<_> = protocols.into_iter().collect();
+        if !protocols.is_empty() {
+            let joined: String = protocols
+                .iter()
+                .map(AsRef::as_ref)
+                .collect::<Vec<&str>>()
+                .join(",");
+            req.headers_mut()?
+                .set("Sec-WebSocket-Protocol", &joined)?;
         }
 
         #[cfg(not(feature = "http"))]

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -110,8 +110,7 @@ impl WebSocket {
                 .map(AsRef::as_ref)
                 .collect::<Vec<&str>>()
                 .join(",");
-            req.headers_mut()?
-                .set("Sec-WebSocket-Protocol", &joined)?;
+            req.headers_mut()?.set("Sec-WebSocket-Protocol", &joined)?;
         }
 
         #[cfg(not(feature = "http"))]


### PR DESCRIPTION
Use `impl IntoIterator` consistently in all APIs. This replaces two other patterns that were in use:
* `Vec<T>` parameters
* `impl Into<Option<Vec<T>>>`
Using a `Vec<T>` parameter when only an iterable collection is an anti-pattern. Using `IntoIterator` instead allows users to pass arrays by value instead since the function is now generic over all array sizes (among many other types). 

`impl Into<Option<Vec<T>>>` is also a poor practice. In every case where it was used, `Some(vec![])` and `None` where treated the same, making the `Option` wrapper redundant. Since `Option` implements iterator, users passing `None` will see no change.

This change is not backwards compatible, but most users will have to make little to no change to existing code.