### PR TITLE
Add blockConcurrencyWhile binding for Durable Objects

### DIFF
--- a/.changeset/do-block-concurrency-while.md
+++ b/.changeset/do-block-concurrency-while.md
@@ -2,7 +2,10 @@
 "workers-rs": minor
 ---
 
-Add `State::block_concurrency_while` and `State::block_concurrency_while_infallible` for
-Durable Objects, binding the runtime's `blockConcurrencyWhile`. Both run an async closure
-while blocking delivery of other events until it completes; the `_infallible` variant
-returns application errors as values instead of resetting the object.
+Add `State::block_concurrency_while` for Durable Objects, binding the runtime's
+`blockConcurrencyWhile` with the same call-time semantics as JavaScript: the event delivery
+gate closes eagerly at the call, and the returned future yields the closure's value when
+awaited. Discarding the future instead supports the constructor idiom, where `new()` gates
+delivery of all events until async initialization completes. A closure returning `Err`
+rejects the promise and resets the object, matching a JavaScript throw; return errors inside
+`Ok` to propagate them as values.

--- a/.changeset/do-block-concurrency-while.md
+++ b/.changeset/do-block-concurrency-while.md
@@ -1,0 +1,8 @@
+---
+"workers-rs": minor
+---
+
+Add `State::block_concurrency_while` and `State::block_concurrency_while_infallible` for
+Durable Objects, binding the runtime's `blockConcurrencyWhile`. Both run an async closure
+while blocking delivery of other events until it completes; the `_infallible` variant
+returns application errors as values instead of resetting the object.

--- a/.changeset/do-block-concurrency-while.md
+++ b/.changeset/do-block-concurrency-while.md
@@ -4,8 +4,8 @@
 
 Add `State::block_concurrency_while` for Durable Objects, binding the runtime's
 `blockConcurrencyWhile` with the same call-time semantics as JavaScript: the event delivery
-gate closes eagerly at the call, and the returned future yields the closure's value when
+gate closes eagerly at the call, and the returned future yields the inner future's value when
 awaited. Discarding the future instead supports the constructor idiom, where `new()` gates
-delivery of all events until async initialization completes. A closure returning `Err`
+delivery of all events until async initialization completes. A future returning `Err`
 rejects the promise and resets the object, matching a JavaScript throw; return errors inside
 `Ok` to propagate them as values.

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -73,7 +73,7 @@ env.WASM_BINDGEN_BIN = '../wasm-bindgen/target/debug/wasm-bindgen'
 env.WORKERD_ALL_AUTOGATES = '1'
 run = '''
 ../target/debug/worker-build --dev
-npx vitest run --testTimeout 25000
+npx vitest run --testTimeout 60000
 '''
 
 [[task]]
@@ -85,7 +85,7 @@ env.WASM_BINDGEN_BIN = '../wasm-bindgen/target/debug/wasm-bindgen'
 env.WORKERD_ALL_AUTOGATES = '1'
 run = '''
 ../target/debug/worker-build --release --features http
-npx vitest run --testTimeout 25000
+npx vitest run --testTimeout 60000
 '''
 
 [[task]]
@@ -97,7 +97,7 @@ env.WASM_BINDGEN_BIN = '../wasm-bindgen/target/debug/wasm-bindgen'
 env.WORKERD_ALL_AUTOGATES = '1'
 run = '''
 ../target/debug/worker-build --dev --panic-unwind
-npx vitest run --testTimeout 25000
+npx vitest run --testTimeout 60000
 '''
 
 [[task]]

