### PR TITLE
deps: update to wasm-bindgen@0.2.128

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1605,9 +1605,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicov"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa3aa12b448ac225b3102217d1ac5cc717908f02722926524b0599c933c7a0"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.127"
+version = "0.2.128"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3363,25 +3363,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "async-trait",
  "cast",
@@ -3401,16 +3401,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.127"
+version = "0.2.128"
 
 [[package]]
 name = "wasm-encoder"
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ chrono = { version = "0.4.41", default-features = false, features = [
 futures-channel = "0.3.31"
 futures-util = { version = "0.3.31", default-features = false }
 http = "1.3"
-js-sys = { version = "0.3.104" }
+js-sys = { version = "0.3.105" }
 serde = { version = "1.0.164", features = ["derive"] }
 strum = { version = "0.28", features = ["derive"] }
 serde_json = "1.0.140"
@@ -37,14 +37,14 @@ syn = "3.0.3"
 trybuild = "1.0"
 proc-macro2 = "1.0.60"
 quote = "1.0.28"
-wasm-bindgen = { version = "0.2.127" }
-wasm-bindgen-cli-support = { version = "0.2.127" }
-wasm-bindgen-futures = { version = "0.4.77" }
-wasm-bindgen-macro-support = { version = "0.2.127" }
-wasm-bindgen-shared = { version = "0.2.127" }
-wasm-bindgen-test = { version = "0.3.77" }
+wasm-bindgen = { version = "0.2.128" }
+wasm-bindgen-cli-support = { version = "0.2.128" }
+wasm-bindgen-futures = { version = "0.4.78" }
+wasm-bindgen-macro-support = { version = "0.2.128" }
+wasm-bindgen-shared = { version = "0.2.128" }
+wasm-bindgen-test = { version = "0.3.78" }
 wasm-streams = { version = "0.6.0" }
-web-sys = { version = "0.3.104", features = [
+web-sys = { version = "0.3.105", features = [
     "AbortController",
     "AbortSignal",
     "BinaryType",
@@ -106,11 +106,11 @@ opt-level = "z"
 # These are local patches we use to test against local wasm bindgen
 # We always align on the exact stable wasm bindgen version for releases
 [patch.crates-io]
-js-sys = { version = "0.3.104", path = './wasm-bindgen/crates/js-sys' }
-wasm-bindgen = { version = "0.2.127", path = './wasm-bindgen' }
-wasm-bindgen-cli-support = { version = "0.2.127", path = "./wasm-bindgen/crates/cli-support" }
-wasm-bindgen-futures = { version = "0.4.77", path = './wasm-bindgen/crates/futures' }
-wasm-bindgen-macro-support = { version = "0.2.127", path = "./wasm-bindgen/crates/macro-support" }
-wasm-bindgen-shared = { version = "0.2.127", path = "./wasm-bindgen/crates/shared" }
-wasm-bindgen-test = { version = "0.3.77", path = "./wasm-bindgen/crates/test" }
-web-sys = { version = "0.3.104", path = './wasm-bindgen/crates/web-sys' }
+js-sys = { version = "0.3.105", path = './wasm-bindgen/crates/js-sys' }
+wasm-bindgen = { version = "0.2.128", path = './wasm-bindgen' }
+wasm-bindgen-cli-support = { version = "0.2.128", path = "./wasm-bindgen/crates/cli-support" }
+wasm-bindgen-futures = { version = "0.4.78", path = './wasm-bindgen/crates/futures' }
+wasm-bindgen-macro-support = { version = "0.2.128", path = "./wasm-bindgen/crates/macro-support" }
+wasm-bindgen-shared = { version = "0.2.128", path = "./wasm-bindgen/crates/shared" }
+wasm-bindgen-test = { version = "0.3.78", path = "./wasm-bindgen/crates/test" }
+web-sys = { version = "0.3.105", path = './wasm-bindgen/crates/web-sys' }

--- a/worker-build/src/versions.rs
+++ b/worker-build/src/versions.rs
@@ -7,7 +7,7 @@ macro_rules! version {
 }
 
 // Current build toolchain, always used exactly for builds, unless overridden by {}_BIN env vars
-pub(crate) static LATEST_WASM_BINDGEN_VERSION: LazyLock<semver::Version> = version!("0.2.125");
+pub(crate) static LATEST_WASM_BINDGEN_VERSION: LazyLock<semver::Version> = version!("0.2.128");
 pub(crate) static CUR_WASM_OPT_VERSION: &str = "132";
 pub(crate) static CUR_ESBUILD_VERSION: LazyLock<semver::Version> = version!("0.28.2");
 


### PR DESCRIPTION
This updates workers-rs to wasm-bindgen 0.2.128.

The wasm-bindgen submodule is moved to the 0.2.128 release tag (246946f), with the workspace crate pins and \`[patch.crates-io]\` entries aligned to the corresponding crate versions:

* wasm-bindgen, wasm-bindgen-cli-support, wasm-bindgen-macro-support, wasm-bindgen-shared: 0.2.128
* js-sys, web-sys: 0.3.105
* wasm-bindgen-futures: 0.4.78
* wasm-bindgen-test: 0.3.78

The worker-build \`LATEST_WASM_BINDGEN_VERSION\` is also bumped to 0.2.128 so the dependency help text points to the current toolchain.

Notable in 0.2.128: export shim symbols are now mangled with a per-crate hash (schema bump, requires matching lib and CLI versions), which worker-build already enforces by installing the CLI matching the locked library version.

Existing test suites (unit, integration, http, panic-unwind) cover the change.