### PR TITLE
feat(worker-build): auto-install nightly prereqs for --panic-unwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,18 +459,10 @@ Or in your `wrangler.toml` build command:
 command = "cargo install worker-build && worker-build --release --panic-unwind"
 ```
 
-### Prerequisites
+This flag:
 
-To configure the nightly toolchain with build std run:
-
-```
-rustup toolchain install nightly
-rustup component add rust-src --toolchain nightly
-rustup target add wasm32-unknown-unknown --toolchain nightly
-```
-
-- Uses the **nightly** Rust toolchain (requires `rustup toolchain install nightly`)
-- Rebuilds `std` with `-Zbuild-std=std,panic_unwind` and `-Cpanic=unwind`
+- Uses the **nightly** Rust toolchain (installed automatically if missing)
+- Rebuilds `std` with `-Zbuild-std=std,panic_unwind` and `-Cpanic=unwind` (the `rust-src` component and `wasm32-unknown-unknown` target for nightly are installed automatically if missing)
 - Enables wasm-bindgen's [panic catching](https://wasm-bindgen.github.io/wasm-bindgen/reference/catch-unwind.html)
   support, which catches panics at FFI boundaries and converts them to JavaScript `PanicError`
   exceptions

--- a/worker-build/src/build/mod.rs
+++ b/worker-build/src/build/mod.rs
@@ -282,6 +282,7 @@ impl Build {
             step_check_rustc_version,
             step_check_crate_config,
             step_check_for_wasm_target,
+            step_check_nightly_prerequisites,
             step_check_lib_versions,
             step_install_wasm_bindgen,
         ]
@@ -333,6 +334,16 @@ impl Build {
         info!("Checking for wasm-target...");
         target::check_for_wasm32_target()?;
         info!("Checking for wasm-target was successful.");
+        Ok(())
+    }
+
+    fn step_check_nightly_prerequisites(&mut self) -> Result<()> {
+        if !self.panic_unwind {
+            return Ok(());
+        }
+        info!("Checking nightly prerequisites for panic=unwind...");
+        target::check_nightly_prerequisites()?;
+        info!("Nightly prerequisites check was successful.");
         Ok(())
     }
 

--- a/worker-build/src/build/target.rs
+++ b/worker-build/src/build/target.rs
@@ -14,6 +14,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
+const NIGHTLY_TOOLCHAIN: &str = "nightly";
+
 struct Wasm32Check {
     rustc_path: PathBuf,
     sysroot: PathBuf,
@@ -164,6 +166,136 @@ fn rustup_add_wasm_target() -> Result<()> {
     let mut cmd = Command::new("rustup");
     cmd.arg("target").arg("add").arg("wasm32-unknown-unknown");
     utils::run(cmd, "rustup").context("Adding the wasm32-unknown-unknown target with rustup")?;
+
+    Ok(())
+}
+
+/// Ensure that the nightly toolchain is installed and has the `rust-src` component
+/// and `wasm32-unknown-unknown` target, which are required for `-Z build-std`.
+pub fn check_nightly_prerequisites() -> Result<()> {
+    let msg = format!(
+        "{}Checking nightly toolchain prerequisites for panic=unwind...",
+        emoji::TARGET
+    );
+    PBAR.info(&msg);
+
+    let nightly_sysroot = get_nightly_sysroot()?;
+
+    if !nightly_sysroot.exists() {
+        install_nightly_toolchain()?;
+    }
+
+    if !has_rust_src_component()? {
+        install_rust_src_component()?;
+    }
+
+    if !does_nightly_wasm32_target_exist() {
+        rustup_add_wasm_target_nightly()?;
+    }
+
+    Ok(())
+}
+
+fn get_nightly_sysroot() -> Result<PathBuf> {
+    let command = Command::new("rustc")
+        .args(["+nightly", "--print", "sysroot"])
+        .output()?;
+
+    if command.status.success() {
+        Ok(String::from_utf8(command.stdout)?.trim().into())
+    } else {
+        Err(anyhow!(
+            "Getting nightly rustc's sysroot wasn't successful. Got {}",
+            command.status
+        ))
+    }
+}
+
+fn install_nightly_toolchain() -> Result<()> {
+    let msg = format!(
+        "{}Installing nightly toolchain via rustup...",
+        emoji::TARGET
+    );
+    PBAR.info(&msg);
+
+    let mut cmd = Command::new("rustup");
+    cmd.arg("toolchain").arg("install").arg(NIGHTLY_TOOLCHAIN);
+    utils::run(cmd, "rustup").context("Installing the nightly toolchain with rustup")?;
+
+    Ok(())
+}
+
+fn has_rust_src_component() -> Result<bool> {
+    let command = Command::new("rustup")
+        .args(["component", "list", "--toolchain", NIGHTLY_TOOLCHAIN])
+        .output()?;
+
+    if !command.status.success() {
+        return Ok(false);
+    }
+
+    let stdout = String::from_utf8(command.stdout)?;
+    Ok(stdout
+        .lines()
+        .any(|line| line.starts_with("rust-src") && line.contains("(installed)")))
+}
+
+fn install_rust_src_component() -> Result<()> {
+    let msg = format!(
+        "{}Installing rust-src component for nightly toolchain...",
+        emoji::TARGET
+    );
+    PBAR.info(&msg);
+
+    let mut cmd = Command::new("rustup");
+    cmd.arg("component")
+        .arg("add")
+        .arg("rust-src")
+        .arg("--toolchain")
+        .arg(NIGHTLY_TOOLCHAIN);
+    utils::run(cmd, "rustup").context("Adding the rust-src component with rustup")?;
+
+    Ok(())
+}
+
+fn does_nightly_wasm32_target_exist() -> bool {
+    let command = Command::new("rustc")
+        .args([
+            "+nightly",
+            "--target",
+            "wasm32-unknown-unknown",
+            "--print",
+            "target-libdir",
+        ])
+        .output();
+
+    match command {
+        Ok(output) if output.status.success() => {
+            let path: PathBuf = String::from_utf8(output.stdout)
+                .ok()
+                .map(|s| s.trim().into())
+                .unwrap_or_default();
+            path.exists()
+        }
+        _ => false,
+    }
+}
+
+fn rustup_add_wasm_target_nightly() -> Result<()> {
+    let msg = format!(
+        "{}Adding wasm32-unknown-unknown target for nightly toolchain...",
+        emoji::TARGET
+    );
+    PBAR.info(&msg);
+
+    let mut cmd = Command::new("rustup");
+    cmd.arg("target")
+        .arg("add")
+        .arg("wasm32-unknown-unknown")
+        .arg("--toolchain")
+        .arg(NIGHTLY_TOOLCHAIN);
+    utils::run(cmd, "rustup")
+        .context("Adding the wasm32-unknown-unknown target for nightly with rustup")?;
 
     Ok(())
 }


### PR DESCRIPTION
When using `--panic-unwind`, cargo is invoked with `+nightly` and `-Z build-std=std,panic_unwind`, which requires the nightly toolchain, the `rust-src` component, and the `wasm32-unknown-unknown` target for nightly. Previously these were not checked, leading to a cryptic error at build time:

```
error: "/Users/.../.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/Cargo.lock" does not exist, unable to build with the standard library, try:
        rustup component add rust-src --toolchain nightly-aarch64-apple-darwin
Error: Compiling your crate to WebAssembly failed
```

This adds a `step_check_nightly_prerequisites` preprocess step that auto-installs all three via rustup when missing:

* Nightly toolchain (`rustup toolchain install nightly`)
* `rust-src` component (`rustup component add rust-src --toolchain nightly`)
* `wasm32-unknown-unknown` target for nightly (`rustup target add wasm32-unknown-unknown --toolchain nightly`)

The step is a no-op when `--panic-unwind` is not specified.