--- a/test/src/durable.rs
+++ b/test/src/durable.rs
@@ -3,6 +3,7 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::panic::AssertUnwindSafe;
+use std::rc::Rc;
 use worker::DurableObject;
 
 use worker::{
@@ -17,22 +18,34 @@ pub struct MyClass {
     state: State,
     number: AssertUnwindSafe<Cell<usize>>,
     ctor_name: Option<String>,
-    // Lazy async-initialization state, exercised by the `/lazy-init` route below.
-    initialized: AssertUnwindSafe<Cell<bool>>,
-    init_runs: AssertUnwindSafe<Cell<usize>>,
-    limit: AssertUnwindSafe<Cell<u64>>,
+    // Constructor-gated async-initialization state, exercised by the `/limit` route below.
+    init_runs: Rc<Cell<usize>>,
+    limit: Rc<Cell<u64>>,
 }
 
 impl DurableObject for MyClass {
     fn new(state: State, _env: Env) -> Self {
         let ctor_name = state.id().name();
+        let init_runs = Rc::new(Cell::new(0));
+        let limit = Rc::new(Cell::new(0));
+        // The JS constructor idiom: call block_concurrency_while without awaiting it. The
+        // runtime gates delivery of all events until the init future completes, so the first
+        // request must observe the loaded limit, never the 0 sentinel. The second await inside
+        // the closure verifies the gate holds across multiple suspension points.
+        let (runs, l, storage) = (init_runs.clone(), limit.clone(), state.storage());
+        let _init = state.block_concurrency_while(move || async move {
+            runs.set(runs.get() + 1);
+            let stored: u64 = storage.get("limit").await?.unwrap_or(100);
+            storage.put("init_probe", stored).await?;
+            l.set(stored);
+            Ok(())
+        });
         Self {
             state,
             number: AssertUnwindSafe(Cell::new(0)),
             ctor_name,
-            initialized: AssertUnwindSafe(Cell::new(false)),
-            init_runs: AssertUnwindSafe(Cell::new(0)),
-            limit: AssertUnwindSafe(Cell::new(0)),
+            init_runs,
+            limit,
         }
     }
 
@@ -186,23 +199,10 @@ impl DurableObject for MyClass {
                 "/transaction" => {
                     Response::error("transactional storage API is still unstable", 501)
                 }
-                "/lazy-init" => {
-                    // Recommended async-init pattern: initialize lazily on first use, guarded
-                    // by `block_concurrency_while`. `init_runs` proves the guard runs once.
-                    if !self.initialized.get() {
-                        self.init_runs.set(self.init_runs.get() + 1);
-                        let storage = self.state.storage();
-                        let limit = self
-                            .state
-                            .block_concurrency_while(move || async move {
-                                Ok(storage.get("limit").await?.unwrap_or(100))
-                            })
-                            .await?;
-                        self.limit.set(limit);
-                        self.initialized.set(true);
-                    }
+                "/limit" => {
+                    // Reports the constructor-gated init state; see `new()` above.
                     Response::ok(format!(
-                        "limit is {}, init_runs {}",
+                        "limit:{}:{}",
                         self.limit.get(),
                         self.init_runs.get()
                     ))
@@ -222,21 +222,21 @@ impl DurableObject for MyClass {
                         .await?;
                     Response::ok(count.to_string())
                 }
-                "/block-concurrency-infallible" => {
+                "/block-concurrency-errors-as-values" => {
                     // In-memory counter to detect resets: a reset would re-run `new()` and
                     // drop this back to 1 on the next request.
                     self.number.set(self.number.get() + 1);
                     let calls = self.number.get();
 
-                    // The closure returns a transient failure as a value; the infallible
-                    // variant does not reset the object.
+                    // Errors returned inside `Ok` are values: they flow back to the caller
+                    // without rejecting the promise, so the object is not reset.
                     let storage = self.state.storage();
                     let outcome: std::result::Result<String, String> = self
                         .state
-                        .block_concurrency_while_infallible(move || async move {
+                        .block_concurrency_while(move || async move {
                             let _seen: Option<usize> =
                                 storage.get("bcw_count").await.ok().flatten();
-                            Err("simulated transient failure".to_string())
+                            Ok(Err("simulated transient failure".to_string()))
                         })
                         .await?;
 
@@ -251,7 +251,7 @@ impl DurableObject for MyClass {
                     Response::ok(self.number.get().to_string())
                 }
                 "/block-concurrency-reset-trigger" => {
-                    // Fallible variant: returning `Err` rejects the promise and resets the object.
+                    // Returning `Err` rejects the promise and resets the object.
                     self.state
                         .block_concurrency_while(move || async move {
                             Err::<(), _>(worker::Error::RustError("intentional reset".into()))
@@ -453,27 +453,27 @@ pub async fn handle_block_concurrency_reset_trigger(
 }
 
 #[worker::send]
-pub async fn handle_lazy_init(
+pub async fn handle_constructor_init(
     _req: Request,
     env: Env,
     _data: crate::SomeSharedData,
 ) -> Result<Response> {
     let namespace = env.durable_object("MY_CLASS")?;
-    let stub = namespace.id_from_name("lazy-init")?.get_stub()?;
-    stub.fetch_with_str("https://fake-host/lazy-init").await
+    let stub = namespace.id_from_name("constructor-init")?.get_stub()?;
+    stub.fetch_with_str("https://fake-host/limit").await
 }
 
 #[worker::send]
-pub async fn handle_block_concurrency_infallible(
+pub async fn handle_block_concurrency_errors_as_values(
     _req: Request,
     env: Env,
     _data: crate::SomeSharedData,
 ) -> Result<Response> {
     let namespace = env.durable_object("MY_CLASS")?;
     let stub = namespace
-        .id_from_name("block-concurrency-infallible")?
+        .id_from_name("block-concurrency-errors-as-values")?
         .get_stub()?;
-    stub.fetch_with_str("https://fake-host/block-concurrency-infallible")
+    stub.fetch_with_str("https://fake-host/block-concurrency-errors-as-values")
         .await
 }
 

--- a/test/src/durable.rs
+++ b/test/src/durable.rs
@@ -17,6 +17,10 @@ pub struct MyClass {
     state: State,
     number: AssertUnwindSafe<Cell<usize>>,
     ctor_name: Option<String>,
+    // Lazy async-initialization state, exercised by the `/lazy-init` route below.
+    initialized: AssertUnwindSafe<Cell<bool>>,
+    init_runs: AssertUnwindSafe<Cell<usize>>,
+    limit: AssertUnwindSafe<Cell<u64>>,
 }
 
 impl DurableObject for MyClass {
@@ -26,6 +30,9 @@ impl DurableObject for MyClass {
             state,
             number: AssertUnwindSafe(Cell::new(0)),
             ctor_name,
+            initialized: AssertUnwindSafe(Cell::new(false)),
+            init_runs: AssertUnwindSafe(Cell::new(0)),
+            limit: AssertUnwindSafe(Cell::new(0)),
         }
     }
 
@@ -179,6 +186,79 @@ impl DurableObject for MyClass {
                 "/transaction" => {
                     Response::error("transactional storage API is still unstable", 501)
                 }
+                "/lazy-init" => {
+                    // Recommended async-init pattern: initialize lazily on first use, guarded
+                    // by `block_concurrency_while`. `init_runs` proves the guard runs once.
+                    if !self.initialized.get() {
+                        self.init_runs.set(self.init_runs.get() + 1);
+                        let storage = self.state.storage();
+                        let limit = self
+                            .state
+                            .block_concurrency_while(move || async move {
+                                Ok(storage.get("limit").await?.unwrap_or(100))
+                            })
+                            .await?;
+                        self.limit.set(limit);
+                        self.initialized.set(true);
+                    }
+                    Response::ok(format!(
+                        "limit is {}, init_runs {}",
+                        self.limit.get(),
+                        self.init_runs.get()
+                    ))
+                }
+                "/block-concurrency" => {
+                    // Atomic read-modify-write inside the guard, returning the new count as a
+                    // value out of `block_concurrency_while`.
+                    let storage = self.state.storage();
+                    let count: usize = self
+                        .state
+                        .block_concurrency_while(move || async move {
+                            let current: usize = storage.get("bcw_count").await?.unwrap_or(0);
+                            let next = current + 1;
+                            storage.put("bcw_count", next).await?;
+                            Ok(next)
+                        })
+                        .await?;
+                    Response::ok(count.to_string())
+                }
+                "/block-concurrency-infallible" => {
+                    // In-memory counter to detect resets: a reset would re-run `new()` and
+                    // drop this back to 1 on the next request.
+                    self.number.set(self.number.get() + 1);
+                    let calls = self.number.get();
+
+                    // The closure returns a transient failure as a value; the infallible
+                    // variant does not reset the object.
+                    let storage = self.state.storage();
+                    let outcome: std::result::Result<String, String> = self
+                        .state
+                        .block_concurrency_while_infallible(move || async move {
+                            let _seen: Option<usize> =
+                                storage.get("bcw_count").await.ok().flatten();
+                            Err("simulated transient failure".to_string())
+                        })
+                        .await?;
+
+                    match outcome {
+                        Ok(value) => Response::ok(format!("ok:{value}:{calls}")),
+                        Err(err) => Response::ok(format!("err:{err}:{calls}")),
+                    }
+                }
+                "/block-concurrency-reset-count" => {
+                    // In-memory counter; a reset re-runs `new()` and drops it back to 1.
+                    self.number.set(self.number.get() + 1);
+                    Response::ok(self.number.get().to_string())
+                }
+                "/block-concurrency-reset-trigger" => {
+                    // Fallible variant: returning `Err` rejects the promise and resets the object.
+                    self.state
+                        .block_concurrency_while(move || async move {
+                            Err::<(), _>(worker::Error::RustError("intentional reset".into()))
+                        })
+                        .await?;
+                    Response::ok("unreachable")
+                }
                 _ => Response::error("Not Found", 404),
             }
         };
@@ -330,6 +410,71 @@ pub async fn handle_basic_test(
     );
 
     Response::ok("ok")
+}
+
+#[worker::send]
+pub async fn handle_block_concurrency(
+    _req: Request,
+    env: Env,
+    _data: crate::SomeSharedData,
+) -> Result<Response> {
+    let namespace = env.durable_object("MY_CLASS")?;
+    let stub = namespace.id_from_name("block-concurrency")?.get_stub()?;
+    stub.fetch_with_str("https://fake-host/block-concurrency")
+        .await
+}
+
+#[worker::send]
+pub async fn handle_block_concurrency_reset_count(
+    _req: Request,
+    env: Env,
+    _data: crate::SomeSharedData,
+) -> Result<Response> {
+    let namespace = env.durable_object("MY_CLASS")?;
+    let stub = namespace
+        .id_from_name("block-concurrency-reset")?
+        .get_stub()?;
+    stub.fetch_with_str("https://fake-host/block-concurrency-reset-count")
+        .await
+}
+
+#[worker::send]
+pub async fn handle_block_concurrency_reset_trigger(
+    _req: Request,
+    env: Env,
+    _data: crate::SomeSharedData,
+) -> Result<Response> {
+    let namespace = env.durable_object("MY_CLASS")?;
+    let stub = namespace
+        .id_from_name("block-concurrency-reset")?
+        .get_stub()?;
+    stub.fetch_with_str("https://fake-host/block-concurrency-reset-trigger")
+        .await
+}
+
+#[worker::send]
+pub async fn handle_lazy_init(
+    _req: Request,
+    env: Env,
+    _data: crate::SomeSharedData,
+) -> Result<Response> {
+    let namespace = env.durable_object("MY_CLASS")?;
+    let stub = namespace.id_from_name("lazy-init")?.get_stub()?;
+    stub.fetch_with_str("https://fake-host/lazy-init").await
+}
+
+#[worker::send]
+pub async fn handle_block_concurrency_infallible(
+    _req: Request,
+    env: Env,
+    _data: crate::SomeSharedData,
+) -> Result<Response> {
+    let namespace = env.durable_object("MY_CLASS")?;
+    let stub = namespace
+        .id_from_name("block-concurrency-infallible")?
+        .get_stub()?;
+    stub.fetch_with_str("https://fake-host/block-concurrency-infallible")
+        .await
 }
 
 #[worker::send]

--- a/test/src/durable.rs
+++ b/test/src/durable.rs
@@ -19,8 +19,8 @@ pub struct MyClass {
     number: AssertUnwindSafe<Cell<usize>>,
     ctor_name: Option<String>,
     // Constructor-gated async-initialization state, exercised by the `/limit` route below.
-    init_runs: Rc<Cell<usize>>,
-    limit: Rc<Cell<u64>>,
+    init_runs: AssertUnwindSafe<Rc<Cell<usize>>>,
+    limit: AssertUnwindSafe<Rc<Cell<u64>>>,
 }
 
 impl DurableObject for MyClass {
@@ -44,8 +44,8 @@ impl DurableObject for MyClass {
             state,
             number: AssertUnwindSafe(Cell::new(0)),
             ctor_name,
-            init_runs,
-            limit,
+            init_runs: AssertUnwindSafe(init_runs),
+            limit: AssertUnwindSafe(limit),
         }
     }
 

--- a/test/src/durable.rs
+++ b/test/src/durable.rs
@@ -4,13 +4,14 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::panic::AssertUnwindSafe;
 use std::rc::Rc;
+use std::time::Duration;
 use worker::DurableObject;
 
 use worker::{
     durable_object,
     js_sys::{self, Uint8Array},
     wasm_bindgen::JsValue,
-    Env, Method, ObjectNamespace, Request, RequestInit, Response, Result, State,
+    Delay, Env, Method, ObjectNamespace, Request, RequestInit, Response, Result, State,
 };
 
 #[durable_object]
@@ -30,11 +31,12 @@ impl DurableObject for MyClass {
         let limit = Rc::new(Cell::new(0));
         // The JS constructor idiom: call block_concurrency_while without awaiting it. The
         // runtime gates delivery of all events until the init future completes, so the first
-        // request must observe the loaded limit, never the 0 sentinel. The second await inside
-        // the closure verifies the gate holds across multiple suspension points.
+        // request must observe the loaded limit, never the 0 sentinel. The delay is a
+        // non-storage await, since storage ops already hold the input gate implicitly.
         let (runs, l, storage) = (init_runs.clone(), limit.clone(), state.storage());
-        let _init = state.block_concurrency_while(move || async move {
+        let _init = state.block_concurrency_while(async move {
             runs.set(runs.get() + 1);
+            Delay::from(Duration::from_millis(200)).await;
             let stored: u64 = storage.get("limit").await?.unwrap_or(100);
             storage.put("init_probe", stored).await?;
             l.set(stored);
@@ -213,7 +215,7 @@ impl DurableObject for MyClass {
                     let storage = self.state.storage();
                     let count: usize = self
                         .state
-                        .block_concurrency_while(move || async move {
+                        .block_concurrency_while(async move {
                             let current: usize = storage.get("bcw_count").await?.unwrap_or(0);
                             let next = current + 1;
                             storage.put("bcw_count", next).await?;
@@ -233,7 +235,7 @@ impl DurableObject for MyClass {
                     let storage = self.state.storage();
                     let outcome: std::result::Result<String, String> = self
                         .state
-                        .block_concurrency_while(move || async move {
+                        .block_concurrency_while(async move {
                             let _seen: Option<usize> =
                                 storage.get("bcw_count").await.ok().flatten();
                             Ok(Err("simulated transient failure".to_string()))
@@ -253,7 +255,7 @@ impl DurableObject for MyClass {
                 "/block-concurrency-reset-trigger" => {
                     // Returning `Err` rejects the promise and resets the object.
                     self.state
-                        .block_concurrency_while(move || async move {
+                        .block_concurrency_while(async move {
                             Err::<(), _>(worker::Error::RustError("intentional reset".into()))
                         })
                         .await?;

--- a/test/src/router.rs
+++ b/test/src/router.rs
@@ -224,6 +224,11 @@ macro_rules! add_routes (
     add_route!($obj, get, "/durable/ctor-name", durable::handle_ctor_name);
     add_route!($obj, get, "/durable/hello-unique", durable::handle_hello_unique);
     add_route!($obj, get, "/durable/storage", durable::handle_storage);
+    add_route!($obj, get, "/durable/block-concurrency", durable::handle_block_concurrency);
+    add_route!($obj, get, "/durable/block-concurrency-infallible", durable::handle_block_concurrency_infallible);
+    add_route!($obj, get, "/durable/block-concurrency-reset-count", durable::handle_block_concurrency_reset_count);
+    add_route!($obj, get, "/durable/block-concurrency-reset-trigger", durable::handle_block_concurrency_reset_trigger);
+    add_route!($obj, get, "/durable/lazy-init", durable::handle_lazy_init);
     add_route!($obj, get, "/durable/handle-basic-test", durable::handle_basic_test);
     add_route!($obj, get, "/durable/get-by-name", durable::handle_get_by_name);
     add_route!($obj, get, "/durable/get-by-name-with-location-hint", durable::handle_get_by_name_with_location_hint);

--- a/test/src/router.rs
+++ b/test/src/router.rs
@@ -225,10 +225,10 @@ macro_rules! add_routes (
     add_route!($obj, get, "/durable/hello-unique", durable::handle_hello_unique);
     add_route!($obj, get, "/durable/storage", durable::handle_storage);
     add_route!($obj, get, "/durable/block-concurrency", durable::handle_block_concurrency);
-    add_route!($obj, get, "/durable/block-concurrency-infallible", durable::handle_block_concurrency_infallible);
+    add_route!($obj, get, "/durable/block-concurrency-errors-as-values", durable::handle_block_concurrency_errors_as_values);
     add_route!($obj, get, "/durable/block-concurrency-reset-count", durable::handle_block_concurrency_reset_count);
     add_route!($obj, get, "/durable/block-concurrency-reset-trigger", durable::handle_block_concurrency_reset_trigger);
-    add_route!($obj, get, "/durable/lazy-init", durable::handle_lazy_init);
+    add_route!($obj, get, "/durable/constructor-init", durable::handle_constructor_init);
     add_route!($obj, get, "/durable/handle-basic-test", durable::handle_basic_test);
     add_route!($obj, get, "/durable/get-by-name", durable::handle_get_by_name);
     add_route!($obj, get, "/durable/get-by-name-with-location-hint", durable::handle_get_by_name_with_location_hint);

--- a/test/tests/durable.spec.ts
+++ b/test/tests/durable.spec.ts
@@ -54,20 +54,20 @@ describe("durable", () => {
     expect(await second.text()).toBe("2");
   });
 
-  // Errors from the infallible guard flow back as values; the incrementing counter
+  // Errors returned inside Ok flow back as values; the incrementing counter
   // proves the object was not reset.
-  test("block-concurrency-while-infallible does not reset on error", async () => {
-    const first = await mf.dispatchFetch(`${mfUrl}durable/block-concurrency-infallible`);
+  test("block-concurrency-while errors as values do not reset", async () => {
+    const first = await mf.dispatchFetch(`${mfUrl}durable/block-concurrency-errors-as-values`);
     expect(first.status).toBe(200);
     expect(await first.text()).toBe("err:simulated transient failure:1");
 
-    const second = await mf.dispatchFetch(`${mfUrl}durable/block-concurrency-infallible`);
+    const second = await mf.dispatchFetch(`${mfUrl}durable/block-concurrency-errors-as-values`);
     expect(second.status).toBe(200);
     expect(await second.text()).toBe("err:simulated transient failure:2");
   });
 
-  // The fallible variant resets the object when the closure returns Err: the in-memory
-  // counter persists across requests (1 -> 2), then drops back to 1 after the reset.
+  // Closures returning Err reset the object: the in-memory counter persists across
+  // requests (1 -> 2), then drops back to 1 after the reset.
   test("block-concurrency-while resets the object on error", async () => {
     const count = () =>
       mf
@@ -85,15 +85,17 @@ describe("durable", () => {
     expect(await count()).toBe("1");
   });
 
-  // Lazy init guarded by block_concurrency_while runs once (init_runs stays 1).
-  test("lazy async initialization runs once", async () => {
-    const first = await mf.dispatchFetch(`${mfUrl}durable/lazy-init`);
+  // Constructor-gated async init: new() fires block_concurrency_while without awaiting
+  // it, so the very first request must already observe the loaded limit rather than the
+  // 0 sentinel, and the init closure runs exactly once.
+  test("constructor async initialization gates event delivery", async () => {
+    const first = await mf.dispatchFetch(`${mfUrl}durable/constructor-init`);
     expect(first.status).toBe(200);
-    expect(await first.text()).toBe("limit is 100, init_runs 1");
+    expect(await first.text()).toBe("limit:100:1");
 
-    const second = await mf.dispatchFetch(`${mfUrl}durable/lazy-init`);
+    const second = await mf.dispatchFetch(`${mfUrl}durable/constructor-init`);
     expect(second.status).toBe(200);
-    expect(await second.text()).toBe("limit is 100, init_runs 1");
+    expect(await second.text()).toBe("limit:100:1");
   });
 
   test("get-by-name", async () => {

--- a/test/tests/durable.spec.ts
+++ b/test/tests/durable.spec.ts
@@ -44,6 +44,58 @@ describe("durable", () => {
     // expect(calledClose).toBe(true);
   });
 
+  test("block-concurrency-while", async () => {
+    const first = await mf.dispatchFetch(`${mfUrl}durable/block-concurrency`);
+    expect(first.status).toBe(200);
+    expect(await first.text()).toBe("1");
+
+    const second = await mf.dispatchFetch(`${mfUrl}durable/block-concurrency`);
+    expect(second.status).toBe(200);
+    expect(await second.text()).toBe("2");
+  });
+
+  // Errors from the infallible guard flow back as values; the incrementing counter
+  // proves the object was not reset.
+  test("block-concurrency-while-infallible does not reset on error", async () => {
+    const first = await mf.dispatchFetch(`${mfUrl}durable/block-concurrency-infallible`);
+    expect(first.status).toBe(200);
+    expect(await first.text()).toBe("err:simulated transient failure:1");
+
+    const second = await mf.dispatchFetch(`${mfUrl}durable/block-concurrency-infallible`);
+    expect(second.status).toBe(200);
+    expect(await second.text()).toBe("err:simulated transient failure:2");
+  });
+
+  // The fallible variant resets the object when the closure returns Err: the in-memory
+  // counter persists across requests (1 -> 2), then drops back to 1 after the reset.
+  test("block-concurrency-while resets the object on error", async () => {
+    const count = () =>
+      mf
+        .dispatchFetch(`${mfUrl}durable/block-concurrency-reset-count`)
+        .then((r) => r.text());
+
+    expect(await count()).toBe("1");
+    expect(await count()).toBe("2");
+
+    const triggered = await mf.dispatchFetch(
+      `${mfUrl}durable/block-concurrency-reset-trigger`,
+    );
+    expect(triggered.status).toBe(500);
+
+    expect(await count()).toBe("1");
+  });
+
+  // Lazy init guarded by block_concurrency_while runs once (init_runs stays 1).
+  test("lazy async initialization runs once", async () => {
+    const first = await mf.dispatchFetch(`${mfUrl}durable/lazy-init`);
+    expect(first.status).toBe(200);
+    expect(await first.text()).toBe("limit is 100, init_runs 1");
+
+    const second = await mf.dispatchFetch(`${mfUrl}durable/lazy-init`);
+    expect(second.status).toBe(200);
+    expect(await second.text()).toBe("limit is 100, init_runs 1");
+  });
+
   test("get-by-name", async () => {
     const resp = await mf.dispatchFetch(`${mfUrl}durable/get-by-name`);
     expect(resp.status).toBe(200);

--- a/test/tests/durable.spec.ts
+++ b/test/tests/durable.spec.ts
@@ -29,13 +29,17 @@ describe("durable", () => {
       calledClose = true;
     });
 
+    const waitForCnt = async (n: number) => {
+      for (let i = 0; i < 100 && cnt < n; i++)
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(cnt).toBe(n);
+    };
+
     socket.send("hi, can you ++?");
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    expect(cnt).toBe(1);
+    await waitForCnt(1);
 
     socket.send("hi again, more ++?");
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    expect(cnt).toBe(2);
+    await waitForCnt(2);
 
     socket.close();
 

--- a/worker-sys/src/types/durable_object/state.rs
+++ b/worker-sys/src/types/durable_object/state.rs
@@ -21,6 +21,12 @@ extern "C" {
     #[wasm_bindgen(method, catch, js_name=waitUntil)]
     pub fn wait_until(this: &DurableObjectState, promise: &js_sys::Promise) -> Result<(), JsValue>;
 
+    #[wasm_bindgen(method, catch, js_name=blockConcurrencyWhile)]
+    pub fn block_concurrency_while(
+        this: &DurableObjectState,
+        callback: &Closure<dyn FnMut() -> js_sys::Promise>,
+    ) -> Result<js_sys::Promise, JsValue>;
+
     #[wasm_bindgen(method, catch, js_name=acceptWebSocket)]
     pub fn accept_websocket(
         this: &DurableObjectState,

--- a/worker-sys/src/types/durable_object/state.rs
+++ b/worker-sys/src/types/durable_object/state.rs
@@ -24,7 +24,7 @@ extern "C" {
     #[wasm_bindgen(method, catch, js_name=blockConcurrencyWhile)]
     pub fn block_concurrency_while(
         this: &DurableObjectState,
-        callback: &Closure<dyn FnMut() -> js_sys::Promise>,
+        callback: &js_sys::Function,
     ) -> Result<js_sys::Promise, JsValue>;
 
     #[wasm_bindgen(method, catch, js_name=acceptWebSocket)]

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -10,7 +10,9 @@
 //! [Learn more](https://developers.cloudflare.com/workers/learning/using-durable-objects) about
 //! using Durable Objects.
 
-use std::{fmt::Display, ops::Deref, panic::AssertUnwindSafe, time::Duration};
+use std::{
+    cell::RefCell, fmt::Display, ops::Deref, panic::AssertUnwindSafe, rc::Rc, time::Duration,
+};
 
 use crate::{
     container::Container,
@@ -277,6 +279,110 @@ impl State {
                 Ok(JsValue::UNDEFINED)
             })))
             .unwrap()
+    }
+
+    /// Executes an async closure while blocking delivery of any other events to the Durable Object
+    /// until it completes, guaranteeing ordering. Binds the runtime's
+    /// [`blockConcurrencyWhile`](https://developers.cloudflare.com/durable-objects/api/state/#blockconcurrencywhile).
+    ///
+    /// **If the closure returns `Err`, the Durable Object is terminated and reset** (as with
+    /// throwing in the JavaScript callback). That is correct for initialization, but usually wrong
+    /// when guarding request-handling work with external calls (`fetch()`, R2, subrequests), where a
+    /// transient failure would discard all in-memory and in-flight state. For that case use
+    /// [`State::block_concurrency_while_infallible`]. The runtime also resets the object if the
+    /// closure exceeds a 30 second timeout.
+    ///
+    /// The closure must be `'static`, so it cannot borrow the calling handler's `&self`; move owned
+    /// values (such as `state.storage()` or a cloned `Env`) in instead.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use worker::*;
+    /// # async fn example(state: &State) -> Result<()> {
+    /// let storage = state.storage();
+    /// let count: u64 = state
+    ///     .block_concurrency_while(move || async move {
+    ///         Ok(storage.get("count").await?.unwrap_or(0))
+    ///     })
+    ///     .await?;
+    /// # let _ = count;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Errors if the `blockConcurrencyWhile` call fails, the closure returns `Err`, or the callback
+    /// does not run.
+    pub async fn block_concurrency_while<F, Fut, T>(&self, closure: F) -> Result<T>
+    where
+        F: FnOnce() -> Fut + 'static,
+        Fut: Future<Output = Result<T>> + 'static,
+        T: 'static,
+    {
+        let output: Rc<RefCell<Option<T>>> = Rc::new(RefCell::new(None));
+        let output_clone = output.clone();
+        let inner: Box<dyn FnOnce() -> js_sys::Promise> = Box::new(move || -> js_sys::Promise {
+            future_to_promise(AssertUnwindSafe(async move {
+                closure()
+                    .await
+                    .map(|value| {
+                        *output_clone.borrow_mut() = Some(value);
+                        JsValue::NULL
+                    })
+                    .map_err(JsValue::from)
+            }))
+        });
+        let clos = wasm_bindgen::closure::Closure::once_assert_unwind_safe(inner);
+        JsFuture::from(self.inner.block_concurrency_while(&clos)?)
+            .await
+            .map_err(Error::from)?;
+        let value = output.borrow_mut().take();
+        value.ok_or_else(|| Error::RustError("block_concurrency_while callback did not run".into()))
+    }
+
+    /// Like [`State::block_concurrency_while`], but application errors cannot reset the Durable
+    /// Object.
+    ///
+    /// The closure returns a plain value `T` rather than a `Result`, so no application error can
+    /// reject the underlying promise. For fallible work, make `T` itself a `Result` (for example
+    /// `T = Result<Outcome, MyError>`) so errors flow back to the caller instead of terminating the
+    /// object. This is the recommended form for guarding request-handling work with external calls.
+    ///
+    /// Note this only removes the *application error* reset path: a Rust panic in the closure, or
+    /// exceeding the runtime's 30 second timeout, will still reset the object.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use worker::*;
+    /// # async fn example(state: &State, env: Env) -> Result<()> {
+    /// // The `?` failures below become the returned `Err` value; they do not reset the object.
+    /// let outcome: Result<String> = state
+    ///     .block_concurrency_while_infallible(move || async move {
+    ///         let bucket = env.bucket("MY_BUCKET")?;
+    ///         let object = bucket.get("key").execute().await?;
+    ///         Ok(object.is_some().to_string())
+    ///     })
+    ///     .await?;
+    /// # let _ = outcome;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Errors only if the `blockConcurrencyWhile` call fails or the callback does not run.
+    /// Application errors should be encoded in `T`.
+    pub async fn block_concurrency_while_infallible<F, Fut, T>(&self, closure: F) -> Result<T>
+    where
+        F: FnOnce() -> Fut + 'static,
+        Fut: Future<Output = T> + 'static,
+        T: 'static,
+    {
+        self.block_concurrency_while(move || async move { Ok(closure().await) })
+            .await
     }
 
     // needs to be accessed by the `#[durable_object]` macro in a conversion step
@@ -888,6 +994,8 @@ impl DurableObject for Chatroom {
 */
 #[allow(async_fn_in_trait)] // Send is not needed
 pub trait DurableObject: has_durable_object_attribute {
+    /// Constructs the Durable Object. This is synchronous; there is no async constructor. For async
+    /// setup, initialize lazily on first use and guard it with [`State::block_concurrency_while`].
     fn new(state: State, env: Env) -> Self;
 
     async fn fetch(&self, req: Request) -> Result<Response>;

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -283,106 +283,61 @@ impl State {
 
     /// Executes an async closure while blocking delivery of any other events to the Durable Object
     /// until it completes, guaranteeing ordering. Binds the runtime's
-    /// [`blockConcurrencyWhile`](https://developers.cloudflare.com/durable-objects/api/state/#blockconcurrencywhile).
+    /// [`blockConcurrencyWhile`](https://developers.cloudflare.com/durable-objects/api/state/#blockconcurrencywhile),
+    /// with the same call-time semantics as JavaScript: the gate closes as a side effect of the
+    /// *call*, and the returned future only observes completion.
     ///
-    /// **If the closure returns `Err`, the Durable Object is terminated and reset** (as with
-    /// throwing in the JavaScript callback). That is correct for initialization, but usually wrong
-    /// when guarding request-handling work with external calls (`fetch()`, R2, subrequests), where a
-    /// transient failure would discard all in-memory and in-flight state. For that case use
-    /// [`State::block_concurrency_while_infallible`]. The runtime also resets the object if the
-    /// closure exceeds a 30 second timeout.
-    ///
-    /// The closure must be `'static`, so it cannot borrow the calling handler's `&self`; move owned
-    /// values (such as `state.storage()` or a cloned `Env`) in instead.
-    ///
-    /// # Examples
+    /// Awaiting the future yields the closure's value. Discarding it instead gives the JavaScript
+    /// constructor idiom, gating all event delivery until async initialization completes:
     ///
     /// ```no_run
+    /// # use std::{cell::Cell, rc::Rc};
     /// # use worker::*;
-    /// # async fn example(state: &State) -> Result<()> {
-    /// let storage = state.storage();
-    /// let count: u64 = state
-    ///     .block_concurrency_while(move || async move {
-    ///         Ok(storage.get("count").await?.unwrap_or(0))
-    ///     })
-    ///     .await?;
-    /// # let _ = count;
-    /// # Ok(())
+    /// # fn example(state: State) {
+    /// let limit = Rc::new(Cell::new(0));
+    /// let (l, storage) = (limit.clone(), state.storage());
+    /// let _init = state.block_concurrency_while(move || async move {
+    ///     l.set(storage.get("limit").await?.unwrap_or(100));
+    ///     Ok(())
+    /// });
     /// # }
     /// ```
+    ///
+    /// **If the closure returns `Err`, the Durable Object is terminated and reset**, as with
+    /// throwing in the JavaScript callback. To treat errors as values instead, return them inside
+    /// `Ok` (`T = Result<Outcome, MyError>`). The runtime also resets the object if the closure
+    /// exceeds a 30 second timeout.
+    ///
+    /// The closure must be `'static`, so it cannot borrow `&self`; move owned values (such as
+    /// `state.storage()` or a cloned `Env`) in instead.
     ///
     /// # Errors
     ///
     /// Errors if the `blockConcurrencyWhile` call fails, the closure returns `Err`, or the callback
     /// does not run.
-    pub async fn block_concurrency_while<F, Fut, T>(&self, closure: F) -> Result<T>
+    pub fn block_concurrency_while<F, Fut, T>(&self, closure: F) -> impl Future<Output = Result<T>>
     where
         F: FnOnce() -> Fut + 'static,
         Fut: Future<Output = Result<T>> + 'static,
         T: 'static,
     {
         let output: Rc<RefCell<Option<T>>> = Rc::new(RefCell::new(None));
-        let output_clone = output.clone();
-        let inner: Box<dyn FnOnce() -> js_sys::Promise> = Box::new(move || -> js_sys::Promise {
+        let slot = output.clone();
+        let callback = wasm_bindgen::closure::Closure::once_into_js(AssertUnwindSafe(move || {
             future_to_promise(AssertUnwindSafe(async move {
-                closure()
-                    .await
-                    .map(|value| {
-                        *output_clone.borrow_mut() = Some(value);
-                        JsValue::NULL
-                    })
-                    .map_err(JsValue::from)
+                let value = closure().await.map_err(JsValue::from)?;
+                *slot.borrow_mut() = Some(value);
+                Ok(JsValue::NULL)
             }))
-        });
-        let clos = wasm_bindgen::closure::Closure::once_assert_unwind_safe(inner);
-        JsFuture::from(self.inner.block_concurrency_while(&clos)?)
-            .await
-            .map_err(Error::from)?;
-        let value = output.borrow_mut().take();
-        value.ok_or_else(|| Error::RustError("block_concurrency_while callback did not run".into()))
-    }
-
-    /// Like [`State::block_concurrency_while`], but application errors cannot reset the Durable
-    /// Object.
-    ///
-    /// The closure returns a plain value `T` rather than a `Result`, so no application error can
-    /// reject the underlying promise. For fallible work, make `T` itself a `Result` (for example
-    /// `T = Result<Outcome, MyError>`) so errors flow back to the caller instead of terminating the
-    /// object. This is the recommended form for guarding request-handling work with external calls.
-    ///
-    /// Note this only removes the *application error* reset path: a Rust panic in the closure, or
-    /// exceeding the runtime's 30 second timeout, will still reset the object.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use worker::*;
-    /// # async fn example(state: &State, env: Env) -> Result<()> {
-    /// // The `?` failures below become the returned `Err` value; they do not reset the object.
-    /// let outcome: Result<String> = state
-    ///     .block_concurrency_while_infallible(move || async move {
-    ///         let bucket = env.bucket("MY_BUCKET")?;
-    ///         let object = bucket.get("key").execute().await?;
-    ///         Ok(object.is_some().to_string())
-    ///     })
-    ///     .await?;
-    /// # let _ = outcome;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Errors only if the `blockConcurrencyWhile` call fails or the callback does not run.
-    /// Application errors should be encoded in `T`.
-    pub async fn block_concurrency_while_infallible<F, Fut, T>(&self, closure: F) -> Result<T>
-    where
-        F: FnOnce() -> Fut + 'static,
-        Fut: Future<Output = T> + 'static,
-        T: 'static,
-    {
-        self.block_concurrency_while(move || async move { Ok(closure().await) })
-            .await
+        }));
+        let promise = self.inner.block_concurrency_while(callback.unchecked_ref());
+        async move {
+            JsFuture::from(promise?).await.map_err(Error::from)?;
+            let value = output.borrow_mut().take();
+            value.ok_or_else(|| {
+                Error::RustError("block_concurrency_while callback did not run".into())
+            })
+        }
     }
 
     // needs to be accessed by the `#[durable_object]` macro in a conversion step
@@ -995,7 +950,8 @@ impl DurableObject for Chatroom {
 #[allow(async_fn_in_trait)] // Send is not needed
 pub trait DurableObject: has_durable_object_attribute {
     /// Constructs the Durable Object. This is synchronous; there is no async constructor. For async
-    /// setup, initialize lazily on first use and guard it with [`State::block_concurrency_while`].
+    /// setup, call [`State::block_concurrency_while`] here without awaiting it: the runtime blocks
+    /// delivery of all events until the initialization future completes.
     fn new(state: State, env: Env) -> Self;
 
     async fn fetch(&self, req: Request) -> Result<Response>;

--- a/worker/src/durable.rs
+++ b/worker/src/durable.rs
@@ -281,14 +281,16 @@ impl State {
             .unwrap()
     }
 
-    /// Executes an async closure while blocking delivery of any other events to the Durable Object
-    /// until it completes, guaranteeing ordering. Binds the runtime's
+    /// Runs a future while blocking delivery of any other events to the Durable Object until it
+    /// completes, guaranteeing ordering. Binds the runtime's
     /// [`blockConcurrencyWhile`](https://developers.cloudflare.com/durable-objects/api/state/#blockconcurrencywhile),
     /// with the same call-time semantics as JavaScript: the gate closes as a side effect of the
     /// *call*, and the returned future only observes completion.
     ///
-    /// Awaiting the future yields the closure's value. Discarding it instead gives the JavaScript
-    /// constructor idiom, gating all event delivery until async initialization completes:
+    /// Awaiting the returned future yields the inner future's value. Discarding it instead gives
+    /// the JavaScript constructor idiom, gating all event delivery until async initialization
+    /// completes. Bind it to a `_`-prefixed name: the `unused_must_use` and clippy
+    /// `let_underscore_future` lints do not apply here since the gate is already active:
     ///
     /// ```no_run
     /// # use std::{cell::Cell, rc::Rc};
@@ -296,36 +298,35 @@ impl State {
     /// # fn example(state: State) {
     /// let limit = Rc::new(Cell::new(0));
     /// let (l, storage) = (limit.clone(), state.storage());
-    /// let _init = state.block_concurrency_while(move || async move {
+    /// let _init = state.block_concurrency_while(async move {
     ///     l.set(storage.get("limit").await?.unwrap_or(100));
     ///     Ok(())
     /// });
     /// # }
     /// ```
     ///
-    /// **If the closure returns `Err`, the Durable Object is terminated and reset**, as with
+    /// **If the future returns `Err`, the Durable Object is terminated and reset**, as with
     /// throwing in the JavaScript callback. To treat errors as values instead, return them inside
-    /// `Ok` (`T = Result<Outcome, MyError>`). The runtime also resets the object if the closure
+    /// `Ok` (`T = Result<Outcome, MyError>`). The runtime also resets the object if the future
     /// exceeds a 30 second timeout.
     ///
-    /// The closure must be `'static`, so it cannot borrow `&self`; move owned values (such as
+    /// The future must be `'static`, so it cannot borrow `&self`; move owned values (such as
     /// `state.storage()` or a cloned `Env`) in instead.
     ///
     /// # Errors
     ///
-    /// Errors if the `blockConcurrencyWhile` call fails, the closure returns `Err`, or the callback
+    /// Errors if the `blockConcurrencyWhile` call fails, the future returns `Err`, or the callback
     /// does not run.
-    pub fn block_concurrency_while<F, Fut, T>(&self, closure: F) -> impl Future<Output = Result<T>>
+    pub fn block_concurrency_while<F, T>(&self, future: F) -> impl Future<Output = Result<T>>
     where
-        F: FnOnce() -> Fut + 'static,
-        Fut: Future<Output = Result<T>> + 'static,
+        F: Future<Output = Result<T>> + 'static,
         T: 'static,
     {
         let output: Rc<RefCell<Option<T>>> = Rc::new(RefCell::new(None));
         let slot = output.clone();
         let callback = wasm_bindgen::closure::Closure::once_into_js(AssertUnwindSafe(move || {
             future_to_promise(AssertUnwindSafe(async move {
-                let value = closure().await.map_err(JsValue::from)?;
+                let value = future.await.map_err(JsValue::from)?;
                 *slot.borrow_mut() = Some(value);
                 Ok(JsValue::NULL)
             }))


### PR DESCRIPTION
NOTE: I used AI to help draft this PR, but I understand and approve the code and think this would be a useful feature for the Rust bindings.

Bind the runtime's blockConcurrencyWhile via State::block_concurrency_while (errors reset the object) and block_concurrency_while_infallible (errors returned as values). This mostly addresses #177, but since a literal async constructor isn't supported we instead document a lazy-init handler pattern.