### PR TITLE
Resolve #485: demonstrate + regression-test Send/Sync for R2 Bucket in axum handlers

### DIFF
--- a/examples/axum/src/lib.rs
+++ b/examples/axum/src/lib.rs
@@ -1,4 +1,4 @@
-use axum::{routing::get, Router};
+use axum::{extract::State, routing::get, Router};
 use std::sync::Arc;
 use tower_service::Service;
 use worker::*;
@@ -12,20 +12,41 @@ use crate::resources::foos::{self, service::FooService};
 #[derive(Clone)]
 struct AppState {
     foo_service: Arc<FooService>,
+    bucket: Arc<Bucket>,
 }
 
 fn router(env: Env) -> Router {
     let kv = env.kv("EXAMPLE").unwrap();
     let foo_service = FooService::new(kv);
+    let bucket = env.bucket("BUCKET").unwrap();
 
     let app_state = AppState {
         foo_service: Arc::new(foo_service),
+        bucket: Arc::new(bucket),
     };
 
     Router::new()
         .route("/", get(root))
         .route("/foo", get(foos::api::get))
+        .route("/list-bucket", get(list_bucket))
         .with_state(app_state)
+}
+
+/// Lists the objects in the bound R2 bucket.
+///
+/// `Bucket` itself is `Send + Sync`, so it's fine to store in `AppState`, but
+/// `Bucket::list().execute()` still awaits a `wasm_bindgen` `JsFuture`
+/// internally, whose state isn't `Send`. That makes the handler's `Future`
+/// `!Send`, which `axum` rejects since it requires handler futures to be
+/// `Send`. Wrapping the handler body with `#[worker::send]` erases that bound
+/// by polling the inner future from within a type that's unconditionally
+/// (and safely, since Workers are single-threaded) marked `Send`.
+///
+/// See <https://github.com/cloudflare/workers-rs/issues/485>.
+#[worker::send]
+async fn list_bucket(State(AppState { bucket, .. }): State<AppState>) -> String {
+    let objects = bucket.list().execute().await.unwrap();
+    format!("{} object(s) in bucket", objects.objects().len())
 }
 
 #[event(fetch)]

--- a/worker/src/r2/mod.rs
+++ b/worker/src/r2/mod.rs
@@ -541,3 +541,29 @@ impl From<Data> for JsValue {
         }
     }
 }
+
+#[cfg(test)]
+mod send_check {
+    // Every R2 handle wraps a `JsValue`-backed extern type, and `JsValue` is
+    // unconditionally `Send + Sync` outside of atomics builds (see
+    // `wasm_bindgen::JsValue`), so these hold without needing manual `unsafe
+    // impl`s. This compile-time check guards against a regression, since
+    // losing `Send` here breaks holding a `Bucket` in `axum` router state
+    // (see https://github.com/cloudflare/workers-rs/issues/485).
+    use super::{Bucket, MultipartUpload, Object, Objects, UploadedPart};
+    fn _assert_send<T: Send>() {}
+    fn _assert_sync<T: Sync>() {}
+    #[allow(dead_code)]
+    fn _check() {
+        _assert_send::<Bucket>();
+        _assert_sync::<Bucket>();
+        _assert_send::<Object>();
+        _assert_sync::<Object>();
+        _assert_send::<Objects>();
+        _assert_sync::<Objects>();
+        _assert_send::<MultipartUpload>();
+        _assert_sync::<MultipartUpload>();
+        _assert_send::<UploadedPart>();
+        _assert_sync::<UploadedPart>();
+    }
+}


### PR DESCRIPTION
## Summary

Closes the reproduction described in #485, where using `Bucket` (an R2 binding) inside an `axum` handler fails to compile with:

```
error[E0277]: `Rc<RefCell<wasm_bindgen_futures::Inner>>` cannot be sent between threads safely
```

Investigating on current `main`, I found this is actually resolvable today, but the fix was never demonstrated or tested end-to-end:

- `Bucket` (and the other R2 handle types: `Object`, `Objects`, `MultipartUpload`, `UploadedPart`) are already `Send + Sync` — no manual `unsafe impl` needed, because `wasm_bindgen::JsValue` itself is unconditionally `Send + Sync` outside of atomics builds, and these types are thin `JsValue` wrappers. So storing a `Bucket` in `axum` router state (`AppState`) already works fine.
- The remaining blocker in the original repro is that `Bucket::list().execute()` (and similarly other R2 methods) internally `.await`s a `JsFuture`, whose `Rc<RefCell<Inner>>` state isn't `Send`. That makes the *handler's* generated future `!Send`, which `axum`'s `Handler` trait rejects.
- The existing `#[worker::send]` macro (added after this issue was filed) fixes exactly this: it wraps the handler body in `SendFuture`, which is unconditionally (and safely, since Workers are single-threaded) marked `Send`, erasing the bound regardless of what's captured inside.

I verified this by reproducing the *exact* repro from the issue (axum `State<AppState>` extractor + `#[debug_handler]` + `Bucket::list().execute().await`): it fails with the same error without `#[worker::send]`, and compiles cleanly with it added.

## Changes

- `examples/axum/src/lib.rs`: adds a `Bucket` field to `AppState` and a `list_bucket` handler demonstrating the working `#[worker::send]` pattern, with a doc comment explaining why it's needed and linking back to #485 for future readers who hit the same wall.
- `worker/src/r2/mod.rs`: adds a compile-time `Send`/`Sync` regression test (mirroring the existing pattern in `worker/src/email.rs`) for `Bucket`, `Object`, `Objects`, `MultipartUpload`, and `UploadedPart`, so a future change (e.g. to `worker-sys` or a `wasm-bindgen` upgrade) that accidentally breaks this doesn't go unnoticed.

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown -p worker --tests` passes, exercising the new `send_check` module.
- [x] Reproduced the original issue's compile error with the handler *without* `#[worker::send]` (confirms root cause).
- [x] `cargo check -p axum-on-workers --target wasm32-unknown-unknown` compiles cleanly with `#[worker::send]` added (confirms the fix).
- [x] `cargo fmt` / `cargo clippy -p axum-on-workers --no-deps` clean on the touched code (pre-existing warnings elsewhere in the example are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)