### PR TITLE
deps: update wasm-bindgen to 0.2.118

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.117"
+version = "0.2.118"
 dependencies = [
  "anyhow",
  "base64",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3316,14 +3316,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "async-trait",
  "cast",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.117"
+version = "0.2.118"
 
 [[package]]
 name = "wasm-encoder"
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ chrono = { version = "0.4.41", default-features = false, features = [
 futures-channel = "0.3.31"
 futures-util = { version = "0.3.31", default-features = false }
 http = "1.3"
-js-sys = { version = "0.3.94" }
+js-sys = { version = "0.3.95" }
 serde = { version = "1.0.164", features = ["derive"] }
 strum = { version = "0.27", features = ["derive"] }
 serde_json = "1.0.140"
@@ -36,14 +36,14 @@ syn = "2.0.17"
 trybuild = "1.0"
 proc-macro2 = "1.0.60"
 quote = "1.0.28"
-wasm-bindgen = { version = "0.2.117" }
-wasm-bindgen-cli-support = { version = "0.2.117" }
-wasm-bindgen-futures = { version = "0.4.67" }
-wasm-bindgen-macro-support = { version = "0.2.117" }
-wasm-bindgen-shared = { version = "0.2.117" }
-wasm-bindgen-test = { version = "0.3.67" }
+wasm-bindgen = { version = "0.2.118" }
+wasm-bindgen-cli-support = { version = "0.2.118" }
+wasm-bindgen-futures = { version = "0.4.68" }
+wasm-bindgen-macro-support = { version = "0.2.118" }
+wasm-bindgen-shared = { version = "0.2.118" }
+wasm-bindgen-test = { version = "0.3.68" }
 wasm-streams = { version = "0.5.0" }
-web-sys = { version = "0.3.94", features = [
+web-sys = { version = "0.3.95", features = [
     "AbortController",
     "AbortSignal",
     "BinaryType",
@@ -105,11 +105,11 @@ opt-level = "z"
 # These are local patches we use to test against local wasm bindgen
 # We always align on the exact stable wasm bindgen version for releases
 [patch.crates-io]
-js-sys = { version = "0.3.94", path = './wasm-bindgen/crates/js-sys' }
-wasm-bindgen = { version = "0.2.117", path = './wasm-bindgen' }
-wasm-bindgen-cli-support = { version = "0.2.117", path = "./wasm-bindgen/crates/cli-support" }
-wasm-bindgen-futures = { version = "0.4.67", path = './wasm-bindgen/crates/futures' }
-wasm-bindgen-macro-support = { version = "0.2.117", path = "./wasm-bindgen/crates/macro-support" }
-wasm-bindgen-shared = { version = "0.2.117", path = "./wasm-bindgen/crates/shared" }
-wasm-bindgen-test = { version = "0.3.67", path = "./wasm-bindgen/crates/test" }
-web-sys = { version = "0.3.94", path = './wasm-bindgen/crates/web-sys' }
+js-sys = { version = "0.3.95", path = './wasm-bindgen/crates/js-sys' }
+wasm-bindgen = { version = "0.2.118", path = './wasm-bindgen' }
+wasm-bindgen-cli-support = { version = "0.2.118", path = "./wasm-bindgen/crates/cli-support" }
+wasm-bindgen-futures = { version = "0.4.68", path = './wasm-bindgen/crates/futures' }
+wasm-bindgen-macro-support = { version = "0.2.118", path = "./wasm-bindgen/crates/macro-support" }
+wasm-bindgen-shared = { version = "0.2.118", path = "./wasm-bindgen/crates/shared" }
+wasm-bindgen-test = { version = "0.3.68", path = "./wasm-bindgen/crates/test" }
+web-sys = { version = "0.3.95", path = './wasm-bindgen/crates/web-sys' }

--- a/worker-build/src/versions.rs
+++ b/worker-build/src/versions.rs
@@ -7,9 +7,9 @@ macro_rules! version {
 }
 
 // Current build toolchain, always used exactly for builds, unless overridden by {}_BIN env vars
-pub(crate) static LATEST_WASM_BINDGEN_VERSION: LazyLock<semver::Version> = version!("0.2.117");
+pub(crate) static LATEST_WASM_BINDGEN_VERSION: LazyLock<semver::Version> = version!("0.2.118");
 pub(crate) static CUR_WASM_OPT_VERSION: &str = "129";
-pub(crate) static CUR_ESBUILD_VERSION: LazyLock<semver::Version> = version!("0.27.4");
+pub(crate) static CUR_ESBUILD_VERSION: LazyLock<semver::Version> = version!("0.28.0");
 
 // Minimum required libraries, validated before build
 pub(crate) static MIN_WASM_BINDGEN_LIB_VERSION: LazyLock<semver::Version> = version!("0.2.115");


### PR DESCRIPTION
This updates the wasm-bindgen submodule and all related dependency versions to 0.2.118, following the same pattern as the previous 0.2.117 upgrade (#963).

* `wasm-bindgen` 0.2.117 → 0.2.118
* `wasm-bindgen-cli-support` 0.2.117 → 0.2.118
* `wasm-bindgen-futures` 0.4.67 → 0.4.68
* `wasm-bindgen-macro-support` 0.2.117 → 0.2.118
* `wasm-bindgen-shared` 0.2.117 → 0.2.118
* `wasm-bindgen-test` 0.3.67 → 0.3.68
* `js-sys` 0.3.94 → 0.3.95
* `web-sys` 0.3.94 → 0.3.95

All 123 tests pass (`npm run build && npm run test`).