### PR TITLE
wasm-bindgen@0.2.122 and unwind safety updates

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
+
+[url."https://github.com/"]
+insteadOf = ["git@github.com:", "ssh://git@github.com/"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
-
-[url."https://github.com/"]
-insteadOf = ["git@github.com:", "ssh://git@github.com/"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,14 @@
 [submodule "wasm-bindgen"]
 	path = wasm-bindgen
 	url = https://github.com/wasm-bindgen/wasm-bindgen
-[submodule "wasm-streams"]
-	path = wasm-streams
-	url = https://github.com/guybedford/wasm-streams
 [submodule "ts-gen"]
 	path = ts-gen
 	url = https://github.com/wasm-bindgen/ts-gen
+[submodule "wasm-streams"]
+	path = wasm-streams
+	url = https://github.com/guybedford/wasm-streams
+	branch = fix-unwind-safety-impls
+[submodule "gloo"]
+	path = gloo
+	url = https://github.com/guybedford/gloo
+	branch = fix-gloo-timers-unwind-safety

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,6 @@
 [submodule "ts-gen"]
 	path = ts-gen
 	url = https://github.com/wasm-bindgen/ts-gen
-[submodule "wasm-streams"]
-	path = wasm-streams
-	url = https://github.com/guybedford/wasm-streams
-	branch = fix-unwind-safety-impls
 [submodule "gloo"]
 	path = gloo
 	url = https://github.com/guybedford/gloo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,7 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.5.0"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d3be8814f5ba5f074491a469eed3d73c273ffad955f25ed1635efac4b0d269"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.121"
+version = "0.2.122"
 dependencies = [
  "anyhow",
  "base64",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3475,14 +3475,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.71"
+version = "0.3.72"
 dependencies = [
  "async-trait",
  "cast",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.71"
+version = "0.3.72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.121"
+version = "0.2.122"
 
 [[package]]
 name = "wasm-encoder"
@@ -3548,8 +3548,6 @@ dependencies = [
 [[package]]
 name = "wasm-streams"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3596,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4101,7 +4099,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "wasm-bindgen-macro-support",
  "wit-parser 0.205.0",
 ]
@@ -4117,7 +4114,6 @@ dependencies = [
  "syn",
  "trybuild",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "wasm-bindgen-macro-support",
  "worker-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ wasm-bindgen-futures = { version = "0.4.72" }
 wasm-bindgen-macro-support = { version = "0.2.122" }
 wasm-bindgen-shared = { version = "0.2.122" }
 wasm-bindgen-test = { version = "0.3.72" }
-wasm-streams = { version = "0.5.0" }
+wasm-streams = { version = "0.6.0" }
 web-sys = { version = "0.3.99", features = [
     "AbortController",
     "AbortSignal",
@@ -115,4 +115,3 @@ wasm-bindgen-macro-support = { version = "0.2.122", path = "./wasm-bindgen/crate
 wasm-bindgen-shared = { version = "0.2.122", path = "./wasm-bindgen/crates/shared" }
 wasm-bindgen-test = { version = "0.3.72", path = "./wasm-bindgen/crates/test" }
 web-sys = { version = "0.3.99", path = './wasm-bindgen/crates/web-sys' }
-wasm-streams = { version = "0.5.0", path = './wasm-streams' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ exclude = [
     "examples/axum",
     "templates/*",
     "wasm-bindgen",
+    "wasm-streams",
+    "gloo",
     "generated",
 ]
 resolver = "2"
@@ -27,7 +29,7 @@ chrono = { version = "0.4.41", default-features = false, features = [
 futures-channel = "0.3.31"
 futures-util = { version = "0.3.31", default-features = false }
 http = "1.3"
-js-sys = { version = "0.3.98" }
+js-sys = { version = "0.3.99" }
 serde = { version = "1.0.164", features = ["derive"] }
 strum = { version = "0.27", features = ["derive"] }
 serde_json = "1.0.140"
@@ -36,14 +38,14 @@ syn = "2.0.17"
 trybuild = "1.0"
 proc-macro2 = "1.0.60"
 quote = "1.0.28"
-wasm-bindgen = { version = "0.2.121" }
-wasm-bindgen-cli-support = { version = "0.2.121" }
-wasm-bindgen-futures = { version = "0.4.71" }
-wasm-bindgen-macro-support = { version = "0.2.121" }
-wasm-bindgen-shared = { version = "0.2.121" }
-wasm-bindgen-test = { version = "0.3.71" }
+wasm-bindgen = { version = "0.2.122" }
+wasm-bindgen-cli-support = { version = "0.2.122" }
+wasm-bindgen-futures = { version = "0.4.72" }
+wasm-bindgen-macro-support = { version = "0.2.122" }
+wasm-bindgen-shared = { version = "0.2.122" }
+wasm-bindgen-test = { version = "0.3.72" }
 wasm-streams = { version = "0.5.0" }
-web-sys = { version = "0.3.98", features = [
+web-sys = { version = "0.3.99", features = [
     "AbortController",
     "AbortSignal",
     "BinaryType",
@@ -105,11 +107,12 @@ opt-level = "z"
 # These are local patches we use to test against local wasm bindgen
 # We always align on the exact stable wasm bindgen version for releases
 [patch.crates-io]
-js-sys = { version = "0.3.98", path = './wasm-bindgen/crates/js-sys' }
-wasm-bindgen = { version = "0.2.121", path = './wasm-bindgen' }
-wasm-bindgen-cli-support = { version = "0.2.121", path = "./wasm-bindgen/crates/cli-support" }
-wasm-bindgen-futures = { version = "0.4.71", path = './wasm-bindgen/crates/futures' }
-wasm-bindgen-macro-support = { version = "0.2.121", path = "./wasm-bindgen/crates/macro-support" }
-wasm-bindgen-shared = { version = "0.2.121", path = "./wasm-bindgen/crates/shared" }
-wasm-bindgen-test = { version = "0.3.71", path = "./wasm-bindgen/crates/test" }
-web-sys = { version = "0.3.98", path = './wasm-bindgen/crates/web-sys' }
+js-sys = { version = "0.3.99", path = './wasm-bindgen/crates/js-sys' }
+wasm-bindgen = { version = "0.2.122", path = './wasm-bindgen' }
+wasm-bindgen-cli-support = { version = "0.2.122", path = "./wasm-bindgen/crates/cli-support" }
+wasm-bindgen-futures = { version = "0.4.72", path = './wasm-bindgen/crates/futures' }
+wasm-bindgen-macro-support = { version = "0.2.122", path = "./wasm-bindgen/crates/macro-support" }
+wasm-bindgen-shared = { version = "0.2.122", path = "./wasm-bindgen/crates/shared" }
+wasm-bindgen-test = { version = "0.3.72", path = "./wasm-bindgen/crates/test" }
+web-sys = { version = "0.3.99", path = './wasm-bindgen/crates/web-sys' }
+wasm-streams = { version = "0.5.0", path = './wasm-streams' }

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -6,8 +6,16 @@ deps = ['install:ts-gen']
 # `Env` / `ExecutionContext` are project-specific re-exports that ts-gen
 # can't infer; everything else (`ReadableStream`, `Headers`, `Event`, …)
 # resolves through ts-gen's built-in web_sys defaults.
+#
+# `--export cloudflare:email` lifts the module's declarations to global
+# scope so consumers see `worker::EmailMessage` directly (rather than
+# `worker::bindings::email::email::EmailMessage`). The file `--export`
+# is required alongside because once any `--export` is specified the
+# implicit "every input is its own export" default is disabled.
 run = '''ts-gen --input types/email.d.ts --output worker/src/bindings/email.rs \
   --errors-as-error \
+  --export types/email.d.ts \
+  --export cloudflare:email \
   --external "Env=crate::Env" \
   --external "ExecutionContext=crate::Context"'''
 

--- a/examples/rpc-client/src/calculator.rs
+++ b/examples/rpc-client/src/calculator.rs
@@ -28,7 +28,7 @@ impl Calculator for CalculatorService {
     async fn add(&self, a: u32, b: u32) -> ::worker::Result<u32> {
         let promise = self.0.add(a, b)?;
         let fut = ::worker::send::SendFuture::new(
-            ::worker::wasm_bindgen_futures::JsFuture::from(promise),
+            ::worker::js_sys::futures::JsFuture::from(promise),
         );
         let output = fut.await?;
         Ok(::serde_wasm_bindgen::from_value(output)?)

--- a/test/src/container.rs
+++ b/test/src/container.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 
 use futures_util::StreamExt;
 use wasm_bindgen::{throw_str, UnwrapThrowExt};
-use wasm_bindgen_futures::spawn_local;
 use worker::*;
 
 use crate::SomeSharedData;
@@ -29,7 +28,7 @@ impl DurableObject for EchoContainer {
         }
         let ready = Arc::new(AtomicBool::new(false));
         let ready_clone = Arc::clone(&ready);
-        spawn_local(async move {
+        js_sys::futures::spawn_local(async move {
             for _ in 0..10 {
                 match container
                     .get_tcp_port(8080)
@@ -112,7 +111,7 @@ pub async fn handle_container(
                 None => return Response::error("Expected websocket response", 500),
             };
             ws.accept()?;
-            spawn_local(redir_websocket(ws, server));
+            js_sys::futures::spawn_local(redir_websocket(ws, server));
             Response::from_websocket(client)
         }
         _ => Response::error("Container method not allowed", 405),

--- a/test/src/counter.rs
+++ b/test/src/counter.rs
@@ -1,37 +1,39 @@
-use std::cell::RefCell;
+use std::cell::Cell;
+use std::panic::AssertUnwindSafe;
 use tokio_stream::{StreamExt, StreamMap};
 use worker::{
-    durable_object, wasm_bindgen, wasm_bindgen_futures, DurableObject, Env, Error, Method, Request,
-    Response, ResponseBuilder, Result, State, WebSocket, WebSocketIncomingMessage, WebSocketPair,
-    WebsocketEvent,
+    durable_object, wasm_bindgen, DurableObject, Env, Error, Method, Request, Response,
+    ResponseBuilder, Result, State, WebSocket, WebSocketIncomingMessage, WebSocketPair,
+    WebsocketEvent, js_sys
 };
 
 use crate::SomeSharedData;
 
 #[durable_object]
 pub struct Counter {
-    count: RefCell<usize>,
-    unstored_count: RefCell<usize>,
+    count: AssertUnwindSafe<Cell<usize>>,
+    unstored_count: AssertUnwindSafe<Cell<usize>>,
     state: State,
-    initialized: RefCell<bool>,
+    initialized: AssertUnwindSafe<Cell<bool>>,
     env: Env,
 }
 
 impl DurableObject for Counter {
     fn new(state: State, env: Env) -> Self {
         Self {
-            count: RefCell::new(0),
-            unstored_count: RefCell::new(0),
-            initialized: RefCell::new(false),
+            count: AssertUnwindSafe(Cell::new(0)),
+            unstored_count: AssertUnwindSafe(Cell::new(0)),
+            initialized: AssertUnwindSafe(Cell::new(false)),
             state,
             env,
         }
     }
 
     async fn fetch(&self, req: Request) -> Result<Response> {
-        if !*self.initialized.borrow() {
-            *self.initialized.borrow_mut() = true;
-            *self.count.borrow_mut() = self.state.storage().get("count").await?.unwrap_or(0);
+        if !self.initialized.get() {
+            self.initialized.set(true);
+            self.count
+                .set(self.state.storage().get("count").await?.unwrap_or(0));
         }
 
         if req.path().eq("/ws") {
@@ -49,15 +51,15 @@ impl DurableObject for Counter {
                 .empty());
         }
 
-        *self.unstored_count.borrow_mut() += 1;
-        *self.count.borrow_mut() += 10;
-        let count = *self.count.borrow();
+        self.unstored_count.set(self.unstored_count.get() + 1);
+        self.count.set(self.count.get() + 10);
+        let count = self.count.get();
         self.state.storage().put("count", count).await?;
 
         Response::ok(format!(
             "[durable_object]: self.count: {}, self.unstored_count: {}, secret value: {}",
-            self.count.borrow(),
-            self.unstored_count.borrow(),
+            self.count.get(),
+            self.unstored_count.get(),
             self.env.secret("SOME_SECRET")?
         ))
     }
@@ -134,7 +136,7 @@ pub async fn handle_websocket(req: Request, env: Env, _data: SomeSharedData) -> 
     let do_ws = res.websocket().expect("server did not accept websocket");
     do_ws.accept()?;
 
-    wasm_bindgen_futures::spawn_local(async move {
+    js_sys::futures::spawn_local(async move {
         let event_stream = server.events().expect("could not open stream");
         let do_event_stream = do_ws.events().expect("could not open stream");
 

--- a/test/src/counter.rs
+++ b/test/src/counter.rs
@@ -2,9 +2,9 @@ use std::cell::Cell;
 use std::panic::AssertUnwindSafe;
 use tokio_stream::{StreamExt, StreamMap};
 use worker::{
-    durable_object, wasm_bindgen, DurableObject, Env, Error, Method, Request, Response,
+    durable_object, js_sys, wasm_bindgen, DurableObject, Env, Error, Method, Request, Response,
     ResponseBuilder, Result, State, WebSocket, WebSocketIncomingMessage, WebSocketPair,
-    WebsocketEvent, js_sys
+    WebsocketEvent,
 };
 
 use crate::SomeSharedData;

--- a/test/src/durable.rs
+++ b/test/src/durable.rs
@@ -1,6 +1,8 @@
 use serde::Serialize;
+use std::cell::Cell;
+use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::{cell::RefCell, collections::HashMap};
+use std::panic::AssertUnwindSafe;
 use worker::DurableObject;
 
 use worker::{
@@ -13,14 +15,14 @@ use worker::{
 #[durable_object]
 pub struct MyClass {
     state: State,
-    number: RefCell<usize>,
+    number: AssertUnwindSafe<Cell<usize>>,
 }
 
 impl DurableObject for MyClass {
     fn new(state: State, _env: Env) -> Self {
         Self {
             state,
-            number: RefCell::new(0),
+            number: AssertUnwindSafe(Cell::new(0)),
         }
     }
 
@@ -153,13 +155,14 @@ impl DurableObject for MyClass {
                         );
                     }
 
-                    *self.number.borrow_mut() = storage.get("count").await?.unwrap_or(0) + 1;
+                    self.number
+                        .set(storage.get("count").await?.unwrap_or(0) + 1);
 
                     storage.delete_all().await?;
 
-                    let count = *self.number.borrow();
+                    let count = self.number.get();
                     storage.put("count", count).await?;
-                    Response::ok(self.number.borrow().to_string())
+                    Response::ok(self.number.get().to_string())
                 }
                 "/transaction" => {
                     Response::error("transactional storage API is still unstable", 501)
@@ -178,20 +181,20 @@ impl DurableObject for MyClass {
 pub struct AnotherClass {
     #[allow(unused)]
     state: State,
-    counter: RefCell<i32>,
+    counter: AssertUnwindSafe<Cell<i32>>,
 }
 
 impl DurableObject for AnotherClass {
     fn new(state: State, _env: Env) -> Self {
         Self {
             state,
-            counter: RefCell::new(0),
+            counter: AssertUnwindSafe(Cell::new(0)),
         }
     }
 
     async fn fetch(&self, _req: Request) -> Result<Response> {
-        *self.counter.borrow_mut() += 1;
-        Response::ok(format!("Counter: {}", self.counter.borrow()))
+        self.counter.set(self.counter.get() + 1);
+        Response::ok(format!("Counter: {}", self.counter.get()))
     }
 }
 

--- a/test/src/fetch.rs
+++ b/test/src/fetch.rs
@@ -3,7 +3,8 @@ use futures_util::future::Either;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use worker::{
-    AbortController, Delay, EncodeBody, Env, Fetch, Method, Request, RequestInit, Response, Result, js_sys
+    js_sys, AbortController, Delay, EncodeBody, Env, Fetch, Method, Request, RequestInit, Response,
+    Result,
 };
 
 #[worker::send]

--- a/test/src/fetch.rs
+++ b/test/src/fetch.rs
@@ -3,8 +3,7 @@ use futures_util::future::Either;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use worker::{
-    wasm_bindgen_futures, AbortController, Delay, EncodeBody, Env, Fetch, Method, Request,
-    RequestInit, Response, Result,
+    AbortController, Delay, EncodeBody, Env, Fetch, Method, Request, RequestInit, Response, Result, js_sys
 };
 
 #[worker::send]
@@ -94,7 +93,7 @@ pub async fn handle_cancelled_fetch(
     let (tx, rx) = futures_channel::oneshot::channel();
 
     // Spawns a future that'll make our fetch request and not block this function.
-    wasm_bindgen_futures::spawn_local({
+    js_sys::futures::spawn_local({
         async move {
             let fetch = Fetch::Url("https://cloudflare.com".parse().unwrap());
             let res = fetch.send_with_signal(&signal).await;

--- a/test/src/ws.rs
+++ b/test/src/ws.rs
@@ -1,7 +1,8 @@
 use super::SomeSharedData;
 use futures_util::StreamExt;
 use worker::{
-    wasm_bindgen_futures, Env, Request, Response, Result, WebSocket, WebSocketPair, WebsocketEvent,
+    js_sys::futures::spawn_local, Env, Request, Response, Result, WebSocket, WebSocketPair,
+    WebsocketEvent,
 };
 
 pub async fn handle_websocket(_req: Request, env: Env, _data: SomeSharedData) -> Result<Response> {
@@ -12,7 +13,7 @@ pub async fn handle_websocket(_req: Request, env: Env, _data: SomeSharedData) ->
 
     let some_namespace_kv = env.kv("SOME_NAMESPACE")?;
 
-    wasm_bindgen_futures::spawn_local(async move {
+    spawn_local(async move {
         let mut event_stream = server.events().expect("could not open stream");
 
         while let Some(event) = event_stream.next().await {

--- a/test/tests/rate_limit.spec.ts
+++ b/test/tests/rate_limit.spec.ts
@@ -22,17 +22,20 @@ describe("rate limit", () => {
   });
 
   test("different keys have independent limits", async () => {
-    // Test that different keys have separate rate limits
+    // Test that different keys have separate rate limits.
+    // NOTE: response bodies from `mf.dispatchFetch` must be consumed immediately;
+    // holding multiple unread responses across further `dispatchFetch` calls can
+    // disturb the earlier streams (undici Pool reuse), surfacing as
+    // "Body is unusable: Body has already been read" when reading later.
     const key1 = "user-1";
     const key2 = "user-2";
 
     const resp1 = await mf.dispatchFetch(`${mfUrl}rate-limit/key/${key1}`);
-    const resp2 = await mf.dispatchFetch(`${mfUrl}rate-limit/key/${key2}`);
-
     expect(resp1.status).toBe(200);
-    expect(resp2.status).toBe(200);
-
     const data1 = await resp1.json() as { success: boolean; key: string };
+
+    const resp2 = await mf.dispatchFetch(`${mfUrl}rate-limit/key/${key2}`);
+    expect(resp2.status).toBe(200);
     const data2 = await resp2.json() as { success: boolean; key: string };
 
     expect(data1.success).toBe(true);

--- a/worker-build/src/build/target.rs
+++ b/worker-build/src/build/target.rs
@@ -388,18 +388,26 @@ pub fn cargo_build_wasm(
 
     cmd.arg("--target").arg("wasm32-unknown-unknown");
 
-    // When panic_unwind is enabled, we need to rebuild std with panic=unwind support
+    // Tell wasm-bindgen's proc-macro to use `js_sys::futures` instead of
+    // `wasm_bindgen_futures`. We pass this as an environment variable rather
+    // than `--cfg` because Cargo does not propagate `RUSTFLAGS`/`--cfg` to
+    // host proc-macros when `--target` is in use. The proc-macro reads this
+    // env var at expansion time.
+    cmd.env("WASM_BINDGEN_USE_JS_SYS", "1");
+
+    // When panic_unwind is enabled, rebuild std with panic=unwind and pass
+    // `-Cpanic=unwind`. Combine with any user-provided RUSTFLAGS so we
+    // don't clobber their flags.
     if panic_unwind {
         cmd.arg("-Z").arg("build-std=std,panic_unwind");
 
-        // Get existing RUSTFLAGS and append panic=unwind
         let existing_rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
-        let new_rustflags = if existing_rustflags.is_empty() {
+        let rustflags = if existing_rustflags.is_empty() {
             "-Cpanic=unwind".to_string()
         } else {
             format!("{existing_rustflags} -Cpanic=unwind")
         };
-        cmd.env("RUSTFLAGS", new_rustflags);
+        cmd.env("RUSTFLAGS", rustflags);
     }
 
     // The `cargo` command is executed inside the directory at `path`, so relative paths set via extra options won't work.

--- a/worker-codegen/Cargo.toml
+++ b/worker-codegen/Cargo.toml
@@ -15,7 +15,6 @@ path = "src/lib.rs"
 
 [dependencies]
 wasm-bindgen.workspace = true
-wasm-bindgen-futures.workspace = true
 wasm-bindgen-macro-support.workspace = true
 syn = { version = "2.0.17", features = ['extra-traits'] }
 proc-macro2 = "1.0.60"

--- a/worker-codegen/src/wit.rs
+++ b/worker-codegen/src/wit.rs
@@ -144,7 +144,7 @@ fn expand_rpc_impl(
         let method_raw = quote!(
             async fn #ident(&self) -> ::worker::Result<#ret_type> {
                 let promise = #invocation_item?;
-                let fut = ::worker::send::SendFuture::new(::worker::wasm_bindgen_futures::JsFuture::from(promise));
+                let fut = ::worker::send::SendFuture::new(::worker::js_sys::futures::JsFuture::from(promise));
                 let output = fut.await?;
                 Ok(::serde_wasm_bindgen::from_value(output)?)
             }

--- a/worker-macros/Cargo.toml
+++ b/worker-macros/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/lib.rs"
 [dependencies]
 async-trait.workspace = true
 wasm-bindgen.workspace = true
-wasm-bindgen-futures.workspace = true
 wasm-bindgen-macro-support.workspace = true
 worker-sys.workspace = true
 strum.workspace = true

--- a/worker-macros/src/durable_object.rs
+++ b/worker-macros/src/durable_object.rs
@@ -47,7 +47,7 @@ mod bindgen_methods {
                 // to the durable object escape into a static-lifetime future.
                 let static_self: &'static Self = unsafe { &*(self as *const _) };
 
-                ::worker::wasm_bindgen_futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
+                ::worker::js_sys::futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
                     <Self as ::worker::DurableObject>::fetch(static_self, req.into()).await
                         .map(::worker::worker_sys::web_sys::Response::from)
                         .map(::worker::wasm_bindgen::JsValue::from)
@@ -67,7 +67,7 @@ mod bindgen_methods {
                 // to the durable object escape into a static-lifetime future.
                 let static_self: &'static Self = unsafe { &*(self as *const _) };
 
-                ::worker::wasm_bindgen_futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
+                ::worker::js_sys::futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
                     <Self as ::worker::DurableObject>::alarm(static_self).await
                         .map(::worker::worker_sys::web_sys::Response::from)
                         .map(::worker::wasm_bindgen::JsValue::from)
@@ -98,7 +98,7 @@ mod bindgen_methods {
                 // to the durable object escape into a static-lifetime future.
                 let static_self: &'static Self = unsafe { &*(self as *const _) };
 
-                ::worker::wasm_bindgen_futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
+                ::worker::js_sys::futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
                     <Self as ::worker::DurableObject>::websocket_message(static_self, ws.into(), message).await
                         .map(|_| ::worker::wasm_bindgen::JsValue::NULL)
                         .map_err(::worker::wasm_bindgen::JsValue::from)
@@ -119,7 +119,7 @@ mod bindgen_methods {
                 // to the durable object escape into a static-lifetime future.
                 let static_self: &'static Self = unsafe { &*(self as *const _) };
 
-                ::worker::wasm_bindgen_futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
+                ::worker::js_sys::futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
                     <Self as ::worker::DurableObject>::websocket_close(static_self, ws.into(), code, reason, was_clean).await
                         .map(|_| ::worker::wasm_bindgen::JsValue::NULL)
                         .map_err(::worker::wasm_bindgen::JsValue::from)
@@ -138,7 +138,7 @@ mod bindgen_methods {
                 // to the durable object escape into a static-lifetime future.
                 let static_self: &'static Self = unsafe { &*(self as *const _) };
 
-                ::worker::wasm_bindgen_futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
+                ::worker::js_sys::futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
                     <Self as ::worker::DurableObject>::websocket_error(static_self, ws.into(), error.into()).await
                         .map(|_| ::worker::wasm_bindgen::JsValue::NULL)
                         .map_err(::worker::wasm_bindgen::JsValue::from)

--- a/worker-macros/src/event.rs
+++ b/worker-macros/src/event.rs
@@ -94,7 +94,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                     env: ::worker::Env,
                     ctx: ::worker::worker_sys::Context
                 ) -> ::worker::js_sys::Promise {
-                    ::worker::wasm_bindgen_futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
+                    ::worker::js_sys::futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
                         let ctx = worker::Context::new(ctx);
                         let response: ::worker::worker_sys::web_sys::Response = match ::worker::FromRequest::from_raw(req) {
                             Ok(req) => {
@@ -136,7 +136,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #input_fn
 
                 mod _worker_fetch {
-                    use ::worker::{wasm_bindgen, wasm_bindgen_futures};
+                    use ::worker::{wasm_bindgen, js_sys};
                     use super::#input_fn_ident;
                     #wasm_bindgen_code
                 }
@@ -159,7 +159,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             // with AssertUnwindSafe to support panic=unwind.
             let wrapper_fn = quote! {
                 pub fn #wrapper_fn_ident(event: ::worker::worker_sys::ScheduledEvent, env: ::worker::Env, ctx: ::worker::worker_sys::ScheduleContext) -> ::worker::js_sys::Promise {
-                    ::worker::wasm_bindgen_futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
+                    ::worker::js_sys::futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
                         // call the original fn
                         #input_fn_ident(::worker::ScheduledEvent::from(event), env, ::worker::ScheduleContext::from(ctx)).await;
                         Ok(::worker::wasm_bindgen::JsValue::UNDEFINED)
@@ -174,7 +174,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #input_fn
 
                 mod _worker_scheduled {
-                    use ::worker::{wasm_bindgen, wasm_bindgen_futures};
+                    use ::worker::wasm_bindgen;
                     use super::#input_fn_ident;
                     #wasm_bindgen_code
                 }
@@ -198,7 +198,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             // with AssertUnwindSafe to support panic=unwind.
             let wrapper_fn = quote! {
                 pub fn #wrapper_fn_ident(event: ::worker::worker_sys::MessageBatch, env: ::worker::Env, ctx: ::worker::worker_sys::Context) -> ::worker::js_sys::Promise {
-                    ::worker::wasm_bindgen_futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
+                    ::worker::js_sys::futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
                         // call the original fn
                         let ctx = worker::Context::new(ctx);
                         match #input_fn_ident(::worker::MessageBatch::from(event), env, ctx).await {
@@ -220,7 +220,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #input_fn
 
                 mod _worker_queue {
-                    use ::worker::{wasm_bindgen, wasm_bindgen_futures};
+                    use ::worker::wasm_bindgen;
                     use super::#input_fn_ident;
                     #wasm_bindgen_code
                 }
@@ -242,7 +242,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             let output = quote! {
                 mod #mod_name {
-                    pub use ::worker::{wasm_bindgen, wasm_bindgen_futures};
+                    pub use ::worker::wasm_bindgen;
                 }
                 use #mod_name::*;
                 #wasm_bindgen_code
@@ -262,7 +262,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
 
             let wrapper_fn = quote! {
                 pub fn #wrapper_fn_ident(message: ::worker::ForwardableEmailMessage, env: ::worker::Env, ctx: ::worker::worker_sys::Context) -> ::worker::js_sys::Promise {
-                    ::worker::wasm_bindgen_futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
+                    ::worker::js_sys::futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
                         let ctx = worker::Context::new(ctx);
                         match #input_fn_ident(message, env, ctx).await {
                             Ok(()) => {},
@@ -283,7 +283,7 @@ pub fn expand_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #input_fn
 
                 mod _worker_email {
-                    use ::worker::{wasm_bindgen, wasm_bindgen_futures};
+                    use ::worker::wasm_bindgen;
                     use super::#input_fn_ident;
                     #wasm_bindgen_code
                 }

--- a/worker/src/ai.rs
+++ b/worker/src/ai.rs
@@ -1,10 +1,10 @@
 use crate::streams::ByteStream;
 use crate::{env::EnvBinding, send::SendFuture};
 use crate::{Error, Result};
+use js_sys::futures::JsFuture;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::JsFuture;
 use web_sys::ReadableStream;
 use worker_sys::Ai as AiSys;
 

--- a/worker/src/bindings/email.rs
+++ b/worker/src/bindings/email.rs
@@ -517,7 +517,7 @@ pub enum FromKind {
 #[wasm_bindgen]
 pub enum ToKind {
     String(String),
-    VecOfString(Array<String>),
+    VecOfString(Vec<String>),
 }
 
 pub use email::EmailMessage;

--- a/worker/src/bindings/email.rs
+++ b/worker/src/bindings/email.rs
@@ -35,14 +35,34 @@ extern "C" {
 impl EmailSendResult {
     #[doc = " * `message_id` - The Email Message ID"]
     pub fn new(message_id: &str) -> EmailSendResult {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: EmailSendResult = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_message_id(message_id);
         inner
     }
 }
+#[wasm_bindgen(module = "cloudflare:email")]
+extern "C" {
+    # [wasm_bindgen (extends = Object)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub type EmailMessage;
+    #[wasm_bindgen(constructor, catch)]
+    pub fn new(from: &str, to: &str, raw: &str) -> Result<EmailMessage, Error>;
+    #[wasm_bindgen(constructor, catch, js_name = "EmailMessage")]
+    pub fn new_with_readable_stream(
+        from: &str,
+        to: &str,
+        raw: &ReadableStream,
+    ) -> Result<EmailMessage, Error>;
+    #[doc = " Envelope From attribute of the email message."]
+    #[wasm_bindgen(method, getter)]
+    pub fn from(this: &EmailMessage) -> String;
+    #[doc = " Envelope To attribute of the email message."]
+    #[wasm_bindgen(method, getter)]
+    pub fn to(this: &EmailMessage) -> String;
+}
 #[wasm_bindgen]
 extern "C" {
-    # [wasm_bindgen (extends = email :: EmailMessage , extends = Object)]
+    # [wasm_bindgen (extends = EmailMessage , extends = Object)]
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type ForwardableEmailMessage;
     #[doc = " Stream of the email message content."]
@@ -92,7 +112,7 @@ extern "C" {
     #[wasm_bindgen(method, catch)]
     pub async fn reply(
         this: &ForwardableEmailMessage,
-        message: &email::EmailMessage,
+        message: &EmailMessage,
     ) -> Result<EmailSendResult, Error>;
 }
 #[wasm_bindgen]
@@ -135,7 +155,7 @@ impl EmailAttachment {
         r#type: &str,
         content: &str,
     ) -> EmailAttachment {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: EmailAttachment = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_disposition("inline");
         inner.set_content_id(content_id);
         inner.set_filename(filename);
@@ -152,7 +172,7 @@ impl EmailAttachment {
         r#type: &str,
         content: &ArrayBuffer,
     ) -> EmailAttachment {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: EmailAttachment = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_disposition("inline");
         inner.set_content_id(content_id);
         inner.set_filename(filename);
@@ -169,7 +189,7 @@ impl EmailAttachment {
         r#type: &str,
         content: &T,
     ) -> EmailAttachment {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: EmailAttachment = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_disposition("inline");
         inner.set_content_id(content_id);
         inner.set_filename(filename);
@@ -211,7 +231,7 @@ impl EmailAttachment {
         r#type: &str,
         content: &str,
     ) -> EmailAttachmentBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: EmailAttachment = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_disposition("attachment");
         inner.set_filename(filename);
         inner.set_type(r#type);
@@ -226,7 +246,7 @@ impl EmailAttachment {
         r#type: &str,
         content: &ArrayBuffer,
     ) -> EmailAttachmentBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: EmailAttachment = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_disposition("attachment");
         inner.set_filename(filename);
         inner.set_type(r#type);
@@ -241,7 +261,7 @@ impl EmailAttachment {
         r#type: &str,
         content: &T,
     ) -> EmailAttachmentBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: EmailAttachment = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_disposition("attachment");
         inner.set_filename(filename);
         inner.set_type(r#type);
@@ -277,7 +297,7 @@ extern "C" {
 }
 impl EmailAddress {
     pub fn new(name: &str, email: &str) -> EmailAddress {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: EmailAddress = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_name(name);
         inner.set_email(email);
         inner
@@ -289,10 +309,7 @@ extern "C" {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub type SendEmail;
     #[wasm_bindgen(method, catch)]
-    pub async fn send(
-        this: &SendEmail,
-        message: &email::EmailMessage,
-    ) -> Result<EmailSendResult, Error>;
+    pub async fn send(this: &SendEmail, message: &EmailMessage) -> Result<EmailSendResult, Error>;
     #[wasm_bindgen(method, catch, js_name = "send")]
     pub async fn send_with_builder(
         this: &SendEmail,
@@ -377,7 +394,7 @@ impl SendEmailBuilder {
         Self::builder_with_email_address_and_slice(from, to, subject).build()
     }
     pub fn builder(from: &str, to: &str, subject: &str) -> SendEmailBuilderBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: SendEmailBuilder = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_from(from);
         inner.set_to(to);
         inner.set_subject(subject);
@@ -388,7 +405,7 @@ impl SendEmailBuilder {
         to: &[String],
         subject: &str,
     ) -> SendEmailBuilderBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: SendEmailBuilder = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_from(from);
         inner.set_to_with_slice(to);
         inner.set_subject(subject);
@@ -399,7 +416,7 @@ impl SendEmailBuilder {
         to: &str,
         subject: &str,
     ) -> SendEmailBuilderBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: SendEmailBuilder = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_from_with_email_address(from);
         inner.set_to(to);
         inner.set_subject(subject);
@@ -410,7 +427,7 @@ impl SendEmailBuilder {
         to: &[String],
         subject: &str,
     ) -> SendEmailBuilderBuilder {
-        let inner: Self = JsCast::unchecked_into(js_sys::Object::new());
+        let inner: SendEmailBuilder = JsCast::unchecked_into(js_sys::Object::new());
         inner.set_from_with_email_address(from);
         inner.set_to_with_slice(to);
         inner.set_subject(subject);
@@ -473,31 +490,6 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn message(this: &EmailEvent) -> ForwardableEmailMessage;
 }
-mod email {
-    use super::*;
-    use js_sys::*;
-    use wasm_bindgen::prelude::*;
-    #[wasm_bindgen(module = "cloudflare:email")]
-    extern "C" {
-        # [wasm_bindgen (extends = Object)]
-        #[derive(Debug, Clone, PartialEq, Eq)]
-        pub type EmailMessage;
-        #[wasm_bindgen(constructor, catch)]
-        pub fn new(from: &str, to: &str, raw: &str) -> Result<EmailMessage, Error>;
-        #[wasm_bindgen(constructor, catch, js_name = "EmailMessage")]
-        pub fn new_with_readable_stream(
-            from: &str,
-            to: &str,
-            raw: &ReadableStream,
-        ) -> Result<EmailMessage, Error>;
-        #[doc = " Envelope From attribute of the email message."]
-        #[wasm_bindgen(method, getter)]
-        pub fn from(this: &EmailMessage) -> String;
-        #[doc = " Envelope To attribute of the email message."]
-        #[wasm_bindgen(method, getter)]
-        pub fn to(this: &EmailMessage) -> String;
-    }
-}
 #[wasm_bindgen]
 pub enum DispositionKind {
     Inline = "inline",
@@ -519,5 +511,3 @@ pub enum ToKind {
     String(String),
     VecOfString(Vec<String>),
 }
-
-pub use email::EmailMessage;

--- a/worker/src/cache.rs
+++ b/worker/src/cache.rs
@@ -1,8 +1,8 @@
 use std::convert::TryInto;
 
+use js_sys::futures::JsFuture;
 use serde::Serialize;
 use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::JsFuture;
 use worker_sys::ext::CacheStorageExt;
 
 use crate::request::Request;

--- a/worker/src/container.rs
+++ b/worker/src/container.rs
@@ -1,6 +1,6 @@
+use js_sys::futures::JsFuture;
 use js_sys::{Map, Object, Reflect};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::JsFuture;
 
 use crate::{Fetcher, Result};
 

--- a/worker/src/context.rs
+++ b/worker/src/context.rs
@@ -4,9 +4,9 @@ use std::panic::AssertUnwindSafe;
 use crate::worker_sys::Context as JsContext;
 use crate::Result;
 
+use js_sys::futures::future_to_promise;
 use serde::de::DeserializeOwned;
 use wasm_bindgen::JsValue;
-use wasm_bindgen_futures::future_to_promise;
 
 /// A context bound to a `fetch` event.
 #[derive(Debug)]

--- a/worker/src/crypto.rs
+++ b/worker/src/crypto.rs
@@ -1,6 +1,6 @@
+use js_sys::futures::JsFuture;
 use js_sys::{ArrayBuffer, Uint8Array};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::JsFuture;
 
 use crate::send::SendFuture;
 

--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -4,13 +4,13 @@ use std::iter::{once, Once};
 use std::ops::Deref;
 use std::result::Result as StdResult;
 
+use js_sys::futures::JsFuture;
 use js_sys::Array;
 use js_sys::ArrayBuffer;
 use js_sys::JsString;
 use js_sys::Uint8Array;
 use serde::Deserialize;
 use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::JsFuture;
 use worker_sys::types::D1Database as D1DatabaseSys;
 use worker_sys::types::D1DatabaseSession as D1DatabaseSessionSys;
 use worker_sys::types::D1ExecResult;

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -24,6 +24,7 @@ use crate::{
 
 use chrono::{DateTime, Utc};
 use futures_util::Future;
+use js_sys::futures::{future_to_promise, JsFuture};
 use js_sys::{Map, Number, Object};
 use serde::{de::DeserializeOwned, Serialize};
 use wasm_bindgen::{prelude::*, JsCast};
@@ -32,8 +33,6 @@ use worker_sys::{
     DurableObjectNamespace as EdgeObjectNamespace, DurableObjectState, DurableObjectStorage,
     DurableObjectTransaction,
 };
-// use wasm_bindgen_futures::future_to_promise;
-use wasm_bindgen_futures::{future_to_promise, JsFuture};
 
 /// A Durable Object stub is a client object used to send requests to a remote Durable Object.
 #[derive(Debug)]

--- a/worker/src/error.rs
+++ b/worker/src/error.rs
@@ -365,7 +365,7 @@ impl From<Error> for JsValue {
 /// indented line under a `Caused by:` header. Matches the convention used
 /// by `anyhow` and `eyre`. Used when serializing back to a `JsValue` so
 /// the full chain is preserved in the rendered string.
-fn format_with_chain(e: &(dyn std::error::Error)) -> String {
+fn format_with_chain(e: &dyn std::error::Error) -> String {
     let mut s = e.to_string();
     let mut current = e.source();
     while let Some(src) = current {

--- a/worker/src/fetcher.rs
+++ b/worker/src/fetcher.rs
@@ -1,7 +1,7 @@
 use crate::{env::EnvBinding, RequestInit, Result};
+use js_sys::futures::JsFuture;
 use std::convert::TryInto;
 use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::JsFuture;
 
 #[cfg(feature = "http")]
 use crate::HttpResponse;

--- a/worker/src/formdata.rs
+++ b/worker/src/formdata.rs
@@ -5,11 +5,11 @@ use crate::Date;
 use crate::DateInit;
 use crate::Result;
 
+use js_sys::futures::JsFuture;
 use js_sys::Array;
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::JsFuture;
 
 /// Representing the options any FormData value can be, a field or a file.
 #[derive(Debug)]

--- a/worker/src/global.rs
+++ b/worker/src/global.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
+use js_sys::futures::JsFuture;
 use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::JsFuture;
 
 use crate::{request::Request, response::Response, AbortSignal, Result};
 

--- a/worker/src/kv/builder.rs
+++ b/worker/src/kv/builder.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
+use js_sys::futures::JsFuture;
 use js_sys::{ArrayBuffer, Function, Map as JsMap, Object, Promise, Uint8Array};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use serde_wasm_bindgen::Serializer;
 use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::JsFuture;
 use web_sys::ReadableStream;
 
 use crate::kv::{self, KvError, ListResponse};

--- a/worker/src/kv/mod.rs
+++ b/worker/src/kv/mod.rs
@@ -20,11 +20,11 @@ mod builder;
 
 pub use builder::*;
 
+use js_sys::futures::JsFuture;
 use js_sys::{global, Array, Function, Object, Promise, Reflect, Uint8Array};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use wasm_bindgen::JsValue;
-use wasm_bindgen_futures::JsFuture;
 use web_sys::ReadableStream;
 
 /// A binding to a Cloudflare KvStore.

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -151,6 +151,7 @@ pub use async_trait;
 pub use js_sys;
 pub use url::Url;
 pub use wasm_bindgen;
+pub use wasm_bindgen_futures;
 pub use web_sys;
 
 pub use cf::{Cf, CfResponseProperties, TlsClientAuth};

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -151,7 +151,6 @@ pub use async_trait;
 pub use js_sys;
 pub use url::Url;
 pub use wasm_bindgen;
-pub use wasm_bindgen_futures;
 pub use web_sys;
 
 pub use cf::{Cf, CfResponseProperties, TlsClientAuth};

--- a/worker/src/queue.rs
+++ b/worker/src/queue.rs
@@ -4,10 +4,10 @@ use std::{
 };
 
 use crate::{env::EnvBinding, Date, Error, Result};
+use js_sys::futures::JsFuture;
 use js_sys::Array;
 use serde::{de::DeserializeOwned, Serialize};
 use wasm_bindgen::{prelude::*, JsCast};
-use wasm_bindgen_futures::JsFuture;
 use worker_sys::{Message as MessageSys, MessageBatch as MessageBatchSys, Queue as EdgeQueue};
 
 /// A batch of messages that are sent to a consumer Worker.

--- a/worker/src/r2/builder.rs
+++ b/worker/src/r2/builder.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, convert::TryFrom};
 
+use js_sys::futures::JsFuture;
 use js_sys::{Array, Date as JsDate, JsString, Object as JsObject, Uint8Array};
 use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::JsFuture;
 use worker_sys::{
     R2Bucket as EdgeR2Bucket, R2HttpMetadata as R2HttpMetadataSys,
     R2MultipartUpload as EdgeR2MultipartUpload, R2Object as EdgeR2Object, R2Range as R2RangeSys,

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -2,9 +2,9 @@ use std::{collections::HashMap, convert::TryInto, ops::Deref};
 
 pub use builder::*;
 
+use js_sys::futures::JsFuture;
 use js_sys::{JsString, Reflect, Uint8Array};
 use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::JsFuture;
 use worker_sys::{
     FixedLengthStream as EdgeFixedLengthStream, R2Bucket as EdgeR2Bucket, R2Checksums,
     R2MultipartUpload as EdgeR2MultipartUpload, R2Object as EdgeR2Object,

--- a/worker/src/rate_limit.rs
+++ b/worker/src/rate_limit.rs
@@ -1,7 +1,7 @@
 use crate::{send::SendFuture, EnvBinding, Result};
+use js_sys::futures::JsFuture;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::JsFuture;
 use worker_sys::RateLimiter as RateLimiterSys;
 
 #[derive(Debug)]

--- a/worker/src/request.rs
+++ b/worker/src/request.rs
@@ -4,6 +4,7 @@ use crate::{
     cf::Cf, error::Error, headers::Headers, http::Method, ByteStream, FormData, RequestInit, Result,
 };
 
+use js_sys::futures::JsFuture;
 use serde::de::DeserializeOwned;
 #[cfg(test)]
 use std::borrow::Cow;
@@ -11,7 +12,6 @@ use std::borrow::Cow;
 use url::form_urlencoded::Parse;
 use url::Url;
 use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::JsFuture;
 use worker_sys::ext::RequestExt;
 
 /// A [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) representation for

--- a/worker/src/schedule.rs
+++ b/worker/src/schedule.rs
@@ -1,7 +1,7 @@
+use js_sys::futures::future_to_promise;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::future_to_promise;
 use worker_sys::{ScheduleContext as EdgeScheduleContext, ScheduledEvent as EdgeScheduledEvent};
 
 /// [Schedule](https://developers.cloudflare.com/workers/runtime-apis/scheduled-event#syntax-module-worker)

--- a/worker/src/secret_store.rs
+++ b/worker/src/secret_store.rs
@@ -3,8 +3,8 @@ use crate::{
     send::{SendFuture, SendWrapper},
     EnvBinding, Result,
 };
+use js_sys::futures::JsFuture;
 use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::JsFuture;
 
 /// A binding to a Cloudflare Secret Store secret.
 ///

--- a/worker/src/socket.rs
+++ b/worker/src/socket.rs
@@ -7,6 +7,7 @@ use std::{
 use crate::Result;
 use crate::{r2::js_object, Error};
 use futures_util::FutureExt;
+use js_sys::futures::JsFuture;
 use js_sys::{
     Boolean as JsBoolean, Error as JsError, JsString, Number as JsNumber, Object as JsObject,
     Reflect, Uint8Array,
@@ -16,7 +17,6 @@ use std::io::Error as IoError;
 use std::io::Result as IoResult;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::JsFuture;
 use web_sys::{
     ReadableStream, ReadableStreamDefaultReader, WritableStream, WritableStreamDefaultWriter,
 };

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -8,14 +8,14 @@ use worker_sys::ext::WebSocketExt;
 
 #[cfg(not(feature = "http"))]
 use crate::Fetch;
+#[cfg(feature = "http")]
+use js_sys::futures::JsFuture;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 use wasm_bindgen::convert::FromWasmAbi;
 use wasm_bindgen::prelude::Closure;
 use wasm_bindgen::JsCast;
-#[cfg(feature = "http")]
-use wasm_bindgen_futures::JsFuture;
 
 pub use crate::ws_events::*;
 pub use worker_sys::WebSocketRequestResponsePair;


### PR DESCRIPTION
This updates to wasm-bindgen@0.2.122.

In the process, it adopts the unwind safety enforcement landed in wasm-bindgen/wasm-bindgen#5128, which adds `MaybeUnwindSafe` bounds on `#[wasm_bindgen]` exports and closure types so that types crossing the JS/Rust boundary under `panic=unwind` are explicitly unwind safe.

Picking up that change required updates in two dependencies, which propagate the bound through their public APIs:

* `wasm-streams` (https://github.com/MattiasBuelens/wasm-streams/pull/35) - implements `UnwindSafe`/`RefUnwindSafe` for the streams wrappers
* `gloo-timers` (https://github.com/rustwasm/gloo/pull/562) - propagates unwind safety to user callbacks

Both are added here as submodules pointing at the corresponding fork branches and patched via `[patch.crates-io]` until the upstreams land and are published.

The durable object test fixtures (`test/src/counter.rs`, `test/src/durable.rs`) had `RefCell<T>` fields holding `Copy` primitives. These were refactored to `Cell<T>` wrapped in `AssertUnwindSafe`:

```rs
// before
count: RefCell<usize>,
*self.count.borrow_mut() += 10;
```

```rs
// after
count: AssertUnwindSafe<Cell<usize>>,
self.count.set(self.count.get() + 10);
```

`Cell<T: Copy>` is genuinely unwind safe in single-threaded wasm - every operation is an atomic move with no borrow guard to leave dangling - but the type system rejects it because `UnsafeCell` has a blanket negative `RefUnwindSafe` impl. `AssertUnwindSafe` is the narrow assertion scoped to just the interior-mutability fields rather than a blanket `impl RefUnwindSafe` on the durable object structs (which would also be asserting unwind safety on the `State` and `Env` fields we don't own).

Also adds a `.cargo/config.toml` URL replacement so transitive git deps fetched via SSH fall back to HTTPS, useful for `cargo generate` users without GitHub SSH set up.

Tested via `npm run test-panic-unwind` - the panic-unwind build now compiles cleanly and the existing test suite passes (one pre-existing rate_limit test failure unrelated to this change).