### PR TITLE
fix: re-add reference-types target feature stripped by `strip = true`

### DIFF
--- a/worker-build/src/build/mod.rs
+++ b/worker-build/src/build/mod.rs
@@ -510,6 +510,11 @@ pub fn wasm_bindgen_build(
         .join(data.crate_name())
         .with_extension("wasm");
 
+    // `strip = true` drops the target_features section that wasm-bindgen
+    // needs to enable its externref transform. Patch it back in.
+    crate::reference_types::ensure_reference_types_feature(&wasm_path)
+        .context("Failed to ensure the reference-types target feature is advertised")?;
+
     let dts_arg = if disable_dts {
         "--no-typescript"
     } else {

--- a/worker-build/src/main.rs
+++ b/worker-build/src/main.rs
@@ -19,6 +19,7 @@ mod emoji;
 mod lockfile;
 mod main_legacy;
 mod producers;
+mod reference_types;
 mod versions;
 
 use build::{Build, BuildOptions};

--- a/worker-build/src/producers.rs
+++ b/worker-build/src/producers.rs
@@ -9,11 +9,14 @@ struct ProducersEntry<'a> {
     version: &'a str,
 }
 
-struct ProducersSection {
-    start: usize,
-    end: usize,
-    content_start: usize,
-    content_end: usize,
+/// Byte range of a wasm custom section (id 0).
+pub(crate) struct CustomSection {
+    /// Byte offset of the section id byte.
+    pub start: usize,
+    /// Byte offset past the last byte of the section.
+    pub end: usize,
+    /// Byte offset of the payload, past the section name.
+    pub content_start: usize,
 }
 
 pub(crate) fn inject_workers_rs_sdk_metadata(out_dir: &Path, version: &'static str) -> Result<()> {
@@ -46,16 +49,11 @@ fn merge_producers_section<'a>(
     bytes: &'a [u8],
     new_entries: &[ProducersEntry<'a>],
 ) -> Result<Vec<u8>> {
-    let existing = find_producers_section(bytes)?;
+    let existing = find_custom_section(bytes, "producers")?;
     let mut entries = Vec::new();
 
     if let Some(section) = &existing {
-        parse_producers(
-            bytes,
-            section.content_start,
-            section.content_end,
-            &mut entries,
-        )?;
+        parse_producers(bytes, section.content_start, section.end, &mut entries)?;
     }
 
     for new_entry in new_entries {
@@ -82,7 +80,8 @@ fn merge_producers_section<'a>(
     Ok(output)
 }
 
-fn find_producers_section(bytes: &[u8]) -> Result<Option<ProducersSection>> {
+/// Find a named custom section (id 0), or `None` if absent.
+pub(crate) fn find_custom_section(bytes: &[u8], name: &str) -> Result<Option<CustomSection>> {
     ensure_wasm_header(bytes)?;
 
     let mut pos = 8;
@@ -100,20 +99,12 @@ fn find_producers_section(bytes: &[u8]) -> Result<Option<ProducersSection>> {
             .ok_or_else(|| anyhow::anyhow!("invalid wasm section length"))?;
 
         if section_id == 0 {
-            let name_len = read_u32_leb128(bytes, &mut pos)? as usize;
-            let name_end = pos
-                .checked_add(name_len)
-                .filter(|end| *end <= section_end)
-                .ok_or_else(|| anyhow::anyhow!("invalid wasm custom section name"))?;
-            let name = std::str::from_utf8(&bytes[pos..name_end])?;
-            pos = name_end;
-
-            if name == "producers" {
-                return Ok(Some(ProducersSection {
+            let mut name_pos = pos;
+            if read_wasm_name(bytes, &mut name_pos, section_end)? == name {
+                return Ok(Some(CustomSection {
                     start: section_start,
                     end: section_end,
-                    content_start: pos,
-                    content_end: section_end,
+                    content_start: name_pos,
                 }));
             }
         }
@@ -181,25 +172,34 @@ fn encode_producers_section(entries: &[ProducersEntry<'_>]) -> Result<Vec<u8>> {
         }
     }
 
-    let mut payload = Vec::new();
-    append_wasm_name(&mut payload, "producers")?;
-    payload.extend_from_slice(&content);
+    encode_custom_section("producers", &content)
+}
 
-    let mut section = vec![0];
+/// Wrap `content` in a wasm custom section (id 0) with the given `name`.
+pub(crate) fn encode_custom_section(name: &str, content: &[u8]) -> Result<Vec<u8>> {
+    let mut payload = Vec::new();
+    append_wasm_name(&mut payload, name)?;
+    payload.extend_from_slice(content);
+
+    let mut section = vec![0u8];
     append_u32_leb128(&mut section, payload.len().try_into()?);
     section.extend_from_slice(&payload);
 
     Ok(section)
 }
 
-fn ensure_wasm_header(bytes: &[u8]) -> Result<()> {
+pub(crate) fn ensure_wasm_header(bytes: &[u8]) -> Result<()> {
     if bytes.len() < 8 || &bytes[..4] != b"\0asm" || bytes[4..8] != [1, 0, 0, 0] {
         anyhow::bail!("invalid wasm header");
     }
     Ok(())
 }
 
-fn read_wasm_name<'a>(bytes: &'a [u8], pos: &mut usize, limit: usize) -> Result<&'a str> {
+pub(crate) fn read_wasm_name<'a>(
+    bytes: &'a [u8],
+    pos: &mut usize,
+    limit: usize,
+) -> Result<&'a str> {
     let len = read_u32_leb128(bytes, pos)? as usize;
     let end = pos
         .checked_add(len)
@@ -210,13 +210,13 @@ fn read_wasm_name<'a>(bytes: &'a [u8], pos: &mut usize, limit: usize) -> Result<
     Ok(name)
 }
 
-fn append_wasm_name(bytes: &mut Vec<u8>, name: &str) -> Result<()> {
+pub(crate) fn append_wasm_name(bytes: &mut Vec<u8>, name: &str) -> Result<()> {
     append_u32_leb128(bytes, name.len().try_into()?);
     bytes.extend_from_slice(name.as_bytes());
     Ok(())
 }
 
-fn read_u32_leb128(bytes: &[u8], pos: &mut usize) -> Result<u32> {
+pub(crate) fn read_u32_leb128(bytes: &[u8], pos: &mut usize) -> Result<u32> {
     let mut result = 0u32;
     let mut shift = 0;
 
@@ -238,7 +238,7 @@ fn read_u32_leb128(bytes: &[u8], pos: &mut usize) -> Result<u32> {
     }
 }
 
-fn append_u32_leb128(bytes: &mut Vec<u8>, mut value: u32) {
+pub(crate) fn append_u32_leb128(bytes: &mut Vec<u8>, mut value: u32) {
     loop {
         let mut byte = (value & 0x7f) as u8;
         value >>= 7;
@@ -254,7 +254,7 @@ fn append_u32_leb128(bytes: &mut Vec<u8>, mut value: u32) {
 
 #[cfg(test)]
 mod test {
-    use super::{find_producers_section, merge_producers_section, parse_producers, ProducersEntry};
+    use super::{find_custom_section, merge_producers_section, parse_producers, ProducersEntry};
 
     const EMPTY_WASM: &[u8] = b"\0asm\x01\0\0\0";
 
@@ -339,15 +339,9 @@ mod test {
     }
 
     fn producers_entries(wasm: &[u8]) -> Vec<ProducersEntry<'_>> {
-        let section = find_producers_section(wasm).unwrap().unwrap();
+        let section = find_custom_section(wasm, "producers").unwrap().unwrap();
         let mut entries = Vec::new();
-        parse_producers(
-            wasm,
-            section.content_start,
-            section.content_end,
-            &mut entries,
-        )
-        .unwrap();
+        parse_producers(wasm, section.content_start, section.end, &mut entries).unwrap();
         entries
     }
 }

--- a/worker-build/src/reference_types.rs
+++ b/worker-build/src/reference_types.rs
@@ -1,0 +1,196 @@
+//! Re-advertise `reference-types` in stripped wasm builds.
+//!
+//! `wasm-bindgen` checks the `target_features` custom section for
+//! `reference-types` before running its externref transform. Without it,
+//! `#[wasm_bindgen(catch)]` wrappers fail with
+//! `externref table required for catch wrappers`.
+//!
+//! `strip = true` (i.e. `strip = "symbols"`) drops the entire section, even
+//! though `wasm32-unknown-unknown` has `reference-types` on by default since
+//! Rust 1.82. We patch it back in after cargo and before `wasm-bindgen`.
+//! `strip = "debuginfo"` avoids the problem entirely.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::build::PBAR;
+use crate::producers::{
+    append_u32_leb128, append_wasm_name, encode_custom_section, find_custom_section,
+    read_u32_leb128, read_wasm_name, CustomSection,
+};
+
+const REFERENCE_TYPES: &str = "reference-types";
+const TARGET_FEATURES: &str = "target_features";
+/// `+` prefix in a `target_features` entry: the feature is enabled/used.
+const PREFIX_ENABLED: u8 = b'+';
+
+/// No-op when the feature is already present (with `+` or `-` prefix).
+pub(crate) fn ensure_reference_types_feature(wasm_path: &Path) -> Result<()> {
+    let bytes = std::fs::read(wasm_path)
+        .with_context(|| format!("Failed to read {}", wasm_path.display()))?;
+
+    let section = find_custom_section(&bytes, TARGET_FEATURES)?;
+    if let Some(section) = &section {
+        if mentions_reference_types(&bytes, section)? {
+            return Ok(());
+        }
+    }
+
+    let patched = add_reference_types_feature(&bytes, section.as_ref())?;
+    std::fs::write(wasm_path, patched)
+        .with_context(|| format!("Failed to write {}", wasm_path.display()))?;
+    PBAR.warn(
+        "Compiled wasm did not advertise the `reference-types` target feature, which \
+         `wasm-bindgen` needs to generate catch wrappers. This is usually caused by \
+         `strip = true` (i.e. `strip = \"symbols\"`) in your release profile dropping the \
+         `target_features` section. Re-added it so the build can continue; prefer \
+         `strip = \"debuginfo\"` to avoid relying on this.",
+    );
+    Ok(())
+}
+
+/// True if `section` mentions `reference-types` with any prefix.
+fn mentions_reference_types(bytes: &[u8], section: &CustomSection) -> Result<bool> {
+    let mut pos = section.content_start;
+    let count = read_u32_leb128(bytes, &mut pos)?;
+    for _ in 0..count {
+        // Each entry is a one-byte +/- prefix followed by the feature name.
+        let _prefix = *bytes
+            .get(pos)
+            .ok_or_else(|| anyhow::anyhow!("invalid target_features section"))?;
+        pos += 1;
+        if read_wasm_name(bytes, &mut pos, section.end)? == REFERENCE_TYPES {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Append `+reference-types` to the existing section, or create one if absent.
+fn add_reference_types_feature(bytes: &[u8], section: Option<&CustomSection>) -> Result<Vec<u8>> {
+    // Rebuild the section content: the existing feature count + 1, the existing
+    // entries verbatim, then our `+reference-types` entry.
+    let (existing_count, existing_entries) = match section {
+        Some(section) => {
+            let mut pos = section.content_start;
+            (read_u32_leb128(bytes, &mut pos)?, &bytes[pos..section.end])
+        }
+        None => (0, &[][..]),
+    };
+
+    let mut content = Vec::new();
+    append_u32_leb128(&mut content, existing_count + 1);
+    content.extend_from_slice(existing_entries);
+    content.push(PREFIX_ENABLED);
+    append_wasm_name(&mut content, REFERENCE_TYPES)?;
+
+    let new_section = encode_custom_section(TARGET_FEATURES, &content)?;
+
+    // Splice the rebuilt section over the old one, or append it if there was none.
+    let (head, tail) = match section {
+        Some(section) => (&bytes[..section.start], &bytes[section.end..]),
+        None => (bytes, &[][..]),
+    };
+
+    let mut output = Vec::with_capacity(head.len() + new_section.len() + tail.len());
+    output.extend_from_slice(head);
+    output.extend_from_slice(&new_section);
+    output.extend_from_slice(tail);
+    Ok(output)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const EMPTY_WASM: &[u8] = b"\0asm\x01\0\0\0";
+
+    /// Minimal wasm with only a `target_features` section.
+    fn wasm_with_features(features: &[(u8, &str)]) -> Vec<u8> {
+        let mut content = Vec::new();
+        append_u32_leb128(&mut content, features.len().try_into().unwrap());
+        for (prefix, name) in features {
+            content.push(*prefix);
+            append_wasm_name(&mut content, name).unwrap();
+        }
+        let section = encode_custom_section(TARGET_FEATURES, &content).unwrap();
+        let mut wasm = EMPTY_WASM.to_vec();
+        wasm.extend_from_slice(&section);
+        wasm
+    }
+
+    /// Check if the wasm mentions `reference-types`.
+    fn mentions(wasm: &[u8]) -> bool {
+        match find_custom_section(wasm, TARGET_FEATURES).unwrap() {
+            Some(section) => mentions_reference_types(wasm, &section).unwrap(),
+            None => false,
+        }
+    }
+
+    #[test]
+    fn missing_section_is_not_mentioned() {
+        assert!(!mentions(EMPTY_WASM));
+    }
+
+    #[test]
+    fn enabled_feature_is_detected() {
+        let wasm = wasm_with_features(&[
+            (PREFIX_ENABLED, "bulk-memory"),
+            (PREFIX_ENABLED, REFERENCE_TYPES),
+        ]);
+        assert!(mentions(&wasm));
+    }
+
+    #[test]
+    fn disallowed_feature_is_respected() {
+        // A `-reference-types` entry counts as mentioned, so we leave it alone.
+        let wasm = wasm_with_features(&[(b'-', REFERENCE_TYPES)]);
+        assert!(mentions(&wasm));
+    }
+
+    #[test]
+    fn section_without_reference_types_is_not_mentioned() {
+        let wasm = wasm_with_features(&[(PREFIX_ENABLED, "bulk-memory")]);
+        assert!(!mentions(&wasm));
+    }
+
+    #[test]
+    fn adds_section_when_absent() {
+        let patched = add_reference_types_feature(EMPTY_WASM, None).unwrap();
+        assert!(mentions(&patched));
+    }
+
+    #[test]
+    fn extends_existing_section_preserving_features() {
+        let wasm = wasm_with_features(&[
+            (PREFIX_ENABLED, "bulk-memory"),
+            (PREFIX_ENABLED, "sign-ext"),
+        ]);
+        let section = find_custom_section(&wasm, TARGET_FEATURES).unwrap();
+        let patched = add_reference_types_feature(&wasm, section.as_ref()).unwrap();
+
+        // reference-types is now advertised...
+        assert!(mentions(&patched));
+
+        // ...and the pre-existing features survived.
+        let section = find_custom_section(&patched, TARGET_FEATURES)
+            .unwrap()
+            .unwrap();
+        let mut pos = section.content_start;
+        let count = read_u32_leb128(&patched, &mut pos).unwrap();
+        assert_eq!(count, 3);
+        let mut names = Vec::new();
+        for _ in 0..count {
+            pos += 1; // prefix
+            names.push(
+                read_wasm_name(&patched, &mut pos, section.end)
+                    .unwrap()
+                    .to_string(),
+            );
+        }
+        assert!(names.contains(&"bulk-memory".to_string()));
+        assert!(names.contains(&"sign-ext".to_string()));
+        assert!(names.contains(&REFERENCE_TYPES.to_string()));
+    }
+}


### PR DESCRIPTION
`strip = true` (alias for `strip = "symbols"`) drops the `target_features` custom section from the compiled wasm, which removes the `reference-types` advertisement that `wasm-bindgen` needs to run its externref transform. Without it, builds fail with "externref table required for catch wrappers".

Generalize the wasm custom-section helpers in `producers.rs` so they can be reused, and add a new `reference_types` module that patches the feature back in after cargo and before `wasm-bindgen` runs.

Fixes #1014