### PR TITLE
Fix the `#[event(start)]` regression from v0.8

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Build all examples
         run: |
-          sed -i 's/, "examples\/axum"//g' Cargo.toml
+          sed -i '/"examples\/axum",/d' Cargo.toml
           for example in examples/*/; do
               example_name=$(basename "$example")
               if [ "$example_name" = "coredump" ]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-on-workers"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "axum-macros",
+ "serde",
+ "tower-service",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "worker",
+ "worker-macros",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,7 +395,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1043,7 +1057,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1463,9 +1477,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -1696,9 +1710,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1728,9 +1742,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -1872,9 +1886,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -1911,7 +1925,7 @@ dependencies = [
  "hmac 0.13.0",
  "md-5",
  "memchr",
- "rand 0.10.0",
+ "rand 0.10.1",
  "sha2",
  "stringprep",
 ]
@@ -2001,9 +2015,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2011,13 +2025,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2041,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2129,7 +2143,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cab9bd343c737660e523ee69f788018f3db686d537d2fd0f99c9f747c1bda4f"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -2207,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",
@@ -2793,7 +2807,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.10.0",
+ "rand 0.10.1",
  "socket2",
  "tokio",
  "tokio-util",
@@ -3099,7 +3113,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -3116,7 +3130,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -4115,7 +4129,7 @@ dependencies = [
  "http",
  "md5",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "retry",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ version = "0.1.0"
 dependencies = [
  "futures-util",
  "serde",
- "worker 0.8.0",
+ "worker",
 ]
 
 [[package]]
@@ -658,7 +658,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-web",
- "worker 0.7.5",
+ "worker",
 ]
 
 [[package]]
@@ -731,7 +731,7 @@ name = "digest-stream-on-workers"
 version = "0.1.0"
 dependencies = [
  "hex",
- "worker 0.7.5",
+ "worker",
 ]
 
 [[package]]
@@ -861,7 +861,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "worker 0.7.5",
+ "worker",
 ]
 
 [[package]]
@@ -1440,7 +1440,7 @@ name = "kv-on-workers"
 version = "0.1.0"
 dependencies = [
  "serde_json",
- "worker 0.7.5",
+ "worker",
 ]
 
 [[package]]
@@ -1975,7 +1975,7 @@ name = "queue-on-workers"
 version = "0.1.0"
 dependencies = [
  "serde",
- "worker 0.7.5",
+ "worker",
 ]
 
 [[package]]
@@ -2152,7 +2152,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "tokio",
- "worker 0.7.5",
+ "worker",
 ]
 
 [[package]]
@@ -2162,7 +2162,7 @@ dependencies = [
  "async-trait",
  "serde-wasm-bindgen",
  "wasm-bindgen",
- "worker 0.8.0",
+ "worker",
  "worker-codegen",
 ]
 
@@ -2170,7 +2170,7 @@ dependencies = [
 name = "rust-rpc-server"
 version = "0.1.0"
 dependencies = [
- "worker 0.8.0",
+ "worker",
 ]
 
 [[package]]
@@ -2806,7 +2806,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "tokio-postgres",
- "worker 0.8.0",
+ "worker",
 ]
 
 [[package]]
@@ -3029,7 +3029,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-web",
- "worker 0.8.0",
+ "worker",
 ]
 
 [[package]]
@@ -4005,36 +4005,6 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7267f3baa986254a8dace6f6a7c6ab88aef59f00c03aaad6749e048b5faaf6f6"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "js-sys",
- "matchit 0.7.3",
- "pin-project",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "worker-macros 0.7.5",
- "worker-sys 0.7.5",
-]
-
-[[package]]
-name = "worker"
 version = "0.8.0"
 dependencies = [
  "async-trait",
@@ -4062,8 +4032,8 @@ dependencies = [
  "wasm-bindgen-test",
  "wasm-streams",
  "web-sys",
- "worker-macros 0.8.0",
- "worker-sys 0.8.0",
+ "worker-macros",
+ "worker-sys",
 ]
 
 [[package]]
@@ -4115,22 +4085,6 @@ dependencies = [
 
 [[package]]
 name = "worker-macros"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7410081121531ec2fa111ab17b911efc601d7b6d590c0a92b847874ebeff0030"
-dependencies = [
- "async-trait",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-macro-support",
- "worker-sys 0.7.5",
-]
-
-[[package]]
-name = "worker-macros"
 version = "0.8.0"
 dependencies = [
  "async-trait",
@@ -4142,7 +4096,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-macro-support",
- "worker-sys 0.8.0",
+ "worker-sys",
 ]
 
 [[package]]
@@ -4174,19 +4128,7 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",
- "worker 0.8.0",
-]
-
-[[package]]
-name = "worker-sys"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4777582bf8a04174a034cb336f3702eb0e5cb444a67fdaa4fd44454ff7e2dd95"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
+ "worker",
 ]
 
 [[package]]
@@ -4207,7 +4149,7 @@ dependencies = [
  "serde",
  "serde_json",
  "web-sys",
- "worker 0.8.0",
+ "worker",
 ]
 
 [[package]]

--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -15,6 +15,6 @@ worker-macros = { workspace = true, features = ['http'] }
 axum = { version = "0.8", default-features = false, features = ['json'] }
 axum-macros = "0.5.0"
 tower-service = "0.3.3"
-wasm-bindgen-futures = "0.4"
-wasm-bindgen = "0.2.117"
+wasm-bindgen-futures = { workspace = true }
+wasm-bindgen = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/worker-macros/src/event.rs
+++ b/worker-macros/src/event.rs
@@ -230,11 +230,24 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Start => {
             validate_event_fn(&input_fn, Start, 0, false);
 
+            let mod_name = Ident::new(
+                &format!("_worker_start_{}", input_fn.sig.ident),
+                input_fn.sig.ident.span(),
+            );
+
             let wasm_bindgen_code =
                 wasm_bindgen_macro_support::expand(quote! { start }, quote! { #input_fn })
                     .expect("wasm_bindgen macro failed to expand");
 
-            TokenStream::from(wasm_bindgen_code)
+            let output = quote! {
+                mod #mod_name {
+                    pub use ::worker::{wasm_bindgen, wasm_bindgen_futures};
+                }
+                use #mod_name::*;
+                #wasm_bindgen_code
+            };
+
+            TokenStream::from(output)
         }
     }
 }

--- a/worker/tests/event.rs
+++ b/worker/tests/event.rs
@@ -3,3 +3,9 @@ fn event_invalid_signatures() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");
 }
+
+#[test]
+fn event_valid_signatures() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/pass/*.rs");
+}

--- a/worker/tests/pass/start-handler.rs
+++ b/worker/tests/pass/start-handler.rs
@@ -1,0 +1,14 @@
+// Regression test for https://github.com/cloudflare/workers-rs/issues/973.
+// A `#[event(start)]` handler must compile without `wasm-bindgen` as a direct
+// dependency. The macro should resolve `wasm_bindgen` through `::worker::`.
+// It must also not conflict when `wasm_bindgen` is already in scope, or when
+// multiple `#[event(start)]` handlers exist in the same module.
+use worker::{event, wasm_bindgen};
+
+#[event(start)]
+pub fn setup_hook() {}
+
+#[event(start)]
+pub fn another_hook() {}
+
+fn main() {}


### PR DESCRIPTION
Fixes a regression from https://github.com/cloudflare/workers-rs/commit/e363ba6#diff-5fbccf7aad8fecebdb79b59bcdf993ad2236c34b9360b7f6cc2862374497a610L244-R234 that made any use of `#[event(start)]` fail to compile unless the user crate had a direct dependency on `wasm-bindgen`.

Closes #973.