### PR TITLE
Remove wasm bindgen futures

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,9 @@
 [target.wasm32-unknown-unknown]
 rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
+
+# Make `#[wasm_bindgen]` emit `js_sys::futures` glue instead of
+# `wasm_bindgen_futures` for every cargo invocation in this workspace
+# (check, clippy, build). The proc-macro reads this at expansion time, so it
+# must be present for host builds too, not just the wasm build worker-build runs.
+[env]
+WASM_BINDGEN_USE_JS_SYS = "1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,7 +4050,6 @@ dependencies = [
  "trybuild",
  "url",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "wasm-streams",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ proc-macro2 = "1.0.60"
 quote = "1.0.28"
 wasm-bindgen = { version = "0.2.123" }
 wasm-bindgen-cli-support = { version = "0.2.123" }
-wasm-bindgen-futures = { version = "0.4.73" }
 wasm-bindgen-macro-support = { version = "0.2.123" }
 wasm-bindgen-shared = { version = "0.2.123" }
 wasm-bindgen-test = { version = "0.3.73" }

--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -15,6 +15,5 @@ worker-macros = { workspace = true, features = ['http'] }
 axum = { version = "0.8", default-features = false, features = ['json'] }
 axum-macros = "0.5.0"
 tower-service = "0.3.3"
-wasm-bindgen-futures = { workspace = true }
 wasm-bindgen = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/tokio-postgres/src/lib.rs
+++ b/examples/tokio-postgres/src/lib.rs
@@ -15,7 +15,7 @@ async fn main(_req: Request, env: Env, _ctx: Context) -> anyhow::Result<Response
 
     let (client, connection) = config.connect_raw(socket, PassthroughTls).await?;
 
-    wasm_bindgen_futures::spawn_local(async move {
+    js_sys::futures::spawn_local(async move {
         if let Err(error) = connection.await {
             console_log!("connection error: {:?}", error);
         }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -38,7 +38,6 @@ tokio-postgres = { version = "0.7", optional = true, default-features = false, f
     "js",
 ] }
 url = "2.4.0"
-wasm-bindgen-futures.workspace = true
 wasm-bindgen.workspace = true
 wasm-streams.workspace = true
 web-sys.workspace = true

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -151,7 +151,6 @@ pub use async_trait;
 pub use js_sys;
 pub use url::Url;
 pub use wasm_bindgen;
-pub use wasm_bindgen_futures;
 pub use web_sys;
 
 pub use cf::{Cf, CfResponseProperties, TlsClientAuth};

--- a/worker/src/websocket.rs
+++ b/worker/src/websocket.rs
@@ -275,7 +275,7 @@ type EvCallback<T> = Closure<dyn FnMut(T)>;
 /// server.accept()?;
 ///
 /// // Spawn a future for handling the stream of events from the websocket.
-/// wasm_bindgen_futures::spawn_local(async move {
+/// js_sys::futures::spawn_local(async move {
 ///     let mut event_stream = server.events().expect("could not open stream");
 ///
 ///     while let Some(event) = event_stream.next().await {


### PR DESCRIPTION
This removes the use of the `wasm-bindgen-futures` crate, with the last commit based to https://github.com/cloudflare/workers-rs/pull/999 and using PR https://github.com/wasm-bindgen/wasm-bindgen/pull/5164.