### PR TITLE
fix(d1): propagate `D1Result::results()` error

### DIFF
--- a/test/src/d1.rs
+++ b/test/src/d1.rs
@@ -381,3 +381,27 @@ pub async fn retrive_first_none(
 
     Response::ok("ok")
 }
+
+#[worker::send]
+pub async fn deserialize_with_type_mismatch(
+    _req: Request,
+    env: Env,
+    _data: SomeSharedData,
+) -> Result<Response> {
+    let db = env.d1("DB")?;
+
+    let error = worker::query!(&db, "SELECT 'hello' AS id")
+        .await?
+        .results::<NullablePerson>();
+
+    if let Err(error) = error {
+        assert_eq!(
+            error.to_string(),
+            "Error: invalid type: string \"hello\", expected u32"
+        );
+    } else {
+        panic!("Expected .results() to propagate its error");
+    }
+
+    Response::ok("ok")
+}

--- a/test/src/router.rs
+++ b/test/src/router.rs
@@ -198,6 +198,7 @@ macro_rules! add_routes (
     add_route!($obj, get, "/d1/retrieve_optional_none", d1::retrieve_optional_none);
     add_route!($obj, get, "/d1/retrieve_optional_some", d1::retrieve_optional_some);
     add_route!($obj, get, "/d1/retrive_first_none", d1::retrive_first_none);
+    add_route!($obj, get, "/d1/deserialize_with_type_mismatch", d1::deserialize_with_type_mismatch);
     add_route!($obj, get, "/kv/get", kv::get);
     add_route!($obj, get, "/kv/get-not-found", kv::get_not_found);
     add_route!($obj, get, "/kv/list-keys", kv::list_keys);

--- a/test/tests/d1.spec.ts
+++ b/test/tests/d1.spec.ts
@@ -143,4 +143,10 @@ describe("d1", () => {
     expect(await resp.text()).toBe("ok");
     expect(resp.status).toBe(200);
   });
+
+  test("deserialize_with_type_mismatch", async () => {
+    const resp = await mf.dispatchFetch(`${mfUrl}d1/deserialize_with_type_mismatch`);
+    expect(await resp.text()).toBe("ok");
+    expect(resp.status).toBe(200);
+  });
 });

--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -502,7 +502,7 @@ impl D1Result {
         if let Some(results) = self.0.results()? {
             let mut vec = Vec::with_capacity(results.length() as usize);
             for result in results.iter() {
-                let result = serde_wasm_bindgen::from_value(result).unwrap();
+                let result = serde_wasm_bindgen::from_value(result)?;
                 vec.push(result);
             }
             Ok(vec)


### PR DESCRIPTION
This replaces the `.unwrap()` with `?` when deserializing the results from D1, which was causing it to panic if the type was mismatched

The error now is propagated correctly

Fixes: https://github.com/cloudflare/workers-rs/issues/1029