### PR TITLE
feat(d1): add raw_with_column_names for raw({ columnNames: true })

### DIFF
--- a/test/src/d1.rs
+++ b/test/src/d1.rs
@@ -56,6 +56,24 @@ pub async fn prepared_statement(
     assert_eq!(columns[1].as_str(), Some("Ryan Upton"));
     assert_eq!(columns[2].as_u64(), Some(21));
 
+    // The same rows, plus the column names they are positioned by.
+    let (column_names, rows) = stmt.raw_with_column_names::<serde_json::Value>().await?;
+    assert_eq!(column_names, vec!["id", "name", "age"]);
+    assert_eq!(rows.len(), 1);
+    let columns = &rows[0];
+
+    assert_eq!(columns[0].as_u64(), Some(6));
+    assert_eq!(columns[1].as_str(), Some("Ryan Upton"));
+    assert_eq!(columns[2].as_u64(), Some(21));
+
+    // Column names are still reported when the statement matches no rows.
+    let (column_names, rows) = worker::query!(&db, "SELECT * FROM people WHERE name = ?")
+        .bind_refs(&D1Type::Text("Nobody At All"))?
+        .raw_with_column_names::<serde_json::Value>()
+        .await?;
+    assert_eq!(column_names, vec!["id", "name", "age"]);
+    assert!(rows.is_empty());
+
     let stmt_2 = unbound_stmt.bind_refs([&D1Type::Text("John Smith")])?;
     let person = stmt_2.first::<Person>(None).await?.unwrap();
     assert_eq!(person.name, "John Smith");

--- a/worker-sys/src/types/d1.rs
+++ b/worker-sys/src/types/d1.rs
@@ -97,4 +97,13 @@ extern "C" {
 
     #[wasm_bindgen(structural, method, catch, js_class=D1PreparedStatement, js_name=raw)]
     pub fn raw(this: &D1PreparedStatement) -> Result<Promise, JsValue>;
+
+    /// `raw()` with an options object, e.g. `{ columnNames: true }`.
+    ///
+    /// Bound separately because wasm-bindgen cannot overload `raw` on arity.
+    #[wasm_bindgen(structural, method, catch, js_class=D1PreparedStatement, js_name=raw)]
+    pub fn raw_with_options(
+        this: &D1PreparedStatement,
+        options: &::js_sys::Object,
+    ) -> Result<Promise, JsValue>;
 }

--- a/worker/src/d1/mod.rs
+++ b/worker/src/d1/mod.rs
@@ -433,6 +433,44 @@ impl D1PreparedStatement {
         Ok(vec)
     }
 
+    /// Executes a query against the database and returns the column names alongside a `Vec` of
+    /// rows, as `(column_names, rows)`.
+    ///
+    /// This calls `raw({ columnNames: true })`, which returns the column names as the first array
+    /// of the result. They are split out here so the rows stay uniformly typed as `T`.
+    ///
+    /// Useful when a caller indexes rows positionally but still needs to know which column each
+    /// position refers to, such as an ORM mapping layer.
+    ///
+    /// The column names are returned even when the query matches no rows, so this can be used to
+    /// inspect a statement's shape without a result set.
+    pub async fn raw_with_column_names<T>(&self) -> Result<(Vec<String>, Vec<Vec<T>>)>
+    where
+        T: for<'a> Deserialize<'a>,
+    {
+        let options = js_sys::Object::new();
+        js_sys::Reflect::set(&options, &JsValue::from_str("columnNames"), &JsValue::TRUE)?;
+
+        let result = JsFuture::from(self.0.raw_with_options(&options)?).await;
+        let result = cast_to_d1_error(result)?;
+        let result = result.dyn_into::<Array>()?;
+
+        let mut iter = result.iter();
+        // The header is always the first element, even for a zero-row result, so this branch is
+        // only a guard against an unexpectedly empty array rather than a normal case.
+        let Some(header) = iter.next() else {
+            return Ok((Vec::new(), Vec::new()));
+        };
+        let column_names: Vec<String> = serde_wasm_bindgen::from_value(header)?;
+
+        let mut rows = Vec::with_capacity(result.length().saturating_sub(1) as usize);
+        for value in iter {
+            rows.push(serde_wasm_bindgen::from_value(value)?);
+        }
+
+        Ok((column_names, rows))
+    }
+
     /// Executes a query against the database and returns a `Vec` of JsValues.
     pub async fn raw_js_value(&self) -> Result<Vec<JsValue>> {
         let result = JsFuture::from(self.0.raw()?).await;


### PR DESCRIPTION
Closes #1052

## Problem

`worker-sys` binds `D1PreparedStatement.raw()` with no arguments, so the `raw({ columnNames: true })` form of the D1 API is unreachable from Rust. `raw()` gives back rows as positional arrays with no way to learn what those positions mean.

That blocks the case in the issue: an ORM mapping layer (the reporter is working on a `diesel-d1` fork) indexes a row by `usize`, so arrays-of-arrays are the right shape — but it still needs the column names to map them.

## Fix

Two layers, both mirroring what's already there.

**`worker-sys/src/types/d1.rs`** — bind `raw` a second time, as `raw_with_options`, taking a `js_sys::Object`. A separate Rust name is required because wasm-bindgen can't overload on arity; `js_name=raw` keeps it pointing at the same JS method. The existing zero-arg `raw` binding is untouched.

**`worker/src/d1/mod.rs`** — add `raw_with_column_names<T>() -> Result<(Vec<String>, Vec<Vec<T>>)>`. It builds `{ columnNames: true }`, calls the new binding, then splits the header off the front.

The split is the reason this is a separate method rather than an option on `raw()`. D1 returns the column names as the *first array of the result* — typed upstream as `Promise<[string[], ...T[]]>` — so a single return value would be heterogeneous and force every caller to deal with a first row that isn't a row. Returning `(names, rows)` keeps rows uniformly `T`.

Also non-breaking: `raw()` and `raw_js_value()` keep their exact signatures and behavior.

## Test

Extended the existing `prepared_statement` integration test in `test/src/d1.rs`, next to the current `raw()` assertions:

- the same single-row query through `raw_with_column_names` yields `["id", "name", "age"]` plus one row whose positional values match what `raw()` returns;
- a query matching no rows still yields the column names, with an empty row set.

That second case is the one I would have got wrong by reading the code alone, so I checked it against a real runtime rather than assuming. With miniflare:

```
raw({columnNames:true}), 1 row  -> [["id","name","age"],[6,"Ryan Upton",21]]
raw({columnNames:true}), 0 rows -> [["id","name","age"]]
raw(),                   0 rows -> []
```

So the header is always present when `columnNames` is set, which matches the upstream tuple type. The implementation still guards the empty-array case, but as a defensive branch rather than an expected one, and the doc comment says the names are reported even with no rows.

Checks run: `cargo check -p worker -p worker-sandbox --target wasm32-unknown-unknown`, `cargo clippy -p worker -p worker-sys --target wasm32-unknown-unknown -- -D warnings` (clean), `cargo fmt --check` (clean).

I did not add a changeset — no `.changeset/*.md` has been filed per-PR in this repo's history, only the README and config. Happy to add one if that's wrong.

## Out of scope

`raw_js_value()` has no `columnNames` counterpart. It seemed better to add the one method the issue asks for than to speculatively double the surface; say the word if you'd like `raw_js_value_with_column_names` for symmetry.
