### PR TITLE
fix(durable-object): fix wrong return type on durable object `alarm` fn

### DIFF
--- a/test/src/alarm.rs
+++ b/test/src/alarm.rs
@@ -29,10 +29,10 @@ impl DurableObject for AlarmObject {
         Response::ok(alarmed.to_string())
     }
 
-    async fn alarm(&self) -> Result<Response> {
+    async fn alarm(&self) -> Result<()> {
         self.state.storage().put("alarmed", true).await?;
         console_log!("Alarm has been triggered!");
-        Response::ok("ALARMED")
+        Ok(())
     }
 }
 

--- a/worker-macros/src/durable_object.rs
+++ b/worker-macros/src/durable_object.rs
@@ -69,8 +69,7 @@ mod bindgen_methods {
 
                 ::worker::js_sys::futures::future_to_promise(::std::panic::AssertUnwindSafe(async move {
                     <Self as ::worker::DurableObject>::alarm(static_self).await
-                        .map(::worker::worker_sys::web_sys::Response::from)
-                        .map(::worker::wasm_bindgen::JsValue::from)
+                        .map(|_| ::worker::wasm_bindgen::JsValue::NULL)
                         .map_err(::worker::wasm_bindgen::JsValue::from)
                 }))
             }

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -885,7 +885,7 @@ pub trait DurableObject: has_durable_object_attribute {
     async fn fetch(&self, req: Request) -> Result<Response>;
 
     #[allow(clippy::diverging_sub_expression)]
-    async fn alarm(&self) -> Result<Response> {
+    async fn alarm(&self) -> Result<()> {
         worker_sys::console_error!("alarm() handler not implemented");
         unimplemented!("alarm() handler")
     }


### PR DESCRIPTION
The `alarm` fn, according to Cloudflare docs https://developers.cloudflare.com/durable-objects/api/alarms/#alarm, returns `void`, but the `workers-rs` was returning a `Result<Response>`, this fixes by changing the return type to `Result<()>`

Fixes https://github.com/cloudflare/workers-rs/issues/712