### PR TITLE
chore: update miniflare to v5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,9 +1605,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicov"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa3aa12b448ac225b3102217d1ac5cc717908f02722926524b0599c933c7a0"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",

--- a/README.md
+++ b/README.md
@@ -551,22 +551,36 @@ root of your project.
 
 ### Step 3: Configure your Miniflare instance in your JavaScript / TypeScript tests
 
-To instantiate the `Miniflare` testing instance in your tests, make sure to
-configure its `scriptPath` option to the relative path of where your JavaScript
-worker entrypoint was generated, and its `moduleRules` so that it is able to
-resolve the `*.wasm` file imported from that JavaScript worker:
+To instantiate the `Miniflare` testing instance, configure an explicit module
+manifest containing the generated JavaScript and WebAssembly modules:
 
 ```js
 // test.mjs
 import assert from "node:assert";
+import { readFileSync } from "node:fs";
 import { Miniflare } from "miniflare";
 
 const mf = new Miniflare({
-  scriptPath: "./build/worker/shim.mjs",
-  modules: true,
-  modulesRules: [
-    { type: "CompiledWasm", include: ["**/*.wasm"], fallthrough: true }
-  ]
+  workers: [{
+    config: {
+      name: "test",
+      type: "worker",
+      compatibilityDate: "2026-08-21",
+      manifest: {
+        mainModule: "build/index.js",
+        modules: {
+          "build/index.js": {
+            type: "esm",
+            contents: readFileSync("./build/index.js", "utf8"),
+          },
+          "build/index_bg.wasm": {
+            type: "wasm",
+            contents: new Uint8Array(readFileSync("./build/index_bg.wasm")),
+          },
+        },
+      },
+    },
+  }],
 });
 
 const res = await mf.dispatchFetch("http://localhost");

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -9,7 +9,7 @@
  */
 
 import { Miniflare } from 'miniflare';
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 async function runBenchmark() {
   console.log('🚀 Starting workers-rs benchmark suite\n');
@@ -19,14 +19,27 @@ async function runBenchmark() {
   const mf = new Miniflare({
     workers: [
       {
-        name: 'benchmark',
-        scriptPath: './build/index.js',
-        compatibilityDate: '2025-01-06',
-        modules: true,
-        modulesRules: [
-          { type: 'CompiledWasm', include: ['**/*.wasm'], fallthrough: true }
-        ],
-        outboundService: 'benchmark',
+        config: {
+          name: 'benchmark',
+          type: 'worker',
+          compatibilityDate: '2025-01-06',
+          manifest: {
+            mainModule: 'build/index.js',
+            modules: {
+              'build/index.js': {
+                type: 'esm',
+                contents: readFileSync('./build/index.js', 'utf8'),
+              },
+              'build/index_bg.wasm': {
+                type: 'wasm',
+                contents: new Uint8Array(readFileSync('./build/index_bg.wasm')),
+              },
+            },
+          },
+        },
+        dev: {
+          outboundService: { type: 'worker', worker: 'benchmark' },
+        },
       }
     ]
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/node": "^26.2.0",
-        "miniflare": "^4.20260730.0",
+        "miniflare": "5.20260907.0-alpha",
         "typescript": "^7.0.2",
         "uuid": "^14.0.2",
         "vitest": "^4.1.11"
@@ -300,91 +300,6 @@
       },
       "engines": {
         "node": ">= 20.12.0"
-      }
-    },
-    "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
-      "integrity": "sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260730.1.tgz",
-      "integrity": "sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260730.1.tgz",
-      "integrity": "sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260730.1.tgz",
-      "integrity": "sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260730.1.tgz",
-      "integrity": "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@cloudflare/workers-types": {
@@ -2378,21 +2293,18 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260730.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260730.0.tgz",
-      "integrity": "sha512-1Z9SB9r/o//80UA02Re3QhtcecSHAyAjf5EcKBfQVlQrCg7Miy79hl2PvtkwFLIaJ5rcrOPdDcRr577okwZPsg==",
+      "version": "5.20260907.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260907.0-alpha.tgz",
+      "integrity": "sha512-56F13BeJQuDbTxcoGGN4MGxN8oNNIH3pK48VyJ1JGmjbzE9MMu6S2kxoON3nOBHlLdNjXyzg1Rz3jdHx+JpuZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
-        "undici": "7.28.0",
-        "workerd": "1.20260730.1",
+        "undici": "7.29.0",
+        "workerd": "1.20260907.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -2729,9 +2641,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2945,9 +2857,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260730.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260730.1.tgz",
-      "integrity": "sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==",
+      "version": "1.20260907.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260907.1.tgz",
+      "integrity": "sha512-MN/jgZkg2y9ZOOXdN9ecYynRFaqTCRkmpt3jS6LQNPoSx8HxTgcG947SduxJEB38YisB7RJ3Gu/y7fpd7fZ5bA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2958,11 +2870,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260730.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260730.1",
-        "@cloudflare/workerd-linux-64": "1.20260730.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260730.1",
-        "@cloudflare/workerd-windows-64": "1.20260730.1"
+        "@cloudflare/workerd-darwin-64": "1.20260907.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260907.1",
+        "@cloudflare/workerd-linux-64": "1.20260907.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260907.1",
+        "@cloudflare/workerd-windows-64": "1.20260907.1"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/cloudflare/workers-rs#readme",
   "devDependencies": {
     "@types/node": "^26.2.0",
-    "miniflare": "^4.20260730.0",
+    "miniflare": "5.20260907.0-alpha",
     "typescript": "^7.0.2",
     "uuid": "^14.0.2",
     "vitest": "^4.1.11"
@@ -31,6 +31,6 @@
     "lint:fix": "cargo fmt && cargo clippy --features d1,queue --all-targets --workspace --fix -- -D warnings"
   },
   "allowScripts": {
-    "workerd@1.20260730.1": true
+    "workerd@1.20260907.1": true
   }
 }

--- a/test/tests/mf-socket.ts
+++ b/test/tests/mf-socket.ts
@@ -1,4 +1,5 @@
 import { Miniflare } from "miniflare";
+import { readFileSync } from "node:fs";
 import { createServer } from "net";
 
 export const server = createServer(function (socket) {
@@ -10,15 +11,26 @@ export const server = createServer(function (socket) {
 }).listen(8080);
 
 export const mf = new Miniflare({
-  scriptPath: "./build/index.js",
-  compatibilityDate: "2024-12-05",
-  modules: true,
-  modulesRules: [
-    { type: "CompiledWasm", include: ["**/*.wasm"], fallthrough: true },
-  ],
-  outboundService: {
-    network: { allow: ["local"] }
-  }
+  workers: [{
+    config: {
+      name: "socket-test",
+      type: "worker",
+      compatibilityDate: "2024-12-05",
+      manifest: {
+        mainModule: "build/index.js",
+        modules: {
+          "build/index.js": {
+            type: "esm",
+            contents: readFileSync("./build/index.js", "utf8"),
+          },
+          "build/index_bg.wasm": {
+            type: "wasm",
+            contents: new Uint8Array(readFileSync("./build/index_bg.wasm")),
+          },
+        },
+      },
+    },
+  }],
 });
 
 export const mfUrl = await mf.ready;

--- a/test/tests/mf.ts
+++ b/test/tests/mf.ts
@@ -1,150 +1,124 @@
-import { Miniflare, Response, createFetchMock } from "miniflare";
+import { readFileSync } from "node:fs";
+import { Miniflare, Request, Response, fetch } from "miniflare";
 
-const mockAgent = createFetchMock();
+const manifest = {
+  mainModule: "build/index.js",
+  modules: {
+    "build/index.js": {
+      type: "esm" as const,
+      contents: readFileSync("./build/index.js", "utf8"),
+    },
+    "build/index_bg.wasm": {
+      type: "wasm" as const,
+      contents: new Uint8Array(readFileSync("./build/index_bg.wasm")),
+    },
+  },
+};
 
-mockAgent
-  .get("https://cloudflare.com")
-  .intercept({ path: "/" })
-  .reply(200, "cloudflare!");
-
-mockAgent
-  .get("https://miniflare.mocks")
-  .intercept({ path: "/delay" })
-  .reply(200, "cloudflare!")
-  .delay(10000);
-
-mockAgent
-  .get("https://jsonplaceholder.typicode.com")
-  .intercept({ path: "/todos/1" })
-  .reply(
-    200,
-    {
+async function outboundFetch(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.origin === "https://cloudflare.com") {
+    return new Response("cloudflare!");
+  }
+  if (url.href === "https://miniflare.mocks/delay") {
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(resolve, 10_000);
+      request.signal.addEventListener("abort", () => {
+        clearTimeout(timeout);
+        reject(request.signal.reason);
+      }, { once: true });
+    });
+    return new Response("cloudflare!");
+  }
+  if (url.href === "https://jsonplaceholder.typicode.com/todos/1") {
+    return Response.json({
       userId: 1,
       id: 1,
       title: "delectus aut autem",
       completed: false,
-    },
-    {
-      headers: {
-        "content-type": "application/json",
-      },
-    }
-  );
+    });
+  }
+  return fetch(request);
+}
 
 const mf_instance = new Miniflare({
-  d1Persist: false,
-  kvPersist: false,
-  r2Persist: false,
-  cachePersist: false,
   workers: [
     {
-      scriptPath: "./build/index.js",
-      compatibilityDate: "2025-07-24",
-      cache: true,
-      d1Databases: ["DB"],
-      modules: true,
-      modulesRules: [
-        { type: "CompiledWasm", include: ["**/*.wasm"], fallthrough: true },
-      ],
-      bindings: {
-        EXAMPLE_SECRET: "example",
-        SOME_SECRET: "secret!",
-        SOME_VARIABLE: "some value",
-        SOME_OBJECT_VARIABLE: {
-          foo: 42,
-          bar: "string"
+      config: {
+        name: "test",
+        type: "worker",
+        compatibilityDate: "2025-07-24",
+        cache: { enabled: true },
+        manifest,
+        env: {
+          EXAMPLE_SECRET: { type: "text", value: "example" },
+          SOME_SECRET: { type: "text", value: "secret!" },
+          SOME_VARIABLE: { type: "text", value: "some value" },
+          SOME_OBJECT_VARIABLE: {
+            type: "json",
+            value: { foo: 42, bar: "string" },
+          },
+          DB: { type: "d1", id: "DB" },
+          SOME_NAMESPACE: { type: "kv", id: "SOME_NAMESPACE" },
+          FILE_SIZES: { type: "kv", id: "FILE_SIZES" },
+          TEST: { type: "kv", id: "TEST" },
+          EMPTY_BUCKET: { type: "r2", name: "EMPTY_BUCKET" },
+          PUT_BUCKET: { type: "r2", name: "PUT_BUCKET" },
+          SEEDED_BUCKET: { type: "r2", name: "SEEDED_BUCKET" },
+          DELETE_BUCKET: { type: "r2", name: "DELETE_BUCKET" },
+          my_queue: { type: "queue", name: "my_queue" },
+          remote: {
+            type: "fetcher",
+            handler: async () => new Response("hello world"),
+          },
+          COUNTER: { type: "durable-object", worker: "test", exportName: "Counter" },
+          PUT_RAW_TEST_OBJECT: { type: "durable-object", worker: "test", exportName: "PutRawTestObject" },
+          AUTO: { type: "durable-object", worker: "test", exportName: "AutoResponseObject" },
+          MY_CLASS: { type: "durable-object", worker: "test", exportName: "MyClass" },
+          ECHO_CONTAINER: { type: "durable-object", worker: "test", exportName: "EchoContainer" },
+          SQL_COUNTER: { type: "durable-object", worker: "test", exportName: "SqlCounter" },
+          SQL_ITERATOR: { type: "durable-object", worker: "test", exportName: "SqlIterator" },
+          ASSETS: { type: "assets" },
+          SECRETS: { type: "secrets-store-secret", storeId: "SECRET_STORE", secretName: "secret-name" },
+          MISSING_SECRET: { type: "secrets-store-secret", storeId: "SECRET_STORE_MISSING", secretName: "missing-secret" },
+          HTTP_ANALYTICS: { type: "analytics-engine-dataset", name: "HTTP_ANALYTICS" },
+          TEST_RATE_LIMITER: {
+            type: "rate-limit",
+            namespace: "1",
+            simple: { limit: 10, period: 60 },
+          },
+          EMAIL: {
+            type: "send-email",
+            allowedSenderAddresses: ["allowed-sender@example.com"],
+            allowedDestinationAddresses: ["allowed-recipient@example.com"],
+          },
+        },
+        exports: {
+          Counter: { type: "durable-object", storage: "legacy-kv" },
+          PutRawTestObject: { type: "durable-object", storage: "legacy-kv" },
+          AutoResponseObject: { type: "durable-object", storage: "legacy-kv" },
+          MyClass: { type: "durable-object", storage: "legacy-kv" },
+          EchoContainer: {
+            type: "durable-object",
+            storage: "sqlite",
+            container: { imageName: "worker-dev/echocontainer:latest" },
+          },
+          SqlCounter: { type: "durable-object", storage: "sqlite" },
+          SqlIterator: { type: "durable-object", storage: "sqlite" },
+        },
+        triggers: [{ type: "queue", name: "my_queue", maxBatchTimeout: 1 }],
+        assets: {
+          directory: "./public",
+          hasUserWorker: true,
         },
       },
-      durableObjects: {
-        COUNTER: "Counter",
-        PUT_RAW_TEST_OBJECT: "PutRawTestObject",
-        AUTO: "AutoResponseObject",
-        MY_CLASS: "MyClass",
-        ECHO_CONTAINER: {
-          className: "EchoContainer",
-          useSQLite: true,
-          container: {
-            imageName: "worker-dev/echocontainer:latest",
-          }
-        },
-        SQL_COUNTER: {
-          className: "SqlCounter",
-          useSQLite: true,
-        },
-        SQL_ITERATOR: {
-          className: "SqlIterator",
-          useSQLite: true,
-        },
+      dev: {
+        outboundService: { type: "fetcher", handler: outboundFetch },
       },
-      kvNamespaces: ["SOME_NAMESPACE", "FILE_SIZES", "TEST"],
-      serviceBindings: {
-        async remote() {
-          return new Response("hello world");
-        },
-      },
-      r2Buckets: ["EMPTY_BUCKET", "PUT_BUCKET", "SEEDED_BUCKET", "DELETE_BUCKET"],
-      queueConsumers: {
-        my_queue: {
-          maxBatchTimeout: 1,
-        },
-      },
-      queueProducers: ["my_queue", "my_queue"],
-      fetchMock: mockAgent,
-      assets: {
-        directory: "./public",
-        binding: "ASSETS",
-        routerConfig: {
-          has_user_worker: true
-        }
-      },
-      secretsStoreSecrets: {
-        SECRETS: {
-          store_id: "SECRET_STORE",
-          secret_name: "secret-name"
-        },
-        MISSING_SECRET: {
-          store_id: "SECRET_STORE_MISSING",
-          secret_name: "missing-secret"
-        }
-      },
-      wrappedBindings: {
-        HTTP_ANALYTICS: {
-          scriptName: "mini-analytics-engine" // mock out analytics engine binding to the "mini-analytics-engine" worker
-        }
-      },
-      ratelimits: {
-        TEST_RATE_LIMITER: {
-          namespace_id: "1",
-          simple: {
-            limit: 10,
-            period: 60,
-          }
-        }
-      },
-      email: {
-        send_email: [
-          {
-            name: "EMAIL",
-            allowed_sender_addresses: ["allowed-sender@example.com"],
-            allowed_destination_addresses: ["allowed-recipient@example.com"],
-          }
-        ]
-      }
     },
-    {
-      name: "mini-analytics-engine",
-      modules: true,
-      script: `export default function (env) {
-        return {
-          writeDataPoint(data) {
-            console.log(data)
-          }
-        }
-      }`
-    }]
+  ],
 });
 
-// Seed the secret store with a value using the new API
 const secretAPI = await mf_instance.getSecretsStoreSecretAPI("SECRETS");
 await secretAPI().create("secret value");
 


### PR DESCRIPTION
This updates miniflare to the new v5 version, and updates the syntax used in tests
The version is marked as "alpha" but but will released as stable soon, I opened this in the meantime