### PR TITLE
bump wasm-bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,9 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+version = "0.3.104"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3347,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bfa49767bb3a9e1afb02aa95bbcbde8d82f2db4ca377afae94d688f14f62378"
+checksum = "25b63a2bc6e4acb4cf69080068a531bad4530791098230e972ffcb64fd1dc266"
 dependencies = [
  "anyhow",
  "gimli",
@@ -3418,9 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+version = "0.2.127"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3431,9 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8106e743adc30550ed6b44d50442a0929efbaed693032b6c71f03ac0b0e860fe"
+version = "0.2.127"
 dependencies = [
  "anyhow",
  "base64",
@@ -3449,9 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+version = "0.4.77"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3459,9 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+version = "0.2.127"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3469,9 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+version = "0.2.127"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3482,18 +3470,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+version = "0.2.127"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16931d57bcdd6a0dcc11254bdd1388827690c1b6807f0d2836f59a4f9eb30ac"
+version = "0.3.77"
 dependencies = [
  "async-trait",
  "cast",
@@ -3513,9 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fccaddcb2cd722baa7453b4c3d2cb2a3071597bb91f7a4373e8775bdb151778c"
+version = "0.3.77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3524,9 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3746ad029217960123cf2ebf939dda51eb931ba9f8f09c117e39c820b96aa794"
+version = "0.2.127"
 
 [[package]]
 name = "wasm-encoder"
@@ -3611,9 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+version = "0.3.104"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ chrono = { version = "0.4.41", default-features = false, features = [
 futures-channel = "0.3.31"
 futures-util = { version = "0.3.31", default-features = false }
 http = "1.3"
-js-sys = { version = "0.3.102" }
+js-sys = { version = "0.3.104" }
 serde = { version = "1.0.164", features = ["derive"] }
 strum = { version = "0.27", features = ["derive"] }
 serde_json = "1.0.140"
@@ -37,14 +37,14 @@ syn = "2.0.17"
 trybuild = "1.0"
 proc-macro2 = "1.0.60"
 quote = "1.0.28"
-wasm-bindgen = { version = "0.2.125" }
-wasm-bindgen-cli-support = { version = "0.2.125" }
-wasm-bindgen-futures = { version = "0.4.75" }
-wasm-bindgen-macro-support = { version = "0.2.125" }
-wasm-bindgen-shared = { version = "0.2.125" }
-wasm-bindgen-test = { version = "0.3.75" }
+wasm-bindgen = { version = "0.2.127" }
+wasm-bindgen-cli-support = { version = "0.2.127" }
+wasm-bindgen-futures = { version = "0.4.77" }
+wasm-bindgen-macro-support = { version = "0.2.127" }
+wasm-bindgen-shared = { version = "0.2.127" }
+wasm-bindgen-test = { version = "0.3.77" }
 wasm-streams = { version = "0.6.0" }
-web-sys = { version = "0.3.102", features = [
+web-sys = { version = "0.3.104", features = [
     "AbortController",
     "AbortSignal",
     "BinaryType",
@@ -105,3 +105,12 @@ opt-level = "z"
 
 # These are local patches we use to test against local wasm bindgen
 # We always align on the exact stable wasm bindgen version for releases
+[patch.crates-io]
+js-sys = { version = "0.3.104", path = './wasm-bindgen/crates/js-sys' }
+wasm-bindgen = { version = "0.2.127", path = './wasm-bindgen' }
+wasm-bindgen-cli-support = { version = "0.2.127", path = "./wasm-bindgen/crates/cli-support" }
+wasm-bindgen-futures = { version = "0.4.77", path = './wasm-bindgen/crates/futures' }
+wasm-bindgen-macro-support = { version = "0.2.127", path = "./wasm-bindgen/crates/macro-support" }
+wasm-bindgen-shared = { version = "0.2.127", path = "./wasm-bindgen/crates/shared" }
+wasm-bindgen-test = { version = "0.3.77", path = "./wasm-bindgen/crates/test" }
+web-sys = { version = "0.3.104", path = './wasm-bindgen/crates/web-sys' }


### PR DESCRIPTION
Updates the wasm-bindgen submodule to latest upstream main (0.2.125 release → current 0.2.127-dev), pulling in the `--experimental-memory-discard` trampoline generation and `--split-debug-info` support among other changes.

Since upstream main carries an unreleased schema bump (schema identity 0.2.123), this re-adds the `[patch.crates-io]` entries pointing the workspace at the submodule crates, per the usual local-patch workflow (stripped again by the release workflow).