### PR TITLE
feat(d1): add IntoFuture and #[must_use] to D1PreparedStatement

### DIFF
--- a/test/src/d1.rs
+++ b/test/src/d1.rs
@@ -297,7 +297,8 @@ pub async fn insert_and_retrieve_optional_none(
         &None::<String>,
         &None::<u32>
     )?;
-    query.run().await?;
+    // Run the insert by awaiting the statement directly (exercises IntoFuture).
+    query.await?;
 
     let stmt = worker::query!(&db, "SELECT * FROM nullable_people WHERE id = 3");
     let person = stmt.first::<NullablePerson>(None).await?.unwrap();

--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -1,7 +1,9 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::future::{Future, IntoFuture};
 use std::iter::{once, Once};
 use std::ops::Deref;
+use std::pin::Pin;
 use std::result::Result as StdResult;
 
 use js_sys::futures::JsFuture;
@@ -332,7 +334,7 @@ impl D1Argument for D1PreparedArgument<'_> {
 
 // A D1 prepared query statement.
 #[derive(Debug, Clone)]
-#[must_use = "D1PreparedStatement does nothing until you 'run' it"]
+#[must_use = "D1PreparedStatement does nothing until you run or await it"]
 pub struct D1PreparedStatement(D1PreparedStatementSys);
 
 impl D1PreparedStatement {
@@ -443,6 +445,17 @@ impl D1PreparedStatement {
     /// Returns the inner JsValue bindings object.
     pub fn inner(&self) -> &D1PreparedStatementSys {
         &self.0
+    }
+}
+
+impl IntoFuture for D1PreparedStatement {
+    type Output = Result<D1Result>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output>>>;
+
+    /// Awaiting runs the statement via [`run`](D1PreparedStatement::run) and returns only metadata.
+    /// Use [`all`](D1PreparedStatement::all) or [`first`](D1PreparedStatement::first) to retrieve rows.
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move { self.run().await })
     }
 }
 
@@ -587,5 +600,20 @@ mod tests {
             D1SessionConstraint::FirstUnconstrained.as_str(),
             "first-unconstrained"
         );
+    }
+}
+
+#[cfg(test)]
+mod into_future_check {
+    // Awaiting a statement resolves through `run`, so the impl must yield
+    // `Result<D1Result>`. This compile-time check guards that contract.
+    use super::{D1PreparedStatement, D1Result};
+    use crate::Result;
+    use std::future::IntoFuture;
+
+    fn _assert_into_future<T: IntoFuture<Output = Result<D1Result>>>() {}
+    #[allow(dead_code)]
+    fn _check() {
+        _assert_into_future::<D1PreparedStatement>();
     }
 }

--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -332,6 +332,7 @@ impl D1Argument for D1PreparedArgument<'_> {
 
 // A D1 prepared query statement.
 #[derive(Debug, Clone)]
+#[must_use = "D1PreparedStatement does nothing until you 'run' it"]
 pub struct D1PreparedStatement(D1PreparedStatementSys);
 
 impl D1PreparedStatement {


### PR DESCRIPTION
`D1PreparedStatement` holds a query that has not run yet. With no terminal call it compiles fine and does nothing, e.g. `query!(&db, "DELETE FROM users WHERE id = ?", id)?;`. Adding `#[must_use]` to the type makes that a compile warning, matching the KV builders (`GetOptionsBuilder`, `PutOptionsBuilder`).

#774 also asks for `impl IntoFuture` so a statement runs when you `.await` it. That would be the first `IntoFuture` in the crate, and `await stmt` has to pick one terminal method. I can follow up with one delegating to `run()` to match the JS `stmt.run()`, or `all()` if you'd prefer.

Part of #774.
