### PR TITLE
feat: add .env and .dev.vars on .gitignore

### DIFF
--- a/templates/axum/.gitignore
+++ b/templates/axum/.gitignore
@@ -1,3 +1,9 @@
 target
 node_modules
-.wrangler
+
+### Wrangler ###
+.wrangler/
+.env*
+!.env.example
+.dev.vars*
+!.dev.vars.example

--- a/templates/hello-world-http/.gitignore
+++ b/templates/hello-world-http/.gitignore
@@ -1,3 +1,9 @@
 target
 node_modules
-.wrangler
+
+### Wrangler ###
+.wrangler/
+.env*
+!.env.example
+.dev.vars*
+!.dev.vars.example

--- a/templates/hello-world/.gitignore
+++ b/templates/hello-world/.gitignore
@@ -1,3 +1,9 @@
 target
 node_modules
-.wrangler
+
+### Wrangler ###
+.wrangler/
+.env*
+!.env.example
+.dev.vars*
+!.dev.vars.example

--- a/templates/leptos/.gitignore
+++ b/templates/leptos/.gitignore
@@ -1,4 +1,10 @@
 target
 node_modules
-.wrangler
 build
+
+### Wrangler ###
+.wrangler/
+.env*
+!.env.example
+.dev.vars*
+!.dev.vars.example


### PR DESCRIPTION
This will make so `.env` and `.dev.vars` are ignored by default when starting a repository using these templates, except by `.env` or `.dev.vars` named with `.example` at the end.

It follows the same `.gitignore` used on https://github.com/cloudflare/templates