### PR TITLE
Re-export url::ParseError alongside url::Url

### DIFF
--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -149,7 +149,8 @@ use std::result::Result as StdResult;
 #[doc(hidden)]
 pub use async_trait;
 pub use js_sys;
-pub use url::{ParseError, Url};
+pub use url;
+pub use url::Url;
 pub use wasm_bindgen;
 pub use wasm_bindgen_futures;
 pub use web_sys;

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -149,7 +149,7 @@ use std::result::Result as StdResult;
 #[doc(hidden)]
 pub use async_trait;
 pub use js_sys;
-pub use url::Url;
+pub use url::{ParseError, Url};
 pub use wasm_bindgen;
 pub use wasm_bindgen_futures;
 pub use web_sys;

--- a/worker/tests/pass/url-parse-error.rs
+++ b/worker/tests/pass/url-parse-error.rs
@@ -2,7 +2,7 @@
 // `Url::parse` returns `Result<Url, ParseError>`, and `Error` has a
 // `From<url::ParseError>` impl, so the error type must be nameable through
 // `::worker::` without `url` as a direct dependency.
-use worker::{ParseError, Url};
+use worker::{url::ParseError, Url};
 
 fn parse(input: &str) -> Result<Url, ParseError> {
     Url::parse(input)

--- a/worker/tests/pass/url-parse-error.rs
+++ b/worker/tests/pass/url-parse-error.rs
@@ -1,0 +1,13 @@
+// Regression test for https://github.com/cloudflare/workers-rs/issues/380.
+// `Url::parse` returns `Result<Url, ParseError>`, and `Error` has a
+// `From<url::ParseError>` impl, so the error type must be nameable through
+// `::worker::` without `url` as a direct dependency.
+use worker::{ParseError, Url};
+
+fn parse(input: &str) -> Result<Url, ParseError> {
+    Url::parse(input)
+}
+
+fn main() {
+    let _ = parse("https://example.com");
+}


### PR DESCRIPTION
`Url::parse` returns `Result<Url, ParseError>` and `Error` already has a `From<url::ParseError>` impl, but only `Url` is re-exported. Naming the error type means taking a direct dependency on `url`.

Re-exports it alongside `Url` (`pub use url::{ParseError, Url};`), with a trybuild `pass` test next to the `start-handler.rs` one from #974.

Adding `ParseError` at the root can conflict under `use worker::*` if `chrono`'s `ParseError` is also in scope via `*`, though I didn't find a public crate doing that and an explicit import clears it. Given #890, I can re-export the `url` module for `worker::url::ParseError` instead if you'd prefer.

Closes #380.
